### PR TITLE
feat: add HTTP header and cookie support for PDF loading

### DIFF
--- a/packages/engines/src/lib/pdfium/engine.ts
+++ b/packages/engines/src/lib/pdfium/engine.ts
@@ -353,6 +353,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
   public openDocumentUrl(file: PdfFileUrl, options?: PdfOpenDocumentUrlOptions) {
     const mode = options?.mode ?? 'auto';
     const password = options?.password ?? '';
+    const requestOptions = options?.requestOptions;
 
     this.logger.debug(LOG_SOURCE, LOG_CATEGORY, 'openDocumentUrl called', file.url, mode);
 
@@ -362,7 +363,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
     // Start an async procedure
     (async () => {
       try {
-        const fetchFullTask = await this.fetchFullAndOpen(file, password);
+        const fetchFullTask = await this.fetchFullAndOpen(file, password, requestOptions);
         fetchFullTask.wait(
           (doc) => task.resolve(doc),
           (err) => task.reject(err.reason),
@@ -385,12 +386,17 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
    */
   private async checkRangeSupport(
     url: string,
+    requestOptions?: { headers?: Record<string, string>; credentials?: RequestCredentials },
   ): Promise<{ supportsRanges: boolean; fileLength: number; content: ArrayBuffer | null }> {
     try {
       this.logger.debug(LOG_SOURCE, LOG_CATEGORY, 'checkRangeSupport', url);
 
       // First try HEAD request
-      const headResponse = await fetch(url, { method: 'HEAD' });
+      const headResponse = await fetch(url, {
+        method: 'HEAD',
+        headers: requestOptions?.headers,
+        credentials: requestOptions?.credentials,
+      });
       const fileLength = headResponse.headers.get('Content-Length');
       const acceptRanges = headResponse.headers.get('Accept-Ranges');
 
@@ -405,7 +411,8 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
 
       // Test actual range request support
       const testResponse = await fetch(url, {
-        headers: { Range: 'bytes=0-1' },
+        headers: { ...requestOptions?.headers, Range: 'bytes=0-1' },
+        credentials: requestOptions?.credentials,
       });
 
       // If we get 200 instead of 206, server doesn't support ranges
@@ -435,11 +442,18 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
    * Fully fetch the file (using fetch) into an ArrayBuffer,
    * then call openDocumentFromBuffer.
    */
-  private async fetchFullAndOpen(file: PdfFileUrl, password: string) {
+  private async fetchFullAndOpen(
+    file: PdfFileUrl,
+    password: string,
+    requestOptions?: { headers?: Record<string, string>; credentials?: RequestCredentials },
+  ) {
     this.logger.debug(LOG_SOURCE, LOG_CATEGORY, 'fetchFullAndOpen', file.url);
 
     // 1. fetch entire PDF as array buffer
-    const response = await fetch(file.url);
+    const response = await fetch(file.url, {
+      headers: requestOptions?.headers,
+      credentials: requestOptions?.credentials,
+    });
     if (!response.ok) {
       throw new Error(`Could not fetch PDF: ${response.statusText}`);
     }
@@ -467,11 +481,12 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
     file: PdfFileUrl,
     password: string,
     knownFileLength?: number,
+    requestOptions?: { headers?: Record<string, string>; credentials?: RequestCredentials },
   ) {
     this.logger.debug(LOG_SOURCE, LOG_CATEGORY, 'openDocumentWithRangeRequest', file.url);
 
     // We first do a HEAD or a partial fetch to get the fileLength:
-    const fileLength = knownFileLength ?? (await this.retrieveFileLength(file.url)).fileLength;
+    const fileLength = knownFileLength ?? (await this.retrieveFileLength(file.url, requestOptions)).fileLength;
 
     // 2. define the callback function used by openDocumentFromLoader
     const callback = (offset: number, length: number) => {
@@ -479,7 +494,22 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       const xhr = new XMLHttpRequest();
       xhr.open('GET', file.url, false); // note: block in the Worker
       xhr.overrideMimeType('text/plain; charset=x-user-defined');
+      
+      // Set Range header
       xhr.setRequestHeader('Range', `bytes=${offset}-${offset + length - 1}`);
+      
+      // Set custom headers if provided
+      if (requestOptions?.headers) {
+        Object.entries(requestOptions.headers).forEach(([key, value]) => {
+          xhr.setRequestHeader(key, value);
+        });
+      }
+      
+      // Set credentials for cookies
+      if (requestOptions?.credentials) {
+        xhr.withCredentials = requestOptions.credentials === 'include';
+      }
+      
       xhr.send(null);
 
       if (xhr.status === 206 || xhr.status === 200) {
@@ -502,11 +532,18 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
   /**
    * Helper to do a HEAD request or partial GET to find file length.
    */
-  private async retrieveFileLength(url: string): Promise<{ fileLength: number }> {
+  private async retrieveFileLength(
+    url: string,
+    requestOptions?: { headers?: Record<string, string>; credentials?: RequestCredentials },
+  ): Promise<{ fileLength: number }> {
     this.logger.debug(LOG_SOURCE, LOG_CATEGORY, 'retrieveFileLength', url);
 
     // We'll do a HEAD request to get Content-Length
-    const resp = await fetch(url, { method: 'HEAD' });
+    const resp = await fetch(url, {
+      method: 'HEAD',
+      headers: requestOptions?.headers,
+      credentials: requestOptions?.credentials,
+    });
     if (!resp.ok) {
       throw new Error(`Failed HEAD request for file length: ${resp.statusText}`);
     }

--- a/packages/models/src/pdf.ts
+++ b/packages/models/src/pdf.ts
@@ -2471,6 +2471,23 @@ export interface PdfOpenDocumentUrlOptions {
    * Loading mode
    */
   mode?: 'auto' | 'range-request' | 'full-fetch';
+  /**
+   * HTTP request options for fetching the PDF
+   */
+  requestOptions?: {
+    /**
+     * Custom HTTP headers to include in all requests (HEAD, GET, range requests)
+     * Example: { 'Authorization': 'Bearer token', 'X-Custom-Header': 'value' }
+     */
+    headers?: Record<string, string>;
+    /**
+     * Controls whether cookies are sent with requests
+     * - 'omit': Never send cookies (default)
+     * - 'same-origin': Send cookies for same-origin requests
+     * - 'include': Always send cookies (requires CORS)
+     */
+    credentials?: RequestCredentials;
+  };
 }
 
 export interface PdfRenderOptions {

--- a/website/src/content/docs/engines/document-lifecycle/open-document-url.mdx
+++ b/website/src/content/docs/engines/document-lifecycle/open-document-url.mdx
@@ -42,6 +42,22 @@ export interface PdfOpenDocumentUrlOptions {
    * behavior is implemented regardless of the selected mode.
    */
   mode?: 'auto' | 'range-request' | 'full-fetch';
+  /**
+   * HTTP request options for fetching the PDF
+   */
+  requestOptions?: {
+    /**
+     * Custom HTTP headers to include in all requests
+     */
+    headers?: Record<string, string>;
+    /**
+     * Controls whether cookies are sent with requests
+     * - 'omit': Never send cookies (default)
+     * - 'same-origin': Send cookies for same-origin requests
+     * - 'include': Always send cookies (requires CORS)
+     */
+    credentials?: RequestCredentials;
+  };
 }
 ```
 
@@ -75,6 +91,48 @@ try {
   console.error('Failed to open document:', error);
 }
 ```
+
+### Using Custom Headers for Authentication
+
+```typescript
+// Load a PDF that requires authentication
+const fileUrl = { id: 'secure-doc', url: 'https://api.example.com/documents/123.pdf' };
+
+const document = await engine.openDocumentUrl(fileUrl, {
+  requestOptions: {
+    headers: {
+      'Authorization': 'Bearer your-access-token-here',
+      'X-Custom-Header': 'custom-value'
+    }
+  }
+}).toPromise();
+```
+
+### Using Cookies for Authentication
+
+```typescript
+// Load a PDF using cookie-based authentication
+const fileUrl = { id: 'session-doc', url: 'https://example.com/documents/secure.pdf' };
+
+const document = await engine.openDocumentUrl(fileUrl, {
+  requestOptions: {
+    credentials: 'include' // Sends cookies with the request
+  }
+}).toPromise();
+
+console.log(`Opened document with ${document.pageCount} pages using session cookies.`);
+```
+
+<Callout type="warning">
+**CORS and Credentials**
+
+When using `credentials: 'include'` to send cookies with cross-origin requests, the server must:
+- Include `Access-Control-Allow-Credentials: true` in the response headers
+- Specify the exact origin in `Access-Control-Allow-Origin` (wildcards are not allowed)
+- Properly handle preflight OPTIONS requests for CORS
+
+For same-origin requests, use `credentials: 'same-origin'` which is more restrictive and secure.
+</Callout>
 
 ## See Also
 


### PR DESCRIPTION
- Add requestOptions parameter to PdfOpenDocumentUrlOptions interface
- Support custom HTTP headers for authentication (Bearer tokens, API keys)
- Support cookie-based authentication via credentials option
- Apply headers and credentials to all request types (HEAD, GET, range requests)
- Update documentation with usage examples and CORS considerations
- Maintain full backwards compatibility