### PR TITLE
Fix react hooks error in annotation plugin

### DIFF
--- a/packages/plugin-annotation/src/shared/components/annotations/circle-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/circle-paint.tsx
@@ -151,7 +151,8 @@ export const CirclePaint = ({
   /* ------------------------------------------------------------------ */
   /* render preview                                                     */
   /* ------------------------------------------------------------------ */
-  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.CIRCLE) return null;
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.CIRCLE)
+    return null;
 
   if (!start || !current) return null;
 

--- a/packages/plugin-annotation/src/shared/components/annotations/circle-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/circle-paint.tsx
@@ -42,15 +42,12 @@ export const CirclePaint = ({
     return annotationProvides.onActiveToolChange(setActiveTool);
   }, [annotationProvides]);
 
-  if (!activeTool.defaults) return null;
-  if (activeTool.defaults.subtype !== PdfAnnotationSubtype.CIRCLE) return null;
-
-  const toolColor = activeTool.defaults.color ?? '#000000';
-  const toolOpacity = activeTool.defaults.opacity ?? 1;
-  const toolStrokeWidth = activeTool.defaults.strokeWidth ?? 2;
-  const toolStrokeColor = activeTool.defaults.strokeColor ?? '#000000';
-  const toolStrokeStyle = activeTool.defaults.strokeStyle ?? PdfAnnotationBorderStyle.SOLID;
-  const toolStrokeDashArray = activeTool.defaults.strokeDashArray ?? [];
+  const toolColor = activeTool.defaults?.color ?? '#000000';
+  const toolOpacity = activeTool.defaults?.opacity ?? 1;
+  const toolStrokeWidth = activeTool.defaults?.strokeWidth ?? 2;
+  const toolStrokeColor = activeTool.defaults?.strokeColor ?? '#000000';
+  const toolStrokeStyle = activeTool.defaults?.strokeStyle ?? PdfAnnotationBorderStyle.SOLID;
+  const toolStrokeDashArray = activeTool.defaults?.strokeDashArray ?? [];
 
   /* ------------------------------------------------------------------ */
   /* integration with interaction-manager                               */
