### PR TITLE
fix(search-layer): interpolate originalIndex and rectIndex in key

### DIFF
--- a/packages/plugin-search/src/shared/components/search-layer.tsx
+++ b/packages/plugin-search/src/shared/components/search-layer.tsx
@@ -47,7 +47,7 @@ export function SearchLayer({
       {pageResults.map(({ result, originalIndex }) =>
         result.rects.map((rect, rectIndex) => (
           <div
-            key={`originalIndex-rectIndex`}
+            key={`${originalIndex}-${rectIndex}`}
             style={{
               position: 'absolute',
               top: rect.origin.y * scale,


### PR DESCRIPTION
Previously, all highlights in the search layer used the same static key.


The PR updates it to interpolate originalIndex and rectIndex, and generate those unique keys.