### PR TITLE
Add redaction plugin and toolbars to React and Vue examples

### DIFF
--- a/.changeset/brave-insects-listen.md
+++ b/.changeset/brave-insects-listen.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-redaction': patch
+---
+
+Add Vue export to the redaction plugin package.json

--- a/.changeset/happy-mirrors-chew.md
+++ b/.changeset/happy-mirrors-chew.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-tiling': patch
+---
+
+Fix refresh not working on Vue component after redaction

--- a/.changeset/hip-pens-enjoy.md
+++ b/.changeset/hip-pens-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-render': patch
+---
+
+Fix refresh not working on Vue component after redaction

--- a/.changeset/nine-animals-mix.md
+++ b/.changeset/nine-animals-mix.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-redaction': patch
+---
+
+Add events function that get events on add, remove, clear, commit

--- a/.changeset/seven-llamas-push.md
+++ b/.changeset/seven-llamas-push.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/utils': patch
+---
+
+Improved pointer event handling in counter-rotate containers to prevent unwanted text selection

--- a/examples/react-mui/package.json
+++ b/examples/react-mui/package.json
@@ -28,6 +28,7 @@
     "@embedpdf/plugin-thumbnail": "workspace:*",
     "@embedpdf/plugin-selection": "workspace:*",
     "@embedpdf/plugin-annotation": "workspace:*",
+    "@embedpdf/plugin-redaction": "workspace:*",
     "@embedpdf/utils": "workspace:*",
     "@embedpdf/models": "workspace:*",
     "@embedpdf/pdfium": "workspace:*",

--- a/examples/react-mui/src/application.tsx
+++ b/examples/react-mui/src/application.tsx
@@ -19,6 +19,7 @@ import { Rotate, RotatePluginPackage } from '@embedpdf/plugin-rotate/react';
 import { SpreadPluginPackage } from '@embedpdf/plugin-spread/react';
 import { FullscreenPluginPackage } from '@embedpdf/plugin-fullscreen/react';
 import { ExportPluginPackage } from '@embedpdf/plugin-export/react';
+import { RedactionLayer, RedactionPluginPackage } from '@embedpdf/plugin-redaction/react';
 import { ThumbnailPluginPackage } from '@embedpdf/plugin-thumbnail/react';
 import { SelectionPluginPackage } from '@embedpdf/plugin-selection/react';
 import { SelectionLayer } from '@embedpdf/plugin-selection/react';
@@ -40,6 +41,7 @@ import { Sidebar } from './components/sidebar';
 import { Toolbar } from './components/toolbar';
 import { ViewSidebarReverseIcon } from './icons';
 import { AnnotationSelectionMenu } from './components/annotation-selection-menu';