@@ -154,6 +151,8 @@ export const CirclePaint = ({
   /* ------------------------------------------------------------------ */
   /* render preview                                                     */
   /* ------------------------------------------------------------------ */
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.CIRCLE) return null;
+
   if (!start || !current) return null;
 
   const minX = Math.min(start.x, current.x);

--- a/packages/plugin-annotation/src/shared/components/annotations/free-text-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/free-text-paint.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from '@framework';
 import type { PointerEventHandlers } from '@embedpdf/plugin-interaction-manager';
 import { usePointerHandlers } from '@embedpdf/plugin-interaction-manager/@framework';
 import { ActiveTool } from '@embedpdf/plugin-annotation';
-import { PdfAnnotationSubtype, PdfFreeTextAnnoObject, Rect, uuidV4 } from '@embedpdf/models';
+import { PdfAnnotationSubtype, PdfFreeTextAnnoObject, PdfStandardFont, PdfTextAlignment, PdfVerticalAlignment, Rect, uuidV4 } from '@embedpdf/models';
 import { useAnnotationCapability, useAnnotationPlugin } from '../../hooks';
 
 interface FreeTextPaintProps {
@@ -32,17 +32,14 @@ export const FreeTextPaint = ({
   const [activeTool, setActiveTool] = useState<ActiveTool>({ variantKey: null, defaults: null });
   useEffect(() => annotationProvides?.onActiveToolChange(setActiveTool), [annotationProvides]);
 
-  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.FREETEXT)
-    return null;
-
-  const toolFontColor = activeTool.defaults.fontColor ?? '#000000';
-  const toolOpacity = activeTool.defaults.opacity ?? 1;
-  const toolFontSize = activeTool.defaults.fontSize ?? 12;
-  const toolFontFamily = activeTool.defaults.fontFamily;
-  const toolBackgroundColor = activeTool.defaults.backgroundColor ?? 'transparent';
-  const toolTextAlign = activeTool.defaults.textAlign;
-  const toolVerticalAlign = activeTool.defaults.verticalAlign;
-  const toolContent = activeTool.defaults.content ?? 'Insert text here';
+  const toolFontColor = activeTool.defaults?.fontColor ?? '#000000';
+  const toolOpacity = activeTool.defaults?.opacity ?? 1;
+  const toolFontSize = activeTool.defaults?.fontSize ?? 12;
+  const toolFontFamily = activeTool.defaults?.fontFamily ?? PdfStandardFont.Unknown;
+  const toolBackgroundColor = activeTool.defaults?.backgroundColor ?? 'transparent';
+  const toolTextAlign = activeTool.defaults?.textAlign ?? PdfTextAlignment.Left;
+  const toolVerticalAlign = activeTool.defaults?.verticalAlign ?? PdfVerticalAlignment.Top;
+  const toolContent = activeTool.defaults?.content ?? 'Insert text here';
 
   /* ------------------------------------------------------------------ */
   /* interaction-manager integration                                    */
@@ -134,6 +131,8 @@ export const FreeTextPaint = ({
   /* ------------------------------------------------------------------ */
   /* render preview while dragging                                      */
   /* ------------------------------------------------------------------ */
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.FREETEXT) return null;
+
   if (!start || !current) return null;
 
   const minX = Math.min(start.x, current.x);

--- a/packages/plugin-annotation/src/shared/components/annotations/free-text-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/free-text-paint.tsx
@@ -3,7 +3,15 @@ import { useEffect, useMemo, useState } from '@framework';
 import type { PointerEventHandlers } from '@embedpdf/plugin-interaction-manager';
 import { usePointerHandlers } from '@embedpdf/plugin-interaction-manager/@framework';
 import { ActiveTool } from '@embedpdf/plugin-annotation';
-import { PdfAnnotationSubtype, PdfFreeTextAnnoObject, PdfStandardFont, PdfTextAlignment, PdfVerticalAlignment, Rect, uuidV4 } from '@embedpdf/models';
+import {
+  PdfAnnotationSubtype,
+  PdfFreeTextAnnoObject,
+  PdfStandardFont,
+  PdfTextAlignment,
+  PdfVerticalAlignment,
+  Rect,
+  uuidV4,
+} from '@embedpdf/models';
 import { useAnnotationCapability, useAnnotationPlugin } from '../../hooks';
 
 interface FreeTextPaintProps {
@@ -131,7 +139,8 @@ export const FreeTextPaint = ({
   /* ------------------------------------------------------------------ */
   /* render preview while dragging                                      */
   /* ------------------------------------------------------------------ */
-  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.FREETEXT) return null;
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.FREETEXT)
+    return null;
 
   if (!start || !current) return null;
 

--- a/packages/plugin-annotation/src/shared/components/annotations/ink-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/ink-paint.tsx
@@ -47,14 +47,11 @@ export const InkPaint = ({ pageIndex, scale, pageWidth, pageHeight }: InkPaintPr
     return off;
   }, [annotationProvides]);
 
-  if (!activeTool.defaults) return null;
-  if (activeTool.defaults.subtype !== PdfAnnotationSubtype.INK) return null;
-
   const toolColor = activeTool.defaults?.color ?? '#000000';
   const toolOpacity = activeTool.defaults?.opacity ?? 1;
   const toolStrokeWidth = activeTool.defaults?.strokeWidth ?? 2;
   const toolBlendMode = activeTool.defaults?.blendMode ?? PdfBlendMode.Normal;
-  const intent = activeTool.defaults?.intent;
+  const intent = activeTool.defaults?.intent ?? undefined;
   /* ------------------------------------------------------------------ */
   /* integration with interaction-manager                               */
   /* ------------------------------------------------------------------ */
@@ -193,6 +190,8 @@ export const InkPaint = ({ pageIndex, scale, pageWidth, pageHeight }: InkPaintPr
   /* ------------------------------------------------------------------ */
   /* render preview                                                     */
   /* ------------------------------------------------------------------ */
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.INK) return null;
+
   if (!currentStrokes.length) return null;
 
   const allPoints = currentStrokes.flatMap((s) => s.points);

--- a/packages/plugin-annotation/src/shared/components/annotations/line-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/line-paint.tsx
@@ -134,7 +134,8 @@ export const LinePaint = ({ pageIndex, scale, pageWidth, pageHeight, cursor }: L
   /* ------------------------------------------------------------------ */
   /* render preview                                                     */
   /* ------------------------------------------------------------------ */
-  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.LINE) return null;
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.LINE)
+    return null;
 
   if (!start || !current) return null;
 

--- a/packages/plugin-annotation/src/shared/components/annotations/line-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/line-paint.tsx
@@ -36,17 +36,14 @@ export const LinePaint = ({ pageIndex, scale, pageWidth, pageHeight, cursor }: L
     return annotationProvides.onActiveToolChange(setActiveTool);
   }, [annotationProvides]);
 
-  if (!activeTool.defaults) return null;
-  if (activeTool.defaults.subtype !== PdfAnnotationSubtype.LINE) return null;
-
-  const toolColor = activeTool.defaults.color ?? '#000000';
-  const toolOpacity = activeTool.defaults.opacity ?? 1;
-  const toolStrokeWidth = activeTool.defaults.strokeWidth ?? 2;
-  const toolStrokeColor = activeTool.defaults.strokeColor ?? '#000000';
-  const toolStrokeStyle = activeTool.defaults.strokeStyle ?? PdfAnnotationBorderStyle.SOLID;
-  const toolStrokeDashArray = activeTool.defaults.strokeDashArray;
-  const toolLineEndings = activeTool.defaults.lineEndings;
-  const intent = activeTool.defaults.intent;
+  const toolColor = activeTool.defaults?.color ?? '#000000';
+  const toolOpacity = activeTool.defaults?.opacity ?? 1;
+  const toolStrokeWidth = activeTool.defaults?.strokeWidth ?? 2;
+  const toolStrokeColor = activeTool.defaults?.strokeColor ?? '#000000';
+  const toolStrokeStyle = activeTool.defaults?.strokeStyle ?? PdfAnnotationBorderStyle.SOLID;
+  const toolStrokeDashArray = activeTool.defaults?.strokeDashArray ?? [];
+  const toolLineEndings = activeTool.defaults?.lineEndings ?? undefined;
+  const intent = activeTool.defaults?.intent ?? undefined;
   /* ------------------------------------------------------------------ */
   /* interaction manager integration                                    */
   /* ------------------------------------------------------------------ */
@@ -137,6 +134,8 @@ export const LinePaint = ({ pageIndex, scale, pageWidth, pageHeight, cursor }: L
   /* ------------------------------------------------------------------ */
   /* render preview                                                     */
   /* ------------------------------------------------------------------ */
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.LINE) return null;
+
   if (!start || !current) return null;
 
   const rect = patching.lineRectWithEndings([start, current], toolStrokeWidth, toolLineEndings);

--- a/packages/plugin-annotation/src/shared/components/annotations/polygon-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/polygon-paint.tsx
@@ -33,15 +33,12 @@ export const PolygonPaint = ({
   const [activeTool, setActiveTool] = useState<ActiveTool>({ variantKey: null, defaults: null });
   useEffect(() => annotationProvides?.onActiveToolChange(setActiveTool), [annotationProvides]);
 
-  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.POLYGON)
-    return null;
-
-  const toolColor = activeTool.defaults.color ?? '#000000';
-  const toolOpacity = activeTool.defaults.opacity ?? 1;
-  const toolStrokeWidth = activeTool.defaults.strokeWidth ?? 2;
-  const toolStrokeColor = activeTool.defaults.strokeColor ?? '#000000';
-  const toolStrokeStyle = activeTool.defaults.strokeStyle ?? PdfAnnotationBorderStyle.SOLID;
-  const toolStrokeDashArray = activeTool.defaults.strokeDashArray;
+  const toolColor = activeTool.defaults?.color ?? '#000000';
+  const toolOpacity = activeTool.defaults?.opacity ?? 1;
+  const toolStrokeWidth = activeTool.defaults?.strokeWidth ?? 2;
+  const toolStrokeColor = activeTool.defaults?.strokeColor ?? '#000000';
+  const toolStrokeStyle = activeTool.defaults?.strokeStyle ?? PdfAnnotationBorderStyle.SOLID;
+  const toolStrokeDashArray = activeTool.defaults?.strokeDashArray ?? [];
 
   const { register } = usePointerHandlers({ modeId: 'polygon', pageIndex });
 
@@ -141,9 +138,8 @@ export const PolygonPaint = ({
   useEffect(() => (register ? register(handlers) : undefined), [register, handlers]);
 
   // ---------- preview ----------
-  if (!vertices.length || !current) return null;
-
-  const allPts = [...vertices, current];
+  const allPts = [...vertices];
+  if (current) allPts.push(current);
   const xs = allPts.map((p) => p.x),
     ys = allPts.map((p) => p.y);
   const minX = Math.min(...xs),
@@ -166,6 +162,10 @@ export const PolygonPaint = ({
     });
     return d.trim();
   }, [allPts, svgMinX, svgMinY]);
+
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.POLYGON) return null;
+
+  if (!vertices.length || !current) return null;
 
   const dottedPath =
     vertices.length >= 2

--- a/packages/plugin-annotation/src/shared/components/annotations/polygon-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/polygon-paint.tsx
@@ -163,7 +163,8 @@ export const PolygonPaint = ({
     return d.trim();
   }, [allPts, svgMinX, svgMinY]);
 
-  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.POLYGON) return null;
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.POLYGON)
+    return null;
 
   if (!vertices.length || !current) return null;
 

