### PR TITLE
Disable group drag/resize without permission

### DIFF
--- a/.changeset/plugin-annotation-group-permissions.md
+++ b/.changeset/plugin-annotation-group-permissions.md
@@ -1,0 +1,9 @@
+---
+'@embedpdf/plugin-annotation': patch
+---
+
+Fixed group selection box ignoring document permissions:
+
+- Added `canModifyAnnotations` permission check to `GroupSelectionBox` component across React, Vue, and Svelte
+- Group drag and resize operations are now properly disabled when the user lacks annotation modification permissions
+- This aligns group selection behavior with individual annotation container permission checks

--- a/examples/svelte-tailwind/src/lib/config/commands.ts
+++ b/examples/svelte-tailwind/src/lib/config/commands.ts
@@ -1035,6 +1035,9 @@ export const commands: Record<string, Command<State>> = {
         selectedAnnotation.object.id,
       );
     },
+    disabled: ({ state, documentId }) => {
+      return lacksPermission(state, documentId, PdfPermissionFlag.ModifyAnnotations);
+    },
   },
 
   'annotation:apply-redaction': {

--- a/examples/vue-tailwind/src/config/commands.ts
+++ b/examples/vue-tailwind/src/config/commands.ts
@@ -1035,6 +1035,9 @@ export const commands: Record<string, Command<State>> = {
         selectedAnnotation.object.id,
       );
     },
+    disabled: ({ state, documentId }) => {
+      return lacksPermission(state, documentId, PdfPermissionFlag.ModifyAnnotations);
+    },
   },
 
   // ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Add document permission checks for group selection box across React, Vue, and Svelte implementations so group drag/resize is disabled when the user lacks ModifyAnnotations permission. Imported useDocumentPermissions and introduced effectiveIsDraggable/effectiveIsResizable to gate gesture handling, UI props, and cursor state. Also updated example command configs to disable relevant annotation commands when ModifyAnnotations is missing. This aligns group behavior with individual annotation permission checks and prevents unauthorized group modifications.