### PR TITLE
add export plugin config to snippet app PluginConfigs (issue #278, #152)

### DIFF
--- a/snippet/src/components/app.tsx
+++ b/snippet/src/components/app.tsx
@@ -144,6 +144,7 @@ import { BookmarkPluginPackage } from '@embedpdf/plugin-bookmark/preact';
 import {
   EXPORT_PLUGIN_ID,
   ExportPlugin,
+  ExportPluginConfig,
   ExportPluginPackage,
 } from '@embedpdf/plugin-export/preact';
 import {
@@ -193,6 +194,7 @@ export interface PluginConfigs {
   rotate?: RotatePluginConfig;
   tiling?: TilingPluginConfig;
   thumbnail?: ThumbnailPluginConfig;
+  export?: ExportPluginConfig;
 }
 
 export interface PDFViewerConfig {
@@ -231,6 +233,9 @@ const DEFAULT_PLUGIN_CONFIGS: Required<PluginConfigs> = {
     buffer: 3,
     labelHeight: 30,
   },
+  export: {
+    defaultFileName: "embedpdf-ebook.pdf"
+  }
 };
 
 // **Utility function to merge configurations**


### PR DESCRIPTION
I saw #278 and thought it would be a simple fix by exposing defaultFileName to PDFViewerConfig.plugins. Correct me if I'm wrong. Also it's just three lines so you could consider adding it to your next update instead of merging a PR.