### PR TITLE
fix(plugin-redaction): keep marquee redact mode active after drawing …

### DIFF
--- a/packages/plugin-redaction/src/lib/redaction-plugin.ts
+++ b/packages/plugin-redaction/src/lib/redaction-plugin.ts
@@ -477,7 +477,6 @@ export class RedactionPlugin extends BasePlugin<
         this.dispatch(addPending(opts.documentId, [item]));
         this.emitPendingChange(opts.documentId);
         opts.callback.onCommit?.(r);
-        this.enableRedactSelection(opts.documentId);
         this.selectPending(opts.pageIndex, item.id, opts.documentId);
       },
     });


### PR DESCRIPTION
## Problem
When using area redaction (marquee redact mode), after drawing an area the mode switches back to text selection mode, requiring users to manually switch back to area mode for each redaction.

I Removed the [enableRedactSelection()](cci:1://file:///Users/abdullahtapadar/Desktop/workspaceforbento/bentopdf-embed-pdf-viewer/packages/plugin-redaction/src/lib/redaction-plugin.ts:375:2-378:3) call in the [onCommit](cci:1://file:///Users/abdullahtapadar/Desktop/workspaceforbento/bentopdf-embed-pdf-viewer/packages/plugin-redaction/src/lib/redaction-plugin.ts:469:6-480:7) callback of [registerMarqueeOnPage](cci:1://file:///Users/abdullahtapadar/Desktop/workspaceforbento/embed-pdf-viewer/packages/plugin-redaction/src/lib/redaction-plugin.ts:443:2-510:3), so the mode stays on MarqueeRedact after completing an area redaction.