### PR TITLE
Pass modal props & fix link modal context

### DIFF
--- a/.changeset/plugin-ui-modal-props.md
+++ b/.changeset/plugin-ui-modal-props.md
@@ -1,0 +1,10 @@
+---
+'@embedpdf/plugin-ui': minor
+---
+
+Added modal props feature to pass context when opening modals:
+
+- Extended `openModal(modalId, props?)` to accept optional props parameter
+- Added `props` field to `ModalSlotState` type
+- Added `modalProps` to `ModalRendererProps` for all frameworks (Preact, React, Svelte, Vue)
+- Updated schema renderers to pass `modalProps` through to modal components

--- a/.changeset/snippet-link-modal-context.md
+++ b/.changeset/snippet-link-modal-context.md
@@ -1,0 +1,10 @@
+---
+'@embedpdf/snippet': minor
+---
+
+Fixed link modal context handling:
+
+- Added `source` prop to LinkModal to distinguish between annotation and text selection context
+- Updated `annotation:add-link` command to pass `{ source: 'selection' }` when opening modal
+- Updated `annotation:toggle-link` command to pass `{ source: 'annotation' }` when opening modal
+- Prevents incorrect behavior where annotation selection would override text selection when creating links

--- a/examples/svelte-tailwind/src/lib/config/commands.ts
+++ b/examples/svelte-tailwind/src/lib/config/commands.ts
@@ -1343,8 +1343,8 @@ export const commands: Record<string, Command<State>> = {
       const ui = registry.getPlugin<UIPlugin>('ui')?.provides();
       if (!ui) return;
 
-      // Open the link modal - it will detect text selection context
-      ui.forDocument(documentId).openModal('link-modal');
+      // Open the link modal with selection context
+      ui.forDocument(documentId).openModal('link-modal', { source: 'selection' });
     },
     disabled: ({ state, documentId }) => {
       return lacksPermission(state, documentId, PdfPermissionFlag.ModifyAnnotations);
@@ -1388,7 +1388,7 @@ export const commands: Record<string, Command<State>> = {
       if (scope.hasAttachedLinks(selected.object.id)) {
         scope.deleteAttachedLinks(selected.object.id);
       } else {
-        ui.forDocument(documentId).openModal('link-modal');
+        ui.forDocument(documentId).openModal('link-modal', { source: 'annotation' });
       }
     },
     visible: ({ registry, documentId }) => {

--- a/examples/svelte-tailwind/src/lib/ui/SchemaModal.svelte
+++ b/examples/svelte-tailwind/src/lib/ui/SchemaModal.svelte
@@ -11,7 +11,7 @@
 
   interface Props extends ModalRendererProps {}
 
-  let { schema, documentId, isOpen, onClose, onExited }: Props = $props();
+  let { schema, documentId, isOpen, onClose, onExited, modalProps }: Props = $props();
 
   const { getCustomComponent } = useItemRenderer();
 
@@ -28,5 +28,5 @@
 </script>
 
 {#if ModalComponent}
-  <ModalComponent {documentId} {isOpen} {onClose} {onExited} />
+  <ModalComponent {documentId} {isOpen} {onClose} {onExited} {...modalProps} />
 {/if}

--- a/examples/vue-tailwind/src/config/commands.ts
+++ b/examples/vue-tailwind/src/config/commands.ts
@@ -1343,8 +1343,8 @@ export const commands: Record<string, Command<State>> = {
       const ui = registry.getPlugin<UIPlugin>('ui')?.provides();
       if (!ui) return;
 
-      // Open the link modal - it will detect text selection context
-      ui.forDocument(documentId).openModal('link-modal');
+      // Open the link modal with selection context
+      ui.forDocument(documentId).openModal('link-modal', { source: 'selection' });
     },
     disabled: ({ state, documentId }) => {
       return lacksPermission(state, documentId, PdfPermissionFlag.ModifyAnnotations);
@@ -1388,7 +1388,7 @@ export const commands: Record<string, Command<State>> = {
       if (scope.hasAttachedLinks(selected.object.id)) {
         scope.deleteAttachedLinks(selected.object.id);
       } else {
-        ui.forDocument(documentId).openModal('link-modal');
+        ui.forDocument(documentId).openModal('link-modal', { source: 'annotation' });
       }
     },
     visible: ({ registry, documentId }) => {

--- a/examples/vue-tailwind/src/ui/SchemaModal.vue
+++ b/examples/vue-tailwind/src/ui/SchemaModal.vue
@@ -20,6 +20,7 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
   onExited: () => void;
+  modalProps?: Record<string, unknown>;
 }
 
 const props = defineProps<Props>();
@@ -38,6 +39,7 @@ const modalContent = computed(() => {
     isOpen: props.isOpen,
     onClose: props.onClose,
     onExited: props.onExited,
+    ...props.modalProps,
   });
 });
 </script>

--- a/packages/plugin-ui/src/lib/actions.ts
+++ b/packages/plugin-ui/src/lib/actions.ts
@@ -73,7 +73,7 @@ export interface SetSidebarTabAction extends Action {
 // Modal action types (with animation lifecycle)
 export interface OpenModalAction extends Action {
   type: typeof OPEN_MODAL;
-  payload: { documentId: string; modalId: string };
+  payload: { documentId: string; modalId: string; props?: Record<string, unknown> };
 }
 
 export interface CloseModalAction extends Action {
@@ -196,9 +196,13 @@ export const setSidebarTab = (
 });
 
 // Modal action creators (with animation lifecycle)
-export const openModal = (documentId: string, modalId: string): OpenModalAction => ({
+export const openModal = (
+  documentId: string,
+  modalId: string,
+  props?: Record<string, unknown>,
+): OpenModalAction => ({
   type: OPEN_MODAL,
-  payload: { documentId, modalId },
+  payload: { documentId, modalId, props },
 });
 
 export const closeModal = (documentId: string): CloseModalAction => ({

--- a/packages/plugin-ui/src/lib/reducer.ts
+++ b/packages/plugin-ui/src/lib/reducer.ts
@@ -222,7 +222,7 @@ export const uiReducer = (state = initialState, action: UIAction): UIState => {
     // ─────────────────────────────────────────────────────────
 
     case OPEN_MODAL: {
-      const { documentId, modalId } = action.payload;
+      const { documentId, modalId, props } = action.payload;
       const docState = state.documents[documentId] || initialDocumentState;
 
       return {
@@ -234,6 +234,7 @@ export const uiReducer = (state = initialState, action: UIAction): UIState => {
             activeModal: {
               modalId,
               isOpen: true,
+              props,
             },
             openMenus: {}, // Close all menus when opening modal
           },

--- a/packages/plugin-ui/src/lib/types.ts
+++ b/packages/plugin-ui/src/lib/types.ts
@@ -48,6 +48,7 @@ export interface SidebarSlotState {
 export interface ModalSlotState {
   modalId: string;
   isOpen: boolean; // false = animating out, true = visible
+  props?: Record<string, unknown>; // Optional props passed when opening the modal
 }
 
 export interface UIDocumentState {
@@ -183,7 +184,7 @@ export interface UIScope {
   isSidebarOpen(placement: string, slot: string, sidebarId?: string): boolean;
 
   // Modals (with animation lifecycle support)
-  openModal(modalId: string): void;
+  openModal(modalId: string, props?: Record<string, unknown>): void;
   closeModal(): void;
   clearModal(): void; // Called after exit animation completes
   getActiveModal(): ModalSlotState | null;
@@ -235,7 +236,7 @@ export interface UICapability {
     documentId?: string,
     activeTab?: string,
   ): void;
-  openModal(modalId: string, documentId?: string): void;
+  openModal(modalId: string, props?: Record<string, unknown>, documentId?: string): void;
   openMenu(
     menuId: string,
     triggeredByCommandId: string,

--- a/packages/plugin-ui/src/lib/ui-plugin.ts
+++ b/packages/plugin-ui/src/lib/ui-plugin.ts
@@ -284,7 +284,8 @@ export class UIPlugin extends BasePlugin<UIPluginConfig, UICapability, UIState, 
         this.setSidebarForDocument(placement, slot, sidebarId, documentId, activeTab),
       toggleSidebar: (placement, slot, sidebarId, documentId, activeTab) =>
         this.toggleSidebarForDocument(placement, slot, sidebarId, documentId, activeTab),
-      openModal: (modalId, documentId) => this.openModalForDocument(modalId, documentId),
+      openModal: (modalId, props, documentId) =>
+        this.openModalForDocument(modalId, props, documentId),
       openMenu: (menuId, triggeredByCommandId, triggeredByItemId, documentId) =>
         this.openMenuForDocument(menuId, triggeredByCommandId, triggeredByItemId, documentId),
       toggleMenu: (menuId, triggeredByCommandId, triggeredByItemId, documentId) =>
@@ -360,7 +361,7 @@ export class UIPlugin extends BasePlugin<UIPluginConfig, UICapability, UIState, 
       getSidebarTab: (sidebarId) => this.getSidebarTabForDocument(sidebarId, documentId),
 
       // ───── Modals (with animation lifecycle) ─────
-      openModal: (modalId) => this.openModalForDocument(modalId, documentId),
+      openModal: (modalId, props) => this.openModalForDocument(modalId, props, documentId),
       closeModal: () => this.closeModalForDocument(documentId),
       clearModal: () => this.clearModalForDocument(documentId),
       getActiveModal: () => this.getActiveModalForDocument(documentId),
@@ -537,9 +538,13 @@ export class UIPlugin extends BasePlugin<UIPluginConfig, UICapability, UIState, 
   // Core Operations - Modals (with animation lifecycle)
   // ─────────────────────────────────────────────────────────
 
-  private openModalForDocument(modalId: string, documentId?: string): void {
+  private openModalForDocument(
+    modalId: string,
+    props?: Record<string, unknown>,
+    documentId?: string,
+  ): void {
     const id = documentId ?? this.getActiveDocumentId();
-    this.dispatch(openModal(id, modalId));
+    this.dispatch(openModal(id, modalId, props));
     this.modalChanged$.emit(id, { modalId, isOpen: true });
   }
 

--- a/packages/plugin-ui/src/shared/hooks/use-schema-renderer.tsx
+++ b/packages/plugin-ui/src/shared/hooks/use-schema-renderer.tsx
@@ -168,6 +168,7 @@ export function useSchemaRenderer(documentId: string) {
               isOpen={activeModal.isOpen}
               onClose={handleClose}
               onExited={handleExited}
+              modalProps={activeModal.props}
             />
           )}
         </Fragment>

--- a/packages/plugin-ui/src/shared/types.ts
+++ b/packages/plugin-ui/src/shared/types.ts
@@ -60,6 +60,7 @@ export interface ModalRendererProps {
   onClose: () => void; // Triggers closeModal()
   onExited: () => void; // Triggers clearModal() after animation completes
   className?: string;
+  modalProps?: Record<string, unknown>; // Props passed when opening the modal
 }
 
 export type ModalRenderer = ComponentType<ModalRendererProps>;

--- a/packages/plugin-ui/src/svelte/hooks/use-schema-renderer.svelte.ts
+++ b/packages/plugin-ui/src/svelte/hooks/use-schema-renderer.svelte.ts
@@ -162,6 +162,7 @@ export function useSchemaRenderer(getDocumentId: () => string | null) {
         isOpen,
         onClose: handleClose,
         onExited: handleExited,
+        modalProps: uiState.state.activeModal.props,
       };
     },
 

--- a/packages/plugin-ui/src/svelte/types.ts
+++ b/packages/plugin-ui/src/svelte/types.ts
@@ -59,6 +59,7 @@ export interface ModalRendererProps {
   onClose: () => void; // Triggers closeModal()
   onExited: () => void; // Triggers clearModal() after animation completes
   className?: string;
+  modalProps?: Record<string, unknown>; // Props passed when opening the modal
 }
 
 export type ModalRenderer = Component<ModalRendererProps>;

--- a/packages/plugin-ui/src/vue/hooks/use-schema-renderer.ts
+++ b/packages/plugin-ui/src/vue/hooks/use-schema-renderer.ts
@@ -167,6 +167,7 @@ export function useSchemaRenderer(documentId: MaybeRefOrGetter<string>) {
         isOpen,
         onClose: handleClose,
         onExited: handleExited,
+        modalProps: uiState.value.activeModal.props,
       });
     },
 

--- a/packages/plugin-ui/src/vue/types.ts
+++ b/packages/plugin-ui/src/vue/types.ts
@@ -59,6 +59,7 @@ export interface ModalRendererProps {
   onClose: () => void; // Triggers closeModal()
   onExited: () => void; // Triggers clearModal() after animation completes
   className?: string;
+  modalProps?: Record<string, unknown>; // Props passed when opening the modal
 }
 
 export type ModalRenderer = Component<ModalRendererProps>;

--- a/viewers/snippet/src/config/commands.ts
+++ b/viewers/snippet/src/config/commands.ts
@@ -1586,8 +1586,8 @@ export const commands: Record<string, Command<State>> = {
       const ui = registry.getPlugin<UIPlugin>('ui')?.provides();
       if (!ui) return;
 
-      // Open the link modal - it will detect text selection context
-      ui.forDocument(documentId).openModal('link-modal');
+      // Open the link modal with selection context
+      ui.forDocument(documentId).openModal('link-modal', { source: 'selection' });
     },
     disabled: ({ state, documentId }) => {
       return lacksPermission(state, documentId, PdfPermissionFlag.ModifyAnnotations);
@@ -1664,7 +1664,7 @@ export const commands: Record<string, Command<State>> = {
       if (scope.hasAttachedLinks(selected.object.id)) {
         scope.deleteAttachedLinks(selected.object.id);
       } else {
-        ui.forDocument(documentId).openModal('link-modal');
+        ui.forDocument(documentId).openModal('link-modal', { source: 'annotation' });
       }
     },
     visible: ({ registry, documentId }) => {

--- a/viewers/snippet/src/ui/schema-modal.tsx
+++ b/viewers/snippet/src/ui/schema-modal.tsx
@@ -8,6 +8,7 @@ export interface ModalRendererProps {
   isOpen: boolean;
   onClose: () => void;
   onExited: () => void;
+  modalProps?: Record<string, unknown>;
 }
 
 /**
@@ -16,7 +17,14 @@ export interface ModalRendererProps {
  * Renders modals defined in the UI schema.
  * Supports animation lifecycle via isOpen and onExited props.
  */
-export function SchemaModal({ schema, documentId, isOpen, onClose, onExited }: ModalRendererProps) {
+export function SchemaModal({
+  schema,
+  documentId,
+  isOpen,
+  onClose,
+  onExited,
+  modalProps,
+}: ModalRendererProps) {
   const { content } = schema;
   const { renderCustomComponent } = useItemRenderer();
 
@@ -31,6 +39,7 @@ export function SchemaModal({ schema, documentId, isOpen, onClose, onExited }: M
         isOpen,
         onClose,
         onExited,
+        ...modalProps,
       })}
     </Fragment>
   );


### PR DESCRIPTION
Add support for passing props when opening UI modals and fix link-modal context handling. openModal(modalId, props?) and modalProps were added to ModalSlotState/ModalRendererProps and propagated through schema renderers (React/Preact/Svelte/Vue). Link modal components in Svelte/Vue/Snippet now accept a source prop ('annotation' | 'selection'), commands updated to open the modal with the correct source, and link creation logic was adjusted to prefer the provided context (avoiding annotation/selection overrides). Also includes related plugin-ui type/hook/reducer changes, new changeset files, and minor auto-generated formatting updates in pdfium vendor files.