### PR TITLE
feat(plugin-selection): add auto-scroll on text selection

### DIFF
--- a/packages/plugin-selection/package.json
+++ b/packages/plugin-selection/package.json
@@ -46,6 +46,7 @@
     "@embedpdf/core": "workspace:*",
     "@embedpdf/plugin-viewport": "workspace:*",
     "@embedpdf/plugin-interaction-manager": "workspace:*",
+    "@embedpdf/plugin-scroll": "workspace:*",
     "@types/react": "^18.2.0",
     "typescript": "^5.0.0"
   },
@@ -53,6 +54,7 @@
     "@embedpdf/core": "workspace:*",
     "@embedpdf/plugin-viewport": "workspace:*",
     "@embedpdf/plugin-interaction-manager": "workspace:*",
+    "@embedpdf/plugin-scroll": "workspace:*",
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
     "preact": "^10.26.4",

--- a/packages/plugin-selection/src/lib/manifest.ts
+++ b/packages/plugin-selection/src/lib/manifest.ts
@@ -8,7 +8,7 @@ export const manifest: PluginManifest<SelectionPluginConfig> = {
   name: 'Selection Plugin',
   version: '1.0.0',
   provides: ['selection'],
-  requires: ['interaction-manager'],
+  requires: ['interaction-manager', 'viewport', 'scroll'],
   optional: [],
   defaultConfig: {
     enabled: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1255,6 +1255,9 @@ importers:
       '@embedpdf/plugin-interaction-manager':
         specifier: workspace:*
         version: link:../plugin-interaction-manager
+      '@embedpdf/plugin-scroll':
+        specifier: workspace:*
+        version: link:../plugin-scroll
       '@embedpdf/plugin-viewport':
         specifier: workspace:*
         version: link:../plugin-viewport


### PR DESCRIPTION
## Description

Adds auto-scroll functionality to text selection, enabling seamless multi-page selection when pointer approaches viewport edges.

## Changes

- Auto-scroll triggers within 50-100px of viewport edges during text selection
- Uses `requestAnimationFrame` for smooth scrolling
- Automatically stops when selection ends or pointer moves away
- Supports all four directional scrolling (up, down, left, right)

## Questions

### Edge Threshold Configuration

I initially set all edge thresholds (top, bottom, left, right) to 50px. 

However, when I was testing with the `snippet` example, I noticed that 50px wasn't quite enough for the top edge - the auto-scroll wouldn't kick in reliably when I moved my cursor near the top. 

As a result, I increased only the top threshold to 100px while keeping the others at 50px:

```typescript
private readonly AUTO_SCROLL_TOP_THRESHOLD = 100;
private readonly AUTO_SCROLL_BOTTOM_THRESHOLD = 50;
private readonly AUTO_SCROLL_LEFT_THRESHOLD = 50;
private readonly AUTO_SCROLL_RIGHT_THRESHOLD = 50;
```

This is my first PR here! I'm absolutely loving this project and it's been a pleasure working with the codebase. Please feel free to let me know if there's anything I should improve. Thanks so much for your time! 💙