+import { RedactionSelectionMenu } from './components/redaction-selection-menu';
 
 const plugins = [
   createPluginRegistration(LoaderPluginPackage, {
@@ -78,6 +80,7 @@ const plugins = [
   }),
   createPluginRegistration(SelectionPluginPackage),
   createPluginRegistration(AnnotationPluginPackage),
+  createPluginRegistration(RedactionPluginPackage),
 ];
 
 const drawerComponents: DrawerComponent[] = [
@@ -243,6 +246,22 @@ function App() {
                               />
                               <MarqueeZoom pageIndex={pageIndex} scale={scale} />
                               <SelectionLayer pageIndex={pageIndex} scale={scale} />
+                              <RedactionLayer
+                                pageIndex={pageIndex}
+                                scale={scale}
+                                rotation={rotation}
+                                selectionMenu={({ menuWrapperProps, selected, item }) => (
+                                  <>
+                                    {selected ? (
+                                      <RedactionSelectionMenu
+                                        menuWrapperProps={menuWrapperProps}
+                                        selected={item}
+                                        container={popperContainerRef.current}
+                                      />
+                                    ) : null}
+                                  </>
+                                )}
+                              />
                               <AnnotationLayer
                                 pageIndex={pageIndex}
                                 scale={scale}

--- a/examples/react-mui/src/components/redaction-selection-menu.tsx
+++ b/examples/react-mui/src/components/redaction-selection-menu.tsx
@@ -1,0 +1,66 @@
+import { Paper, IconButton, Popper } from '@mui/material';
+import DeleteOutlineOutlinedIcon from '@mui/icons-material/DeleteOutlineOutlined';
+import DoneIcon from '@mui/icons-material/Done';
+import { MenuWrapperProps } from '@embedpdf/utils/react';
+import { useState } from 'react';
+import { RedactionItem, useRedactionCapability } from '@embedpdf/plugin-redaction/react';
+
+interface RedactionSelectionMenuProps {
+  menuWrapperProps: MenuWrapperProps;
+  selected: RedactionItem;
+  container?: HTMLElement | null;
+}
+
+export function RedactionSelectionMenu({
+  selected,
+  container,
+  menuWrapperProps,
+}: RedactionSelectionMenuProps) {
+  const { provides: redaction } = useRedactionCapability();
+  const [anchorEl, setAnchorEl] = useState<HTMLSpanElement | null>(null);
+
+  const handleDelete = () => {
+    if (!redaction) return;
+    const { page, id } = selected;
+    redaction.removePending(page, id);
+  };
+
+  const handleCommit = () => {
+    if (!redaction) return;
+    const { page, id } = selected;
+    redaction.commitPending(page, id);
+  };
+
+  return (
+    <>
+      <span ref={setAnchorEl} {...menuWrapperProps} />
+      <Popper
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        placement="bottom"
+        modifiers={[{ name: 'offset', options: { offset: [0, 8] } }]}
+        container={container ?? undefined}
+      >
+        <Paper
+          elevation={2}
+          sx={{
+            px: 0.5,
+            py: 0.25,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.25,
+            borderRadius: 1,
+            cursor: 'default',
+          }}
+        >
+          <IconButton size="small" onClick={handleDelete} aria-label="Delete annotation">
+            <DeleteOutlineOutlinedIcon fontSize="small" />
+          </IconButton>
+          <IconButton size="small" onClick={handleCommit} aria-label="Commit redaction">
+            <DoneIcon fontSize="small" />
+          </IconButton>
+        </Paper>
+      </Popper>
+    </>
+  );
+}

--- a/examples/react-mui/src/components/toolbar/index.tsx
+++ b/examples/react-mui/src/components/toolbar/index.tsx
@@ -37,6 +37,7 @@ import { useFullscreen } from '@embedpdf/plugin-fullscreen/react';
 import { useExportCapability } from '@embedpdf/plugin-export/react';
 import { useLoaderCapability } from '@embedpdf/plugin-loader/react';
 import { useIsMobile } from '../../hooks/use-is-mobile';
+import { RedactToolbar } from './redact-toolbar';
 
 export const Toolbar = () => {
   const { provides: panProvider, isPanning } = usePan();
@@ -56,8 +57,8 @@ export const Toolbar = () => {
   const menuOpen = Boolean(menuAnchorEl);
 
   // View/Annotate mode
-  const [mode, setMode] = useState<'view' | 'annotate'>('view');
-  const handleModeChange = (_event: SyntheticEvent, value: 'view' | 'annotate') => {
+  const [mode, setMode] = useState<'view' | 'annotate' | 'redact'>('view');
+  const handleModeChange = (_event: SyntheticEvent, value: 'view' | 'annotate' | 'redact') => {
     setMode(value);
   };
 
@@ -255,22 +256,51 @@ export const Toolbar = () => {
               </ToggleIconButton>
             </>
           )}
-          <Box sx={{ flexGrow: 1, display: 'flex', justifyContent: 'center' }}>
+          <Box
+            sx={{
+              flexGrow: 1,
+              display: 'flex',
+              justifyContent: 'center',
+              minWidth: 0, // Allow shrinking below content size
+              overflow: 'hidden', // Prevent overflow
+            }}
+          >
             <Tabs
               value={mode}
               onChange={handleModeChange}
               textColor="inherit"
-              TabIndicatorProps={{ style: { backgroundColor: 'white', opacity: 0.7 } }}
-              sx={{ minHeight: 32, '& .MuiTab-root': { minHeight: 32, paddingY: 0.5 } }}
+              variant="scrollable"
+              scrollButtons="auto"
+              allowScrollButtonsMobile
+              slotProps={{
+                indicator: { style: { backgroundColor: 'white', opacity: 0.7 } },
+              }}
+              sx={{
+                minHeight: 32,
+                maxWidth: '100%',
+                '& .MuiTab-root': {
+                  minHeight: 32,
+                  paddingY: 0.5,
+                  minWidth: 'auto',
+                  fontSize: '0.875rem',
+                },
+                '& .MuiTabs-scrollButtons': {
+                  '&.Mui-disabled': {
+                    opacity: 0.3,
+                  },
+                },
+              }}
             >
               <Tab label="View" value="view" />
               <Tab label="Annotate" value="annotate" />
+              <Tab label="Redact" value="redact" />
             </Tabs>
           </Box>
           <DrawerToggleButton componentId="search" />
         </MuiToolbar>
       </AppBar>
       {mode === 'annotate' && <AnnotationToolbar />}
+      {mode === 'redact' && <RedactToolbar />}
     </>
   );
 };

--- a/examples/react-mui/src/components/toolbar/redact-toolbar.tsx
+++ b/examples/react-mui/src/components/toolbar/redact-toolbar.tsx
@@ -1,0 +1,66 @@
+import { RedactionMode, useRedaction } from '@embedpdf/plugin-redaction/react';
+import { AppBar, Divider, IconButton, Toolbar as MuiToolbar } from '@mui/material';
+import DoneIcon from '@mui/icons-material/Done';
+import ClearIcon from '@mui/icons-material/Clear';
+
+import { ToggleIconButton } from '../toggle-icon-button';
+import { RedactIcon, RedactAreaIcon } from '../../icons';
+
+export const RedactToolbar = () => {
+  const { provides, state } = useRedaction();
+
+  const handleTextRedact = () => {
+    provides?.toggleRedactSelection();
+  };
+
+  const handleAreaRedact = () => {
+    provides?.toggleMarqueeRedact();
+  };
+
+  const handleCommitPending = () => {
+    provides?.commitAllPending();
+  };
+
+  const handleClearPending = () => {
+    provides?.clearPending();
+  };
+
+  return (
+    <AppBar
+      position="static"
+      color="default"
+      elevation={0}
+      sx={{ borderBottom: '1px solid #cfd4da' }}
+    >
+      <MuiToolbar
+        variant="dense"
+        disableGutters
+        sx={{ gap: 1.5, px: 1.5, justifyContent: 'center' }}
+      >
+        <ToggleIconButton
+          tone="light"
+          isOpen={state.activeType === RedactionMode.RedactSelection}
+          onClick={handleTextRedact}
+          aria-label="Redact text"
+        >
+          <RedactIcon fontSize="small" />
+        </ToggleIconButton>
+        <ToggleIconButton
+          tone="light"
+          isOpen={state.activeType === RedactionMode.MarqueeRedact}
+          onClick={handleAreaRedact}
+          aria-label="Redact area"
+        >
+          <RedactAreaIcon fontSize="small" />
+        </ToggleIconButton>
+        <Divider orientation="vertical" flexItem />
+        <IconButton size="small" disabled={state.pendingCount === 0} onClick={handleCommitPending}>
+          <DoneIcon fontSize="small" />
+        </IconButton>
+        <IconButton size="small" disabled={state.pendingCount === 0} onClick={handleClearPending}>
+          <ClearIcon fontSize="small" />
+        </IconButton>
+      </MuiToolbar>
+    </AppBar>
+  );
+};

--- a/examples/react-mui/src/icons.tsx
+++ b/examples/react-mui/src/icons.tsx
@@ -20,3 +20,159 @@ export const ViewSidebarReverseIcon = forwardRef<SVGSVGElement, SvgIconProps>((p
     }}
   />
 ));
+
+export const RedactAreaIcon = forwardRef<SVGSVGElement, SvgIconProps>((props, ref) => (
+  <SvgIcon ref={ref} {...props} viewBox="0 0 24 24" fill="none">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M6 20h-3" stroke="currentColor" strokeWidth={2} strokeLinecap="square" />
+    <path d="M3 20v-3" stroke="currentColor" strokeWidth={2} strokeLinecap="square" />
+    <path d="M3 13v-3" stroke="currentColor" strokeWidth={2} strokeLinecap="square" />
+    <path d="M3 6v-3" stroke="currentColor" strokeWidth={2} strokeLinecap="square" />
+    <path d="M3 3h3" stroke="currentColor" strokeWidth={2} strokeLinecap="square" />
+    <path d="M10 3h3" stroke="currentColor" strokeWidth={2} strokeLinecap="square" />
+    <path d="M17 3h3" stroke="currentColor" strokeWidth={2} strokeLinecap="square" />
+    <path d="M20 3v3" stroke="currentColor" strokeWidth={2} strokeLinecap="square" />
+    <defs>
+      <clipPath id="redactClip">
+        <rect x="10" y="10" width="12" height="12" />
+      </clipPath>
+    </defs>
+    <rect
+      x="10"
+      y="10"
+      width="12"
+      height="12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="square"
+    />
+    <g clipPath="url(#redactClip)">
+      <path
+        d="M-2 24l14 -14"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M2 24l14 -14"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6 24l14 -14"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M10 24l15 -15"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M14 24l15 -15"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M18 24l15 -15"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+  </SvgIcon>
+));
+
+RedactAreaIcon.displayName = 'RedactAreaIcon';
+
+export const RedactIcon = forwardRef<SVGSVGElement, SvgIconProps>((props, ref) => (
+  <SvgIcon ref={ref} {...props} viewBox="0 0 24 24" fill="none">
+    <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+    <path d="M5 4h14" stroke="currentColor" strokeWidth={3} />
+    <path d="M12 4v8" stroke="currentColor" strokeWidth={3} />
+    <defs>
+      <clipPath id="stripeClip">
+        <rect x="2" y="12" width="20" height="10" />
+      </clipPath>
+    </defs>
+    <rect x="2" y="12" width="20" height="10" fill="none" stroke="currentColor" strokeWidth={2} />
+    <g clipPath="url(#stripeClip)">
+      <path
+        d="M-7 24l12 -12"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M-3 24l12 -12"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M1 24l12 -12"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M5 24l12 -12"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9 24l12 -12"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M13 24l12 -12"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M17 24l12 -12"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M21 24l12 -12"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M25 24l12 -12"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+  </SvgIcon>
+));
+
+RedactIcon.displayName = 'RedactIcon';

--- a/examples/vue-vuetify/components.d.ts
+++ b/examples/vue-vuetify/components.d.ts
@@ -15,6 +15,7 @@ declare module 'vue' {
     HelloWorld: typeof import('./src/components/HelloWorld.vue')['default']
     PageControls: typeof import('./src/components/PageControls.vue')['default']
     PrintDialog: typeof import('./src/components/PrintDialog.vue')['default']
+    RedactToolbar: typeof import('./src/components/RedactToolbar.vue')['default']
     Search: typeof import('./src/components/Search.vue')['default']
     Sidebar: typeof import('./src/components/Sidebar.vue')['default']
     Toolbar: typeof import('./src/components/Toolbar.vue')['default']

--- a/examples/vue-vuetify/package.json
+++ b/examples/vue-vuetify/package.json
@@ -31,6 +31,7 @@
     "@embedpdf/plugin-print": "workspace:*",
     "@embedpdf/plugin-search": "workspace:*",
     "@embedpdf/plugin-thumbnail": "workspace:*",
+    "@embedpdf/plugin-redaction": "workspace:*",
     "@fontsource/roboto": "5.2.6",
     "@mdi/font": "7.4.47",
     "vue": "^3.5.0",

--- a/examples/vue-vuetify/src/components/Application.vue
+++ b/examples/vue-vuetify/src/components/Application.vue
@@ -23,6 +23,7 @@ import { SpreadPluginPackage } from '@embedpdf/plugin-spread/vue';
 import { PrintPluginPackage } from '@embedpdf/plugin-print/vue';
 import { SearchPluginPackage, SearchLayer } from '@embedpdf/plugin-search/vue';
 import { ThumbnailPluginPackage } from '@embedpdf/plugin-thumbnail/vue';
+import { RedactionPluginPackage, RedactionLayer } from '@embedpdf/plugin-redaction/vue';
 
 import Toolbar from './Toolbar.vue';
 import DrawerProvider from './drawer-system/DrawerProvider.vue';
@@ -115,6 +116,7 @@ const { engine, isLoading: engineLoading, error: engineError } = usePdfiumEngine
           flags: [],
           showAllResults: true,
         }),