--- a/packages/plugin-annotation/src/shared/components/annotations/polyline-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/polyline-paint.tsx
@@ -42,16 +42,13 @@ export const PolylinePaint = ({
     return annotationProvides.onActiveToolChange(setActiveTool);
   }, [annotationProvides]);
 
-  if (!activeTool.defaults) return null;
-  if (activeTool.defaults.subtype !== PdfAnnotationSubtype.POLYLINE) return null;
-
-  const toolColor = activeTool.defaults.color ?? '#000000';
-  const toolOpacity = activeTool.defaults.opacity ?? 1;
-  const toolStrokeWidth = activeTool.defaults.strokeWidth ?? 2;
-  const toolStrokeColor = activeTool.defaults.strokeColor ?? '#000000';
-  const toolLineEndings = activeTool.defaults.lineEndings;
-  const toolStrokeStyle = activeTool.defaults.strokeStyle ?? PdfAnnotationBorderStyle.SOLID;
-  const toolStrokeDashArray = activeTool.defaults.strokeDashArray;
+  const toolColor = activeTool.defaults?.color ?? '#000000';
+  const toolOpacity = activeTool.defaults?.opacity ?? 1;
+  const toolStrokeWidth = activeTool.defaults?.strokeWidth ?? 2;
+  const toolStrokeColor = activeTool.defaults?.strokeColor ?? '#000000';
+  const toolLineEndings = activeTool.defaults?.lineEndings ?? undefined;
+  const toolStrokeStyle = activeTool.defaults?.strokeStyle ?? PdfAnnotationBorderStyle.SOLID;
+  const toolStrokeDashArray = activeTool.defaults?.strokeDashArray ?? [];
 
   /* ------------------------------------------------------------------ */
   /* integration with interaction-manager                               */
