### PR TITLE
fix: pass page context to readPageAnnotation for improved annotation handling

### DIFF
--- a/packages/engines/src/lib/pdfium/engine.ts
+++ b/packages/engines/src/lib/pdfium/engine.ts
@@ -6664,8 +6664,21 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
     }
 
     let isChecked = false;
+    let exportValue = "";
     if (type === PDF_FORM_FIELD_TYPE.CHECKBOX || type === PDF_FORM_FIELD_TYPE.RADIOBUTTON) {
       isChecked = this.pdfiumModule.FPDFAnnot_IsChecked(formHandle, annotationPtr);
+      exportValue = readString(
+        this.pdfiumModule.pdfium,
+        (buffer: number, bufferLength) => {
+          return this.pdfiumModule.FPDFAnnot_GetFormFieldExportValue(
+            formHandle,
+            annotationPtr,
+            buffer,
+            bufferLength,
+          );
+        },
+        this.pdfiumModule.pdfium.UTF16ToString,
+      );
     }
 
     return {
@@ -6676,6 +6689,7 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
       value,
       isChecked,
       options,
+      exportValue,
     };
   }
 

--- a/packages/models/src/pdf.ts
+++ b/packages/models/src/pdf.ts
@@ -1332,6 +1332,10 @@ export interface PdfWidgetAnnoField {
    * options of field
    */
   options: PdfWidgetAnnoOption[];
+  /**
+   * export value of field, associated with check box or radio button
+   */
+  exportValue?: string;
 }
 
 /**


### PR DESCRIPTION
Fixes embedpdf/embed-pdf-viewer#288, resolves embedpdf/embed-pdf-viewer#290

This pull request introduces improvements to how PDF form field annotations are processed in the `PdfiumEngine`. The main updates involve capturing and exposing the "export value" for checkbox and radio button fields, and passing additional context when reading page annotations. These changes enhance the fidelity and utility of PDF annotation data in the engine.

**PDF Form Field Annotation Enhancements:**

* Added support for reading and returning the `exportValue` property for checkbox and radio button form fields, allowing consumers to access the value exported when the field is checked. [[1]](diffhunk://#diff-e6cf3ac01e92067dbb302e2f106b7802e5a6e09bc5a453f337d7ac6973b8d1ceR6667-R6681) [[2]](diffhunk://#diff-e6cf3ac01e92067dbb302e2f106b7802e5a6e09bc5a453f337d7ac6973b8d1ceR6692)
* Updated the `PdfWidgetAnnoField` interface to include an optional `exportValue` property, documenting its purpose and usage.

**Annotation Reading Improvements:**

* Modified the annotation reading logic to acquire and pass a page context (`pageCtx`) when reading page annotations, which may improve annotation handling and performance.