+        createPluginRegistration(RedactionPluginPackage),
       ]"
     >
       <template #default="{ pluginsReady }">
@@ -169,6 +171,11 @@ const { engine, isLoading: engineLoading, error: engineError } = usePdfiumEngine
                             />
                             <MarqueeZoom :page-index="page.pageIndex" :scale="page.scale" />
                             <SearchLayer :page-index="page.pageIndex" :scale="page.scale" />
+                            <RedactionLayer
+                              :page-index="page.pageIndex"
+                              :scale="page.scale"
+                              :rotation="page.rotation"
+                            />
                             <SelectionLayer :page-index="page.pageIndex" :scale="page.scale" />
                           </PagePointerProvider>
                         </Rotate>

--- a/examples/vue-vuetify/src/components/RedactToolbar.vue
+++ b/examples/vue-vuetify/src/components/RedactToolbar.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { RedactionMode, useRedaction } from '@embedpdf/plugin-redaction/vue';
+
+const { provides, state } = useRedaction();
+
+const handleTextRedact = () => {
+  provides?.value?.toggleRedactSelection();
+};
+
+const handleAreaRedact = () => {
+  provides?.value?.toggleMarqueeRedact();
+};
+
+const handleCommitPending = () => {
+  provides?.value?.commitAllPending();
+};
+
+const handleClearPending = () => {
+  provides?.value?.clearPending();
+};
+</script>
+
+<template>
+  <v-app-bar elevation="0" density="compact" color="surface" class="redact-toolbar">
+    <v-toolbar density="compact">
+      <v-spacer></v-spacer>
+      <v-btn
+        :color="state.activeType === RedactionMode.RedactSelection ? 'primary' : undefined"
+        :variant="state.activeType === RedactionMode.RedactSelection ? 'tonal' : 'text'"
+        @click="handleTextRedact"
+        icon="mdi-format-text-variant"
+        size="small"
+        class="mx-1"
+      />
+      <v-btn
+        :color="state.activeType === RedactionMode.MarqueeRedact ? 'primary' : undefined"
+        :variant="state.activeType === RedactionMode.MarqueeRedact ? 'tonal' : 'text'"
+        @click="handleAreaRedact"
+        icon="mdi-selection-drag"
+        size="small"
+        class="mx-1"
+      />
+      <v-divider vertical class="mx-2" />
+      <v-btn
+        :disabled="state.pendingCount === 0"
+        @click="handleCommitPending"
+        icon="mdi-check"
+        size="small"
+        class="mx-1"
+      />
+      <v-btn
+        :disabled="state.pendingCount === 0"
+        @click="handleClearPending"
+        icon="mdi-close"
+        size="small"
+        class="mx-1"
+      />
+      <v-spacer></v-spacer>
+    </v-toolbar>
+  </v-app-bar>
+</template>
+
+<style scoped>
+.redact-toolbar {
+  border-bottom: 1px solid #cfd4da;
+}
+</style>

--- a/examples/vue-vuetify/src/components/Toolbar.vue
+++ b/examples/vue-vuetify/src/components/Toolbar.vue
@@ -24,6 +24,9 @@ const mainMenuOpen = ref(false);
 const pageSettingsMenuOpen = ref(false);
 const printDialogOpen = ref(false);
 
+// View/Annotate/Redact mode
+const mode = ref<'view' | 'annotate' | 'redact'>('view');
+
 const handleFullscreenToggle = () => {
   fullscreenProvider?.value?.toggleFullscreen();
   mainMenuOpen.value = false;
@@ -224,11 +227,22 @@ const handlePrintDialogClose = () => {
       </template>
     </v-tooltip>
 
+    <!-- Mode Tabs -->
+    <v-spacer></v-spacer>
+    <div class="mode-tabs-container">
+      <v-tabs v-model="mode" color="primary" density="compact" class="mode-tabs">
+        <v-tab value="view">View</v-tab>
+        <v-tab value="redact">Redact</v-tab>
+      </v-tabs>
+    </div>
     <v-spacer></v-spacer>
 
     <!-- Search Toggle -->
     <DrawerToggleButton component-id="search" />
   </v-app-bar>
+
+  <!-- Conditional Toolbars -->
+  <RedactToolbar v-if="mode === 'redact'" />
 
   <!-- Print Dialog -->
   <PrintDialog :open="printDialogOpen" @close="handlePrintDialogClose" />

--- a/packages/plugin-redaction/package.json
+++ b/packages/plugin-redaction/package.json
@@ -21,6 +21,11 @@
       "types": "./dist/react/index.d.ts",
       "import": "./dist/react/index.js",
       "require": "./dist/react/index.cjs"
+    },
+    "./vue": {
+      "types": "./dist/vue/index.d.ts",
+      "import": "./dist/vue/index.js",
+      "require": "./dist/vue/index.cjs"
     }
   },
   "scripts": {

--- a/packages/plugin-redaction/src/lib/actions.ts
+++ b/packages/plugin-redaction/src/lib/actions.ts
@@ -1,8 +1,9 @@
 import { Action } from '@embedpdf/core';
-import { RedactionItem } from './types';
+import { RedactionItem, RedactionMode } from './types';
 
 export const START_REDACTION = 'START_REDACTION';
 export const END_REDACTION = 'END_REDACTION';
+export const SET_ACTIVE_TYPE = 'SET_ACTIVE_TYPE';
 
 export const ADD_PENDING = 'ADD_PENDING';
 export const REMOVE_PENDING = 'REMOVE_PENDING';
@@ -13,9 +14,14 @@ export const DESELECT_PENDING = 'DESELECT_PENDING';
 
 export interface StartRedactionAction extends Action {
   type: typeof START_REDACTION;
+  payload: RedactionMode;
 }
 export interface EndRedactionAction extends Action {
   type: typeof END_REDACTION;
+}
+export interface SetActiveTypeAction extends Action {
+  type: typeof SET_ACTIVE_TYPE;
+  payload: RedactionMode | null;
 }
 
 export interface AddPendingAction extends Action {
@@ -41,6 +47,7 @@ export interface DeselectPendingAction extends Action {
 export type RedactionAction =
   | StartRedactionAction
   | EndRedactionAction
+  | SetActiveTypeAction
   | AddPendingAction
   | RemovePendingAction
   | ClearPendingAction
@@ -57,8 +64,15 @@ export const removePending = (page: number, id: string): RemovePendingAction => 
 });
 export const clearPending = (): ClearPendingAction => ({ type: CLEAR_PENDING });
 
-export const startRedaction = (): StartRedactionAction => ({ type: START_REDACTION });
+export const startRedaction = (mode: RedactionMode): StartRedactionAction => ({
+  type: START_REDACTION,
+  payload: mode,
+});
 export const endRedaction = (): EndRedactionAction => ({ type: END_REDACTION });
+export const setActiveType = (mode: RedactionMode | null): SetActiveTypeAction => ({
+  type: SET_ACTIVE_TYPE,
+  payload: mode,
+});
 
 export const selectPending = (page: number, id: string): SelectPendingAction => ({
   type: SELECT_PENDING,

--- a/packages/plugin-redaction/src/lib/index.ts
+++ b/packages/plugin-redaction/src/lib/index.ts
@@ -21,3 +21,4 @@ export * from './redaction-plugin';
 export * from './types';
 export * from './manifest';
 export * from './selectors';
+export { initialState } from './reducer';

--- a/packages/plugin-redaction/src/lib/redaction-plugin.ts
+++ b/packages/plugin-redaction/src/lib/redaction-plugin.ts
@@ -119,7 +119,7 @@ export class RedactionPlugin extends BasePlugin<
         id: uuidV4(),
         kind: 'text',
         page: s.pageIndex,
-        boundingRect: s.rect,
+        rect: s.rect,
         rects: s.segmentRects,
       }));
 