@@ -140,6 +137,8 @@ export const PolylinePaint = ({
   /* ------------------------------------------------------------------ */
   /* render preview                                                     */
   /* ------------------------------------------------------------------ */
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.POLYLINE) return null;
+
   if (!vertices.length || !current) return null;
 
   const allPts = [...vertices, current];

--- a/packages/plugin-annotation/src/shared/components/annotations/polyline-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/polyline-paint.tsx
@@ -137,7 +137,8 @@ export const PolylinePaint = ({
   /* ------------------------------------------------------------------ */
   /* render preview                                                     */
   /* ------------------------------------------------------------------ */
-  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.POLYLINE) return null;
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.POLYLINE)
+    return null;
 
   if (!vertices.length || !current) return null;
 

--- a/packages/plugin-annotation/src/shared/components/annotations/square-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/square-paint.tsx
@@ -152,7 +152,8 @@ export const SquarePaint = ({
   /* ------------------------------------------------------------------ */
   /* render preview                                                     */
   /* ------------------------------------------------------------------ */
-  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.SQUARE) return null;
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.SQUARE)
+    return null;
 
   if (!start || !current) return null;
 

--- a/packages/plugin-annotation/src/shared/components/annotations/square-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/square-paint.tsx
@@ -43,15 +43,12 @@ export const SquarePaint = ({
     return annotationProvides.onActiveToolChange(setActiveTool);
   }, [annotationProvides]);
 
-  if (!activeTool.defaults) return null;
-  if (activeTool.defaults.subtype !== PdfAnnotationSubtype.SQUARE) return null;
-
-  const toolColor = activeTool.defaults.color ?? '#000000';
-  const toolOpacity = activeTool.defaults.opacity ?? 1;
-  const toolStrokeWidth = activeTool.defaults.strokeWidth ?? 2;
-  const toolStrokeColor = activeTool.defaults.strokeColor ?? '#000000';
-  const toolStrokeStyle = activeTool.defaults.strokeStyle ?? PdfAnnotationBorderStyle.SOLID;
-  const toolStrokeDashArray = activeTool.defaults.strokeDashArray ?? [];
+  const toolColor = activeTool.defaults?.color ?? '#000000';
+  const toolOpacity = activeTool.defaults?.opacity ?? 1;
+  const toolStrokeWidth = activeTool.defaults?.strokeWidth ?? 2;
+  const toolStrokeColor = activeTool.defaults?.strokeColor ?? '#000000';
+  const toolStrokeStyle = activeTool.defaults?.strokeStyle ?? PdfAnnotationBorderStyle.SOLID;
+  const toolStrokeDashArray = activeTool.defaults?.strokeDashArray ?? [];
 
   /* ------------------------------------------------------------------ */
   /* integration with interaction-manager                               */
@@ -155,6 +152,8 @@ export const SquarePaint = ({
   /* ------------------------------------------------------------------ */
   /* render preview                                                     */
   /* ------------------------------------------------------------------ */
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.SQUARE) return null;
+
   if (!start || !current) return null;
 
   const minX = Math.min(start.x, current.x);

--- a/packages/plugin-annotation/src/shared/components/annotations/stamp-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/stamp-paint.tsx
@@ -31,9 +31,6 @@ export const StampPaint = ({ pageIndex, scale, pageWidth, pageHeight }: StampPai
     return annotationProvides.onActiveToolChange(setActiveTool);
   }, [annotationProvides]);
 
-  if (!activeTool.defaults) return null;
-  if (activeTool.defaults.subtype !== PdfAnnotationSubtype.STAMP) return null;
-
   /* ------------------------------------------------------------------ */
   /* integration with interaction-manager                               */
   /* ------------------------------------------------------------------ */
@@ -61,6 +58,8 @@ export const StampPaint = ({ pageIndex, scale, pageWidth, pageHeight }: StampPai
 
   /* register with the interaction-manager */
   useEffect(() => (register ? register(handlers) : undefined), [register, handlers]);
+
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.STAMP) return null;
 
   const onChange = async (e: ChangeEvent<HTMLInputElement>) => {
     if (!annotationProvides || !start) return;

--- a/packages/plugin-annotation/src/shared/components/annotations/stamp-paint.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/stamp-paint.tsx
@@ -59,7 +59,8 @@ export const StampPaint = ({ pageIndex, scale, pageWidth, pageHeight }: StampPai
   /* register with the interaction-manager */
   useEffect(() => (register ? register(handlers) : undefined), [register, handlers]);
 
-  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.STAMP) return null;
+  if (!activeTool.defaults || activeTool.defaults.subtype !== PdfAnnotationSubtype.STAMP)
+    return null;
 
   const onChange = async (e: ChangeEvent<HTMLInputElement>) => {
     if (!annotationProvides || !start) return;


### PR DESCRIPTION
Fixes #70 

### Changes Made
- All hooks in annotation rendering components are moved to before any conditional return statements, (mainly just the short-circuit returns if the active tool is not the respective annotation subtype). 
  This ensures all hooks will run in the same order regardless of the state of the component.
- Added optional chaining to all variables accessing `activeTool.defaults?.*`since the null checks for `activeTool.defaults` are now moved to the bottom.