### PR TITLE
Add MIT license field to all package.json files

### DIFF
--- a/.changeset/wild-jokes-wave.md
+++ b/.changeset/wild-jokes-wave.md
@@ -1,0 +1,31 @@
+---
+'@embedpdf/plugin-interaction-manager': patch
+'@embedpdf/plugin-annotation': patch
+'@embedpdf/plugin-attachment': patch
+'@embedpdf/plugin-fullscreen': patch
+'@embedpdf/plugin-redaction': patch
+'@embedpdf/plugin-selection': patch
+'@embedpdf/plugin-thumbnail': patch
+'@embedpdf/plugin-bookmark': patch
+'@embedpdf/plugin-viewport': patch
+'@embedpdf/plugin-capture': patch
+'@embedpdf/plugin-history': patch
+'@embedpdf/plugin-export': patch
+'@embedpdf/plugin-loader': patch
+'@embedpdf/plugin-render': patch
+'@embedpdf/plugin-rotate': patch
+'@embedpdf/plugin-scroll': patch
+'@embedpdf/plugin-search': patch
+'@embedpdf/plugin-spread': patch
+'@embedpdf/plugin-tiling': patch
+'@embedpdf/plugin-print': patch
+'@embedpdf/plugin-zoom': patch
+'@embedpdf/plugin-pan': patch
+'@embedpdf/plugin-ui': patch
+'@embedpdf/pdfium': patch
+'@embedpdf/build': patch
+'@embedpdf/utils': patch
+'@embedpdf/core': patch
+---
+
+Add license fields to the package.json with the value MIT

--- a/examples/react-mui/package.json
+++ b/examples/react-mui/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "license": "MIT",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/examples/react-tailwind/package.json
+++ b/examples/react-tailwind/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "license": "MIT",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/examples/vue-tailwind/package.json
+++ b/examples/vue-tailwind/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "license": "MIT",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/examples/vue-vuetify/package.json
+++ b/examples/vue-vuetify/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/example-vue-vuetify",
   "private": true,
   "type": "module",
+  "license": "MIT",
   "version": "0.0.0",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "packageManager": "pnpm@10.4.0",
+  "license": "MIT",
   "scripts": {
     "dev": "turbo run dev --parallel",
     "dev:vanilla": "pnpm --filter @embedpdf/example-vanilla run dev",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "type": "module",
+  "license": "MIT",
   "exports": {
     "./vite": {
       "types": "./dist/vite/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/core",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/engines/examples/node/package.json
+++ b/packages/engines/examples/node/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Node.js examples for @embedpdf/engines",
   "type": "module",
+  "license": "MIT",
   "main": "basic-example.js",
   "scripts": {
     "start": "node basic-example.js",

--- a/packages/pdfium/examples/node/package.json
+++ b/packages/pdfium/examples/node/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Node.js examples for @embedpdf/pdfium",
   "type": "module",
+  "license": "MIT",
   "main": "basic-example.js",
   "scripts": {
     "start": "node basic-example.js",

--- a/packages/pdfium/package.json
+++ b/packages/pdfium/package.json
@@ -4,6 +4,7 @@
   "private": false,
   "description": "PDFium WebAssembly for the web platform. This package provides a powerful JavaScript interface to PDFium, enabling high-quality PDF rendering and manipulation directly in web applications.",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-annotation/package.json
+++ b/packages/plugin-annotation/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-annotation",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-attachment/package.json
+++ b/packages/plugin-attachment/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-attachment",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-bookmark/package.json
+++ b/packages/plugin-bookmark/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-bookmark",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-capture/package.json
+++ b/packages/plugin-capture/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-capture",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-export/package.json
+++ b/packages/plugin-export/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-export",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-fullscreen/package.json
+++ b/packages/plugin-fullscreen/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-fullscreen",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-history/package.json
+++ b/packages/plugin-history/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-history",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-interaction-manager/package.json
+++ b/packages/plugin-interaction-manager/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-interaction-manager",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-loader/package.json
+++ b/packages/plugin-loader/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-loader",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-pan/package.json
+++ b/packages/plugin-pan/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-pan",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-print/package.json
+++ b/packages/plugin-print/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-print",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-redaction/package.json
+++ b/packages/plugin-redaction/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-redaction",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-render/package.json
+++ b/packages/plugin-render/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-render",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-rotate/package.json
+++ b/packages/plugin-rotate/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-rotate",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-scroll/package.json
+++ b/packages/plugin-scroll/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-scroll",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-search/package.json
+++ b/packages/plugin-search/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-search",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-selection/package.json
+++ b/packages/plugin-selection/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-selection",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-spread/package.json
+++ b/packages/plugin-spread/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-spread",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-thumbnail/package.json
+++ b/packages/plugin-thumbnail/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-thumbnail",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-tiling/package.json
+++ b/packages/plugin-tiling/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-tiling",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-ui/package.json
+++ b/packages/plugin-ui/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-ui",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-viewport/package.json
+++ b/packages/plugin-viewport/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-viewport",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/plugin-zoom/package.json
+++ b/packages/plugin-zoom/package.json
@@ -2,6 +2,7 @@
   "name": "@embedpdf/plugin-zoom",
   "version": "1.2.1",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -4,6 +4,7 @@
   "private": false,
   "description": "Shared utility helpers (geometry, tasks, logging, PDF primitives) that underpin every package in the EmbedPDF ecosystem.",
   "type": "module",
+  "license": "MIT",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/snippet/package.json
+++ b/snippet/package.json
@@ -6,6 +6,7 @@
   "types": "dist/embedpdf.d.ts",
   "license": "MIT",
   "type": "module",
+  "license": "MIT",
   "files": [
     "dist",
     "README.md"


### PR DESCRIPTION
Added the "license": "MIT" field to every package.json across the repository to ensure license information is explicitly declared for all packages and examples.