@@ -308,7 +308,7 @@ export class RedactionPlugin extends BasePlugin<
       id,
       kind: 'text',
       page: s.pageIndex,
-      boundingRect: s.rect,
+      rect: s.rect,
       rects: s.segmentRects,
     }));
 

--- a/packages/plugin-redaction/src/lib/types.ts
+++ b/packages/plugin-redaction/src/lib/types.ts
@@ -1,6 +1,5 @@
 import { BasePluginConfig, EventHook } from '@embedpdf/core';
 import { PdfErrorReason, Rect, Task } from '@embedpdf/models';
-import { FormattedSelection } from '@embedpdf/plugin-selection';
 
 // Redaction mode enum
 export enum RedactionMode {
@@ -51,6 +50,26 @@ export interface RedactionPluginConfig extends BasePluginConfig {
   drawBlackBoxes: boolean;
 }
 
+// Add event types similar to annotation plugin
+export type RedactionEvent =
+  | {
+      type: 'add';
+      items: RedactionItem[];
+    }
+  | {
+      type: 'remove';
+      page: number;
+      id: string;
+    }
+  | {
+      type: 'clear';
+    }
+  | {
+      type: 'commit';
+      success: boolean;
+      error?: PdfErrorReason;
+    };
+
 export interface RedactionCapability {
   queueCurrentSelectionAsPending: () => Task<boolean, PdfErrorReason>;
 
@@ -62,10 +81,8 @@ export interface RedactionCapability {
   toggleRedactSelection: () => void;
   isRedactSelectionActive: () => boolean;
 
-  onRedactionSelectionChange: EventHook<FormattedSelection[]>;
-  onStateChange: EventHook<RedactionState>;
-
   onPendingChange: EventHook<Record<number, RedactionItem[]>>;
+  addPending: (items: RedactionItem[]) => void;
   removePending: (page: number, id: string) => void;
   clearPending: () => void;
   commitAllPending: () => Task<boolean, PdfErrorReason>;
@@ -74,10 +91,11 @@ export interface RedactionCapability {
   endRedaction: () => void;
   startRedaction: () => void;
 
-  onSelectionChange: EventHook<SelectedRedaction | null>;
   selectPending: (page: number, id: string) => void;
   deselectPending: () => void;
 
-  // keep the single entry point to wire marquee on a page
-  registerMarqueeOnPage(opts: RegisterMarqueeOnPageOptions): () => void;
+  // Event hook for redaction events
+  onSelectedChange: EventHook<SelectedRedaction | null>;
+  onRedactionEvent: EventHook<RedactionEvent>;
+  onStateChange: EventHook<RedactionState>;
 }

--- a/packages/plugin-redaction/src/lib/types.ts
+++ b/packages/plugin-redaction/src/lib/types.ts
@@ -2,6 +2,12 @@ import { BasePluginConfig, EventHook } from '@embedpdf/core';
 import { PdfErrorReason, Rect, Task } from '@embedpdf/models';
 import { FormattedSelection } from '@embedpdf/plugin-selection';
 
+// Redaction mode enum
+export enum RedactionMode {
+  MarqueeRedact = 'marqueeRedact',
+  RedactSelection = 'redactSelection',
+}
+
 export interface SelectedRedaction {
   page: number;
   id: string | null;
@@ -9,7 +15,9 @@ export interface SelectedRedaction {
 
 export interface RedactionState {
   isRedacting: boolean;
+  activeType: RedactionMode | null;
   pending: Record<number, RedactionItem[]>;
+  pendingCount: number;
   selected: SelectedRedaction | null;
 }
 
@@ -55,6 +63,7 @@ export interface RedactionCapability {
   isRedactSelectionActive: () => boolean;
 
   onRedactionSelectionChange: EventHook<FormattedSelection[]>;
+  onStateChange: EventHook<RedactionState>;
 
   onPendingChange: EventHook<Record<number, RedactionItem[]>>;
   removePending: (page: number, id: string) => void;

--- a/packages/plugin-redaction/src/lib/types.ts
+++ b/packages/plugin-redaction/src/lib/types.ts
@@ -25,8 +25,8 @@ export type RedactionItem =
       id: string;
       kind: 'text';
       page: number;
-      boundingRect: Rect;
-      rects: Rect[]; // inner segments
+      rect: Rect;
+      rects: Rect[];
     }
   | {
       id: string;

--- a/packages/plugin-redaction/src/shared/components/highlight.tsx
+++ b/packages/plugin-redaction/src/shared/components/highlight.tsx
@@ -14,7 +14,7 @@ type HighlightProps = Omit<HTMLAttributes<HTMLDivElement>, 'style'> & {
 
 export function Highlight({
   color = '#FFFF00',
-  opacity = 0.5,
+  opacity = 1,
   border = '1px solid red',
   rects,
   rect,

--- a/packages/plugin-redaction/src/shared/components/index.ts
+++ b/packages/plugin-redaction/src/shared/components/index.ts
@@ -1,1 +1,2 @@
 export * from './redaction-layer';
+export * from './types';

--- a/packages/plugin-redaction/src/shared/components/pending-redactions.tsx
+++ b/packages/plugin-redaction/src/shared/components/pending-redactions.tsx
@@ -94,7 +94,7 @@ export function PendingRedactions({
           );
         }
         // kind === 'text' → draw bounding box; inner rects are not drawn here to avoid clutter.
-        const b = it.boundingRect;
+        const b = it.rect;
         return (
           <Fragment key={it.id}>
             <div

--- a/packages/plugin-redaction/src/shared/components/pending-redactions.tsx
+++ b/packages/plugin-redaction/src/shared/components/pending-redactions.tsx
@@ -28,7 +28,7 @@ export function PendingRedactions({
   useEffect(() => {
     if (!redaction) return;
     const off1 = redaction.onPendingChange((map) => setItems(map[pageIndex] ?? []));
-    const off2 = redaction.onSelectionChange((sel) => {
+    const off2 = redaction.onSelectedChange((sel) => {
       setSelectedId(sel && sel.page === pageIndex ? sel.id : null);
     });
     return () => {

--- a/packages/plugin-redaction/src/shared/components/pending-redactions.tsx
+++ b/packages/plugin-redaction/src/shared/components/pending-redactions.tsx
@@ -37,8 +37,6 @@ export function PendingRedactions({
     };
   }, [redaction, pageIndex]);
 
-  if (!items.length) return null;
-
   const select = useCallback(
     (e: MouseEvent | TouchEvent, id: string) => {
       e.stopPropagation();
@@ -47,6 +45,8 @@ export function PendingRedactions({
     },
     [redaction, pageIndex],
   );
+
+  if (!items.length) return null;
 
   return (
     <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}>

--- a/packages/plugin-redaction/src/shared/components/selection-redact.tsx
+++ b/packages/plugin-redaction/src/shared/components/selection-redact.tsx
@@ -1,7 +1,7 @@
 import { Rect } from '@embedpdf/models';
 
 import { useEffect, useState } from '@framework';
-import { useRedactionCapability } from '../hooks';
+import { useRedactionPlugin } from '../hooks';
 import { Highlight } from './highlight';
 
 interface SelectionRedactProps {
@@ -10,19 +10,19 @@ interface SelectionRedactProps {
 }
 
 export function SelectionRedact({ pageIndex, scale }: SelectionRedactProps) {
-  const { provides: redactionProvides } = useRedactionCapability();
+  const { plugin: redactionPlugin } = useRedactionPlugin();
   const [rects, setRects] = useState<Array<Rect>>([]);
   const [boundingRect, setBoundingRect] = useState<Rect | null>(null);
 
   useEffect(() => {
-    if (!redactionProvides) return;
+    if (!redactionPlugin) return;
 
-    return redactionProvides.onRedactionSelectionChange((formattedSelection) => {
+    return redactionPlugin.onRedactionSelectionChange((formattedSelection) => {
       const selection = formattedSelection.find((s) => s.pageIndex === pageIndex);
       setRects(selection?.segmentRects ?? []);
       setBoundingRect(selection?.rect ?? null);
     });
-  }, [redactionProvides, pageIndex]);
+  }, [redactionPlugin, pageIndex]);
 
   if (!boundingRect) return null;
 

--- a/packages/plugin-redaction/src/shared/hooks/use-redaction.ts
+++ b/packages/plugin-redaction/src/shared/hooks/use-redaction.ts
@@ -1,5 +1,22 @@
 import { useCapability, usePlugin } from '@embedpdf/core/@framework';
-import { RedactionPlugin } from '@embedpdf/plugin-redaction';
+import { initialState, RedactionPlugin, RedactionState } from '@embedpdf/plugin-redaction';
+import { useState, useEffect } from '@framework';
 
 export const useRedactionPlugin = () => usePlugin<RedactionPlugin>(RedactionPlugin.id);
 export const useRedactionCapability = () => useCapability<RedactionPlugin>(RedactionPlugin.id);
+
+export const useRedaction = () => {
+  const { provides } = useRedactionCapability();
+  const [state, setState] = useState<RedactionState>(initialState);
+
+  useEffect(() => {
+    return provides?.onStateChange((action) => {
+      setState(action);
+    });
+  }, [provides]);
+
+  return {
+    state,
+    provides,
+  };
+};

--- a/packages/plugin-redaction/src/vue/components/highlight.vue
+++ b/packages/plugin-redaction/src/vue/components/highlight.vue
@@ -36,7 +36,7 @@ interface HighlightProps {
 
 const props = withDefaults(defineProps<HighlightProps>(), {
   color: '#FFFF00',
-  opacity: 0.5,
+  opacity: 1,
   border: '1px solid red',
 });
 

--- a/packages/plugin-redaction/src/vue/components/pending-redactions.vue
+++ b/packages/plugin-redaction/src/vue/components/pending-redactions.vue
@@ -45,10 +45,10 @@
         <div
           :style="{
             position: 'absolute',
-            left: `${item.boundingRect.origin.x * scale}px`,
-            top: `${item.boundingRect.origin.y * scale}px`,
-            width: `${item.boundingRect.size.width * scale}px`,
-            height: `${item.boundingRect.size.height * scale}px`,
+            left: `${item.rect.origin.x * scale}px`,
+            top: `${item.rect.origin.y * scale}px`,
+            width: `${item.rect.size.width * scale}px`,
+            height: `${item.rect.size.height * scale}px`,
             background: 'transparent',
             outline: selectedId === item.id ? `1px solid ${bboxStroke}` : 'none',
             outlineOffset: '2px',
@@ -57,7 +57,7 @@
           }"
         >
           <Highlight
-            :rect="item.boundingRect"
+            :rect="item.rect"
             :rects="item.rects"
             color="transparent"
             border="1px solid red"
@@ -68,12 +68,12 @@
         <CounterRotate
           :rect="{
             origin: {
-              x: item.boundingRect.origin.x * scale,
-              y: item.boundingRect.origin.y * scale,
+              x: item.rect.origin.x * scale,
+              y: item.rect.origin.y * scale,
             },
             size: {
-              width: item.boundingRect.size.width * scale,
-              height: item.boundingRect.size.height * scale,
+              width: item.rect.size.width * scale,
+              height: item.rect.size.height * scale,
             },
           }"
           :rotation="rotation"

--- a/packages/plugin-redaction/src/vue/components/pending-redactions.vue
+++ b/packages/plugin-redaction/src/vue/components/pending-redactions.vue
@@ -134,7 +134,7 @@ onMounted(() => {
     items.value = map[props.pageIndex] ?? [];
   });
 
-  unsubscribeSelection = redaction.value.onSelectionChange((sel) => {
+  unsubscribeSelection = redaction.value.onSelectedChange((sel) => {
     selectedId.value = sel && sel.page === props.pageIndex ? sel.id : null;
   });
 });

--- a/packages/plugin-redaction/src/vue/components/selection-redact.vue
+++ b/packages/plugin-redaction/src/vue/components/selection-redact.vue
@@ -21,7 +21,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue';
 import type { Rect } from '@embedpdf/models';
-import { useRedactionCapability } from '../hooks/use-redaction';
+import { useRedactionPlugin } from '../hooks/use-redaction';
 import Highlight from './highlight.vue';
 
 interface SelectionRedactProps {
@@ -31,16 +31,16 @@ interface SelectionRedactProps {
 
 const props = defineProps<SelectionRedactProps>();
 
-const { provides: redactionProvides } = useRedactionCapability();
+const { plugin: redactionPlugin } = useRedactionPlugin();
 const rects = ref<Rect[]>([]);
 const boundingRect = ref<Rect | null>(null);
 
 let unsubscribe: (() => void) | undefined;
 
 onMounted(() => {
-  if (!redactionProvides.value) return;
+  if (!redactionPlugin.value) return;
 
-  unsubscribe = redactionProvides.value.onRedactionSelectionChange((formattedSelection) => {
+  unsubscribe = redactionPlugin.value.onRedactionSelectionChange((formattedSelection) => {
     const selection = formattedSelection.find((s) => s.pageIndex === props.pageIndex);
     rects.value = selection?.segmentRects ?? [];
     boundingRect.value = selection?.rect ?? null;

--- a/packages/plugin-redaction/src/vue/hooks/use-redaction.ts
+++ b/packages/plugin-redaction/src/vue/hooks/use-redaction.ts
@@ -1,5 +1,25 @@
+import { ref, watchEffect, readonly } from 'vue';
 import { useCapability, usePlugin } from '@embedpdf/core/vue';
-import { RedactionPlugin } from '@embedpdf/plugin-redaction';
+import { RedactionPlugin, initialState, RedactionState } from '@embedpdf/plugin-redaction';
 
 export const useRedactionPlugin = () => usePlugin<RedactionPlugin>(RedactionPlugin.id);
 export const useRedactionCapability = () => useCapability<RedactionPlugin>(RedactionPlugin.id);
+
+export const useRedaction = () => {
+  const { provides } = useRedactionCapability();
+  const state = ref<RedactionState>(initialState);
+
+  watchEffect((onCleanup) => {
+    if (!provides.value) return;
+
+    const unsubscribe = provides.value.onStateChange((newState) => {
+      state.value = newState;
+    });
+    onCleanup(unsubscribe);
+  });
+
+  return {
+    state: readonly(state),
+    provides,
+  };
+};

--- a/packages/plugin-render/src/vue/components/render-layer.vue
+++ b/packages/plugin-render/src/vue/components/render-layer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, onBeforeUnmount, computed } from 'vue';
+import { ref, watch, onBeforeUnmount, computed, watchEffect } from 'vue';
 import { ignore, PdfErrorCode, PdfErrorReason, Task } from '@embedpdf/models';
 
 import { useRenderCapability, useRenderPlugin } from '../hooks';
@@ -78,20 +78,15 @@ function startRender() {
 }
 
 // Watch for external refresh events
-watch(
-  renderPlugin,
-  (pluginInstance, _, onCleanup) => {
-    if (pluginInstance) {
-      const unsubscribe = pluginInstance.onRefreshPages((pages: number[]) => {
-        if (pages.includes(props.pageIndex)) {
-          refreshTick.value++;
-        }
-      });
-      onCleanup(unsubscribe);
+watchEffect((onCleanup) => {
+  if (!renderPlugin.value) return;
+  const unsubscribe = renderPlugin.value.onRefreshPages((pages: number[]) => {
+    if (pages.includes(props.pageIndex)) {
+      refreshTick.value++;
     }
-  },
-  { immediate: true },
-);
+  });
+  onCleanup(unsubscribe);
+});
 
 // Watch for changes that require a re-render
 watch(

--- a/packages/plugin-tiling/src/vue/components/tile-img.vue
+++ b/packages/plugin-tiling/src/vue/components/tile-img.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, toRaw, computed } from 'vue';
+import { ref, onMounted, onBeforeUnmount, toRaw, computed, watchEffect, watch } from 'vue';
 import { ignore, PdfErrorCode, PdfErrorReason, Task } from '@embedpdf/models';
 import type { StyleValue } from 'vue';
 
 import type { Tile } from '@embedpdf/plugin-tiling';
-import { useTilingCapability } from '../hooks';
+import { useTilingCapability, useTilingPlugin } from '../hooks';
 
 interface Props {
   pageIndex: number;
@@ -19,8 +19,10 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const { provides: tilingCapability } = useTilingCapability();
+const { plugin: tilingPlugin } = useTilingPlugin();
 
 const url = ref<string>();
+const refreshTick = ref(0);
 let blobUrl: string | null = null;
 let renderTask: Task<Blob, PdfErrorReason> | null = null;
 
@@ -44,10 +46,27 @@ function abortCurrentTask() {
 }
 
 /* -------------------------------------------------- */
-/* start one render task when component mounts        */
+/* Watch for external refresh events                  */
 /* -------------------------------------------------- */
-onMounted(() => {
+watchEffect((onCleanup) => {
+  if (!tilingPlugin.value) return;
+  const unsubscribe = tilingPlugin.value.onRefreshPages((pages) => {
+    if (pages.includes(props.pageIndex)) {
+      refreshTick.value++;
+    }
+  });
+  onCleanup(unsubscribe);
+});
+
+/* -------------------------------------------------- */
+/* start render task when dependencies change         */
+/* -------------------------------------------------- */
+function startRender() {
+  if (props.tile.status === 'ready' && blobUrl) return; // already done
   if (!tilingCapability.value) return;
+
+  abortCurrentTask();
+  revoke();
 
   const task = tilingCapability.value.renderTile({
     pageIndex: props.pageIndex,
@@ -61,7 +80,14 @@ onMounted(() => {
     url.value = blobUrl;
     renderTask = null; // Task completed
   }, ignore);
-});
+}
+
+// Watch for changes that require a re-render
+watch(
+  () => [props.pageIndex, props.tile.id, refreshTick.value, !!tilingCapability.value],
+  startRender,
+  { immediate: true },
+);
 
 /* -------------------------------------------------- */
 /* cleanup                                            */

--- a/packages/utils/src/shared/components/counter-rotate-container.tsx
+++ b/packages/utils/src/shared/components/counter-rotate-container.tsx
@@ -1,6 +1,6 @@
 import { Rect, Rotation } from '@embedpdf/models';
 import { getCounterRotation } from '@embedpdf/utils';
-import { ReactNode, CSSProperties, PointerEvent, Fragment, TouchEvent } from '@framework';
+import { ReactNode, CSSProperties, Fragment, useRef, useEffect } from '@framework';
 
 interface CounterRotateProps {
   rect: Rect;
@@ -9,8 +9,7 @@ interface CounterRotateProps {
 
 export interface MenuWrapperProps {
   style: CSSProperties;
-  onPointerDown: (e: PointerEvent<HTMLDivElement>) => void;
-  onTouchStart: (e: TouchEvent<HTMLDivElement>) => void;
+  ref: (el: HTMLDivElement | null) => void;
 }
 
 interface CounterRotateComponentProps extends CounterRotateProps {
@@ -24,6 +23,32 @@ interface CounterRotateComponentProps extends CounterRotateProps {
 export function CounterRotate({ children, ...props }: CounterRotateComponentProps) {
   const { rect, rotation } = props;
   const { matrix, width, height } = getCounterRotation(rect, rotation);
+  const elementRef = useRef<HTMLDivElement | null>(null);
+
+  // Use native event listeners with capture phase to prevent text selection
+  useEffect(() => {
+    const element = elementRef.current;
+    if (!element) return;
+
+    const handlePointerDown = (e: Event) => {
+      e.stopPropagation();
+      e.preventDefault();
+    };
+
+    const handleTouchStart = (e: Event) => {
+      e.stopPropagation();
+      e.preventDefault();
+    };
+
+    // Use capture phase to intercept before synthetic events
+    element.addEventListener('pointerdown', handlePointerDown, { capture: true });
+    element.addEventListener('touchstart', handleTouchStart, { capture: true });
+
+    return () => {
+      element.removeEventListener('pointerdown', handlePointerDown, { capture: true });
+      element.removeEventListener('touchstart', handleTouchStart, { capture: true });
+    };
+  }, []);
 
   const menuWrapperStyle: CSSProperties = {
     position: 'absolute',
@@ -37,10 +62,11 @@ export function CounterRotate({ children, ...props }: CounterRotateComponentProp
     zIndex: 3,
   };
 
-  const menuWrapperProps = {
+  const menuWrapperProps: MenuWrapperProps = {
     style: menuWrapperStyle,
-    onPointerDown: (e: PointerEvent<HTMLDivElement>) => e.stopPropagation(),
-    onTouchStart: (e: TouchEvent<HTMLDivElement>) => e.stopPropagation(),
+    ref: (el: HTMLDivElement | null) => {
+      elementRef.current = el;
+    },
   };
 
   return (

--- a/packages/utils/src/vue/components/counter-rotate-container.vue
+++ b/packages/utils/src/vue/components/counter-rotate-container.vue
@@ -28,8 +28,14 @@ const menuWrapperProps = computed(() => ({
     pointerEvents: 'none',
     zIndex: 3,
   } as CSSProperties,
-  onPointerDown: (e: PointerEvent) => e.stopPropagation(),
-  onTouchStart: (e: TouchEvent) => e.stopPropagation(),
+  onPointerDown: (e: PointerEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+  },
+  onTouchStart: (e: TouchEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+  },
 }));
 
 const adjustedRect = computed(() => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1695,6 +1695,9 @@ importers:
       '@embedpdf/plugin-print':
         specifier: workspace:*
         version: link:../packages/plugin-print
+      '@embedpdf/plugin-redaction':
+        specifier: workspace:*
+        version: link:../packages/plugin-redaction
       '@embedpdf/plugin-render':
         specifier: workspace:*
         version: link:../packages/plugin-render

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       '@embedpdf/plugin-pan':
         specifier: workspace:*
         version: link:../../packages/plugin-pan
+      '@embedpdf/plugin-redaction':
+        specifier: workspace:*
+        version: link:../../packages/plugin-redaction
       '@embedpdf/plugin-render':
         specifier: workspace:*
         version: link:../../packages/plugin-render
@@ -403,6 +406,9 @@ importers:
       '@embedpdf/plugin-print':
         specifier: workspace:*
         version: link:../../packages/plugin-print
+      '@embedpdf/plugin-redaction':
+        specifier: workspace:*
+        version: link:../../packages/plugin-redaction
       '@embedpdf/plugin-render':
         specifier: workspace:*
         version: link:../../packages/plugin-render

--- a/snippet/src/components/redaction-menu.tsx
+++ b/snippet/src/components/redaction-menu.tsx
@@ -25,7 +25,7 @@ export const RedactionMenu = ({ item, pageIndex, ...props }: RedactionMenuProps)
   return (
     <div
       {...props}
-      className="flex flex-row gap-1 rounded-md border border-[#cfd4da] bg-[#f8f9fa] p-1"
+      className="flex cursor-default flex-row gap-1 rounded-md border border-[#cfd4da] bg-[#f8f9fa] p-1"
     >
       <Tooltip position={'bottom'} content={'Delete Redaction'} trigger={'hover'} delay={500}>
         <Button onClick={handleDeleteClick}>

--- a/website/package.json
+++ b/website/package.json
@@ -34,6 +34,7 @@
     "@embedpdf/plugin-history": "workspace:*",
     "@embedpdf/plugin-thumbnail": "workspace:*",
     "@embedpdf/plugin-capture": "workspace:*",
+    "@embedpdf/plugin-redaction": "workspace:*",
     "@headlessui/react": "^2.2.0",
     "@mdx-js/loader": "^3.0.0",
     "@mdx-js/react": "^3.0.0",

--- a/website/src/content/docs/react/code-examples/redaction-example.tsx
+++ b/website/src/content/docs/react/code-examples/redaction-example.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { createPluginRegistration } from '@embedpdf/core'
+import { EmbedPDF } from '@embedpdf/core/react'
+import { usePdfiumEngine } from '@embedpdf/engines/react'
+import {
+  InteractionManagerPluginPackage,
+  PagePointerProvider,
+} from '@embedpdf/plugin-interaction-manager/react'
+import { LoaderPluginPackage } from '@embedpdf/plugin-loader/react'
+import {
+  RedactionLayer,
+  RedactionMode,
+  RedactionPluginPackage,
+  useRedaction,
+  SelectionMenuProps,
+} from '@embedpdf/plugin-redaction/react'
+import { RenderLayer, RenderPluginPackage } from '@embedpdf/plugin-render/react'
+import { Scroller, ScrollPluginPackage } from '@embedpdf/plugin-scroll/react'
+import {
+  SelectionLayer,
+  SelectionPluginPackage,
+} from '@embedpdf/plugin-selection/react'
+import {
+  Viewport,
+  ViewportPluginPackage,
+} from '@embedpdf/plugin-viewport/react'
+import { useState } from 'react'
+
+// 1. Register plugins, including Redaction and its dependencies
+const plugins = [
+  createPluginRegistration(LoaderPluginPackage, {
+    loadingOptions: {
+      type: 'url',
+      pdfFile: {
+        id: 'example-pdf',
+        url: 'https://snippet.embedpdf.com/ebook.pdf',
+      },
+    },
+  }),
+  createPluginRegistration(ViewportPluginPackage),
+  createPluginRegistration(ScrollPluginPackage),
+  createPluginRegistration(RenderPluginPackage),
+  createPluginRegistration(InteractionManagerPluginPackage),
+  createPluginRegistration(SelectionPluginPackage),
+  createPluginRegistration(RedactionPluginPackage, {
+    drawBlackBoxes: true,
+  }),
+]
+
+// 2. Create a toolbar to manage redaction
+const RedactionToolbar = () => {
+  const { state, provides } = useRedaction()
+  const [isCommitting, setIsCommitting] = useState(false)
+
+  const handleApplyAll = () => {
+    if (!provides || isCommitting) return
+    setIsCommitting(true)
+    provides.commitAllPending().wait(
+      () => setIsCommitting(false),
+      () => setIsCommitting(false),
+    )
+  }
+
+  return (
+    <div className="mb-4 mt-4 flex flex-wrap items-center gap-2 rounded-lg border border-gray-200 bg-white p-2 shadow-sm">
+      <button
+        onClick={() => provides?.toggleRedactSelection()}
+        className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
+          state.activeType === RedactionMode.RedactSelection
+            ? 'bg-blue-500 text-white'
+            : 'bg-gray-100 hover:bg-gray-200'
+        }`}
+      >
+        Mark Text
+      </button>
+      <button
+        onClick={() => provides?.toggleMarqueeRedact()}
+        className={`rounded-md px-3 py-1 text-sm font-medium transition-colors ${
+          state.activeType === RedactionMode.MarqueeRedact
+            ? 'bg-blue-500 text-white'
+            : 'bg-gray-100 hover:bg-gray-200'
+        }`}
+      >
+        Mark Area
+      </button>
+      <div className="h-6 w-px bg-gray-200"></div>
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium text-gray-600">
+          {state.pendingCount} marks pending
+        </span>
+        <button
+          onClick={handleApplyAll}
+          disabled={state.pendingCount === 0 || isCommitting}
+          className="rounded-md bg-red-500 px-3 py-1 text-sm font-medium text-white transition-colors hover:bg-red-600 disabled:cursor-not-allowed disabled:bg-red-300"
+        >
+          {isCommitting ? 'Applying...' : 'Apply All'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// 3. Define a custom menu for selected redaction marks
+const RedactionMenu = ({
+  item,
+  selected,
+  menuWrapperProps,
+  rect,
+}: SelectionMenuProps) => {
+  const { provides } = useRedaction()
+  if (!selected) return null
+
+  return (
+    <div {...menuWrapperProps}>
+      <div
+        className="flex cursor-default gap-2 rounded-lg border border-gray-200 bg-white p-1.5 shadow-lg"
+        style={{
+          position: 'absolute',
+          top: rect.size.height + 10,
+          left: 0,
+          pointerEvents: 'auto',
+        }}
+      >
+        <button
+          onClick={() => provides?.commitPending(item.page, item.id)}
+          className="rounded-md bg-red-500 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-red-600 active:bg-red-700"
+        >
+          Apply
+        </button>
+        <button
+          onClick={() => provides?.removePending(item.page, item.id)}
+          className="rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 active:bg-gray-300"
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// 4. Create the main viewer component
+export const PDFViewer = () => {
+  const { engine, isLoading } = usePdfiumEngine()
+
+  if (isLoading || !engine) {
+    return <div>Loading PDF Engine...</div>
+  }
+
+  return (
+    <div
+      style={{
+        height: '600px',
+        display: 'flex',
+        flexDirection: 'column',
+        userSelect: 'none',
+      }}
+    >
+      <EmbedPDF engine={engine} plugins={plugins}>
+        <RedactionToolbar />
+        <div style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
+          <Viewport
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              backgroundColor: '#f1f3f5',
+            }}
+          >
+            <Scroller
+              renderPage={({ width, height, pageIndex, scale, rotation }) => (
+                <PagePointerProvider
+                  pageIndex={pageIndex}
+                  pageWidth={width}
+                  pageHeight={height}
+                  rotation={rotation}
+                  scale={scale}
+                >
+                  <RenderLayer
+                    pageIndex={pageIndex}
+                    style={{ pointerEvents: 'none' }}
+                  />
+                  <SelectionLayer pageIndex={pageIndex} scale={scale} />
+                  <RedactionLayer
+                    pageIndex={pageIndex}
+                    scale={scale}
+                    rotation={rotation}
+                    selectionMenu={(props) => <RedactionMenu {...props} />}
+                  />
+                </PagePointerProvider>
+              )}
+            />
+          </Viewport>
+        </div>
+      </EmbedPDF>
+    </div>
+  )
+}

--- a/website/src/content/docs/react/plugins/_meta.ts
+++ b/website/src/content/docs/react/plugins/_meta.ts
@@ -13,4 +13,5 @@ export default {
   'plugin-spread': 'Spread',
   'plugin-pan': 'Pan',
   'plugin-capture': 'Capture',
+  'plugin-redaction': 'Redaction',
 }

--- a/website/src/content/docs/react/plugins/plugin-redaction.mdx
+++ b/website/src/content/docs/react/plugins/plugin-redaction.mdx
@@ -1,0 +1,206 @@
+---
+title: Redaction Plugin
+description: Securely and permanently remove text and image content from a PDF document.
+searchable: true
+---
+
+import { Callout } from '@/components/callout'
+
+# Redaction Plugin
+
+The Redaction Plugin provides the tools to permanently remove sensitive content from a PDF document. Unlike annotations which are simply layered on top, redaction is a destructive process that alters the underlying PDF content, making it unrecoverable.
+
+The process involves two main stages:
+1.  **Marking**: Users mark content for redaction by selecting text or drawing a rectangle over an area. These marks are called "pending redactions."
+2.  **Committing**: Users apply the pending redactions, which permanently removes the marked content from the document in the viewer's memory and, optionally, draws black boxes in its place.
+
+<Callout type="warning" title="Destructive Action">
+Redaction is an irreversible process. Once committed, the original content is removed and cannot be restored from the document.
+</Callout>
+
+## Installation
+
+The plugin has optional but highly recommended dependencies on the `Selection` and `Interaction Manager` plugins, which are required for marking text and areas, respectively.
+
+```sh npm2yarn
+npm install @embedpdf/plugin-redaction @embedpdf/plugin-selection @embedpdf/plugin-interaction-manager
+````
+
+## Registration
+
+Import `RedactionPluginPackage` and its dependencies, then add them to the `plugins` array. The dependencies should be registered first.
+
+```tsx {6, 18-20}
+import { createPluginRegistration } from '@embedpdf/core'
+import { EmbedPDF } from '@embedpdf/core/react'
+// ... other imports
+import { InteractionManagerPluginPackage } from '@embedpdf/plugin-interaction-manager/react'
+import { SelectionPluginPackage } from '@embedpdf/plugin-selection/react'
+import { RedactionPluginPackage } from '@embedpdf/plugin-redaction/react'
+
+const plugins = [
+  // ... other essential plugins
+  createPluginRegistration(LoaderPluginPackage, { /* ... */ }),
+  createPluginRegistration(RenderPluginPackage),
+
+  // Register dependencies first
+  createPluginRegistration(InteractionManagerPluginPackage),
+  createPluginRegistration(SelectionPluginPackage),
+
+  // Register and configure the redaction plugin
+  createPluginRegistration(RedactionPluginPackage, {
+    drawBlackBoxes: true, // Draw black boxes over redacted content
+  }),
+]
+```
+
+## Usage
+
+The plugin's functionality is primarily managed through the `<RedactionLayer />` component and the `useRedaction` hook.
+
+### 1\. Add the `<RedactionLayer />`
+
+This component is responsible for rendering all redaction-related UI, including the text selection highlights, area selection marquee, and all pending redaction marks. It must be placed inside your `Scroller`'s `renderPage` prop and be a child of the `<PagePointerProvider>`.
+
+```tsx {2, 10}
+import { PagePointerProvider } from '@embedpdf/plugin-interaction-manager/react';
+import { RedactionLayer } from '@embedpdf/plugin-redaction/react';
+
+// ...
+<Scroller
+  renderPage={({ width, height, pageIndex, scale, rotation }) => (
+    <PagePointerProvider {...{ pageIndex, width, height, scale, rotation }}>
+      <RenderLayer pageIndex={pageIndex} />
+      <SelectionLayer pageIndex={pageIndex} />
+      <RedactionLayer pageIndex={pageIndex} scale={scale} rotation={rotation} />
+    </PagePointerProvider>
+  )}
+/>
+```
+
+### 2\. Build a Redaction Toolbar
+
+The `useRedaction` hook provides the `state` of the redaction process (e.g., how many marks are pending) and a `provides` object with methods to control it. You can build a toolbar to allow users to switch between redaction modes and apply their changes.
+
+```tsx
+import { useRedaction, RedactionMode } from '@embedpdf/plugin-redaction/react';
+
+const RedactionToolbar = () => {
+  const { state, provides } = useRedaction();
+
+  return (
+    <div>
+      <button onClick={() => provides?.toggleRedactSelection()}>Mark Text</button>
+      <button onClick={() => provides?.toggleMarqueeRedact()}>Mark Area</button>
+      <span>{state.pendingCount} pending marks</span>
+      <button
+        onClick={() => provides?.commitAllPending()}
+        disabled={state.pendingCount === 0}
+      >
+        Apply All Redactions
+      </button>
+    </div>
+  );
+};
+```
+
+### 3\. Create a Menu for Pending Marks
+
+You can provide a `selectionMenu` render prop to the `<RedactionLayer />` to display a custom UI when a user clicks on a pending redaction mark. This is useful for allowing users to apply or remove individual marks.
+
+```tsx
+import { SelectionMenuProps, useRedaction } from '@embedpdf/plugin-redaction/react';
+
+// A custom menu component
+const RedactionMenu = ({ item, selected, menuWrapperProps }: SelectionMenuProps) => {
+  const { provides } = useRedaction();
+  if (!selected) return null;
+
+  return (
+    <div {...menuWrapperProps}>
+      <div
+        style={{ 
+          position: 'absolute', 
+          top: rect.size.height + 10, 
+          left: 0, 
+          pointerEvents: 'auto' 
+        }}
+      >
+        <button onClick={() => provides?.removePending(item.page, item.id)}>Remove</button>
+      </div>
+    </div>
+  );
+};
+
+// Pass it to the layer
+<RedactionLayer
+  pageIndex={pageIndex}
+  scale={scale}
+  rotation={rotation}
+  selectionMenu={(props) => <RedactionMenu {...props} />}
+/>
+```
+
+## Live Example
+
+This example demonstrates the full redaction workflow. Use the "Mark Text" and "Mark Area" buttons to queue redactions. Click a pending mark to see the option to remove it. Finally, click "Apply All" to permanently redact the content.
+
+import { PDFViewer } from '../code-examples/redaction-example';
+
+<PDFViewer />
+
+## API Reference
+
+### Configuration (`RedactionPluginConfig`)
+
+| Option | Type | Description |
+| :--- | :--- | :--- |
+| **`drawBlackBoxes`** | `boolean` | If `true`, a black rectangle is drawn over the redacted content after committing. **Default**: `true` |
+
+### Component: `<RedactionLayer />`
+
+Renders all UI related to marking and managing redactions.
+
+| Prop | Type | Description |
+| :--- | :--- | :--- |
+| **`pageIndex`** | `number` | **(Required)** The page index this layer corresponds to. |
+| **`scale`** | `number` | **(Required)** The current zoom scale of the page. |
+| **`rotation`** | `Rotation` | **(Required)** The current rotation of the page. |
+| **`selectionMenu`** | `(props: SelectionMenuProps) => JSX.Element` | A render prop for a custom menu that appears when a pending redaction is selected. |
+
+### Hook: `useRedaction()`
+
+Connects your components to the redaction plugin's state and methods.
+
+#### Returns
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| **`state`** | `RedactionState` | An object containing the current state of the redaction process. |
+| **`provides`**| `RedactionCapability \| null` | An object with methods to control the plugin, or `null` if not ready. |
+
+#### `RedactionState` Properties
+
+| Property | Type | Description |
+| :--- | :--- | :--- |
+| **`isRedacting`**| `boolean`| `true` when any redaction mode is active. |
+| **`activeType`** | `RedactionMode \| null` | The currently active mode (`'marqueeRedact'` or `'redactSelection'`). |
+| **`pending`**| `object`| A map of pending redactions, keyed by page number. |
+| **`pendingCount`**| `number`| The total number of pending redactions across all pages. |
+| **`selected`**| `object \| null`| The currently selected pending redaction, if any. |
+
+#### `RedactionCapability` Methods
+
+A selection of key methods available on the `provides` object:
+
+| Method | Description |
+| :--- | :--- |
+| **`toggleRedactSelection()`** | Toggles the text redaction mode. |
+| **`toggleMarqueeRedact()`** | Toggles the area redaction mode. |
+| **`addPending(items)`** | Programmatically adds new `RedactionItem`s to the pending queue. |
+| **`removePending(page, id)`** | Removes a specific pending redaction mark. |
+| **`clearPending()`** | Removes all pending redaction marks. |
+| **`commitAllPending()`** | **(Destructive)** Applies all pending redactions to the document. Returns a `Task`. |
+| **`commitPending(page, id)`** | **(Destructive)** Applies a single pending redaction. Returns a `Task`. |
+| **`onStateChange(cb)`** | Subscribes to any change in the `RedactionState`. |
+| **`onRedactionEvent(cb)`** | Subscribes to events like adding, removing, or committing redactions. |


### PR DESCRIPTION
Integrated @embedpdf/plugin-redaction into both React (MUI) and Vue (Vuetify) example apps, including new redaction toolbars, selection menus, and UI modes. Updated plugin-redaction to support state tracking, mode switching, and improved hooks for both frameworks. Also added new icons and improved highlight rendering for redactions.