### PR TITLE
fix: annotation reading by acquiring page context for improved accuracy

### DIFF
--- a/packages/engines/src/lib/pdfium/engine.ts
+++ b/packages/engines/src/lib/pdfium/engine.ts
@@ -4075,12 +4075,14 @@ export class PdfiumEngine<T = Blob> implements PdfEngine<T> {
 
     const out: PdfAnnotationObject[] = [];
 
+    const pageCtx = ctx.acquirePage(page.index);
+
     for (let i = 0; i < count; ++i) {
       const annotPtr = this.pdfiumModule.EPDFPage_GetAnnotRaw(ctx.docPtr, page.index, i);
       if (!annotPtr) continue;
 
       try {
-        const anno = this.readPageAnnotation(ctx.docPtr, page, annotPtr);
+        const anno = this.readPageAnnotation(ctx.docPtr, page, annotPtr, pageCtx);
         if (anno) out.push(anno);
       } finally {
         this.pdfiumModule.FPDFPage_CloseAnnot(annotPtr);


### PR DESCRIPTION
fixes #288

This pull request makes a targeted update to the `PdfiumEngine` class to improve how page annotations are read. The main change is the introduction of a `pageCtx` (page context), which is now acquired once per page and passed into the annotation reading logic. This helps optimize annotation processing and potentially enables more advanced annotation handling in the future.

**Annotation handling improvements:**

* Acquired a single `pageCtx` using `ctx.acquirePage(page.index)` and passed it into each call to `readPageAnnotation`, reducing redundant context acquisition and setting up for more robust annotation processing.

This improvement allows to read the form field annotations correctly, with the correct type.