### PR TITLE
Added `selection:copy-to-clipboard` command with keyboard shortcuts (…

### DIFF
--- a/.changeset/swift-cats-jump.md
+++ b/.changeset/swift-cats-jump.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/snippet': patch
+---
+
+Added `selection:copy-to-clipboard` command with keyboard shortcuts (Ctrl+C / Cmd+C) that copies selected text without clearing the selection, providing a better user experience for keyboard-based copying.

--- a/viewers/snippet/src/config/commands.ts
+++ b/viewers/snippet/src/config/commands.ts
@@ -1486,6 +1486,19 @@ export const commands: Record<string, Command<State>> = {
     },
   },
 
+  'selection:copy-to-clipboard': {
+    id: 'selection:copy-to-clipboard',
+    labelKey: 'selection.copyToClipboard',
+    icon: 'copy',
+    shortcuts: ['Ctrl+C', 'Meta+C'],
+    categories: ['selection', 'selection-copy-to-clipboard'],
+    action: ({ registry, documentId }) => {
+      const plugin = registry.getPlugin<SelectionPlugin>('selection');
+      const scope = plugin?.provides().forDocument(documentId);
+      scope?.copyToClipboard();
+    },
+  },
+
   'selection:copy': {
     id: 'selection:copy',
     labelKey: 'selection.copy',


### PR DESCRIPTION
…Ctrl+C / Cmd+C)

Added `selection:copy-to-clipboard` command with keyboard shortcuts (Ctrl+C / Cmd+C) that copies selected text without clearing the selection, providing a better user experience for keyboard-based copying.