### PR TITLE
Cleanup image encoder workers on destroy

### DIFF
--- a/.changeset/engines-imageconverter-destroy.md
+++ b/.changeset/engines-imageconverter-destroy.md
@@ -1,0 +1,11 @@
+---
+'@embedpdf/engines': patch
+---
+
+Fixed memory leak where image encoder workers were never terminated when the engine was destroyed:
+
+- Added optional `destroy()` method to `ImageDataConverter` interface for resource cleanup
+- Updated `createWorkerPoolImageConverter` and `createHybridImageConverter` to attach `destroy()` that terminates the encoder worker pool
+- Updated `PdfEngine.destroy()` to call `imageConverter.destroy?.()` to clean up encoder workers
+
+Previously, each viewer instance would leave 2 encoder workers running after destruction.

--- a/.changeset/snippet-container-cleanup.md
+++ b/.changeset/snippet-container-cleanup.md
@@ -1,0 +1,10 @@
+---
+'@embedpdf/snippet': patch
+---
+
+Fixed memory leak in `EmbedPdfContainer` where Preact components were not unmounted on disconnect:
+
+- Added `render(null, this.root)` in `disconnectedCallback()` to properly unmount Preact components
+- This triggers the cleanup chain: plugin destroy, engine destroy, and worker termination
+
+Previously, navigating between pages would leave workers running (1 PDFium + 2 encoder workers per viewer instance).

--- a/examples/vue-tailwind/src/examples/headless/redaction-annotation-example-content.vue
+++ b/examples/vue-tailwind/src/examples/headless/redaction-annotation-example-content.vue
@@ -6,7 +6,8 @@ import { RenderLayer } from '@embedpdf/plugin-render/vue';
 import { PagePointerProvider } from '@embedpdf/plugin-interaction-manager/vue';
 import { SelectionLayer } from '@embedpdf/plugin-selection/vue';
 import { AnnotationLayer, useAnnotation } from '@embedpdf/plugin-annotation/vue';
-import { RedactionLayer, RedactionMode, useRedaction } from '@embedpdf/plugin-redaction/vue';
+import { RedactionLayer, useRedaction } from '@embedpdf/plugin-redaction/vue';
+import { RedactionMode } from '@embedpdf/plugin-redaction';
 import { PdfAnnotationSubtype, PdfRedactAnnoObject } from '@embedpdf/models';
 import { AlertCircle, Loader2, Check, Crosshair, Trash2 } from 'lucide-vue-next';
 

--- a/examples/vue-tailwind/src/examples/headless/redaction-example-content.vue
+++ b/examples/vue-tailwind/src/examples/headless/redaction-example-content.vue
@@ -5,7 +5,8 @@ import { Scroller } from '@embedpdf/plugin-scroll/vue';
 import { RenderLayer } from '@embedpdf/plugin-render/vue';
 import { PagePointerProvider } from '@embedpdf/plugin-interaction-manager/vue';
 import { SelectionLayer } from '@embedpdf/plugin-selection/vue';
-import { RedactionLayer, RedactionMode, useRedaction } from '@embedpdf/plugin-redaction/vue';
+import { RedactionLayer, useRedaction } from '@embedpdf/plugin-redaction/vue';
+import { RedactionMode } from '@embedpdf/plugin-redaction';
 import { Type, Square, AlertCircle, Loader2, Check, Trash2 } from 'lucide-vue-next';
 
 const props = defineProps<{

--- a/packages/engines/src/lib/converters/browser.ts
+++ b/packages/engines/src/lib/converters/browser.ts
@@ -66,12 +66,12 @@ export const browserImageDataToBlobConverter: ImageDataConverter<Blob> = (
  * This is the preferred approach for performance
  *
  * @param workerPool - Instance of ImageEncoderWorkerPool
- * @returns ImageDataConverter function
+ * @returns ImageDataConverter function with destroy() for cleanup
  */
 export function createWorkerPoolImageConverter(
   workerPool: ImageEncoderWorkerPool,
 ): ImageDataConverter<Blob> {
-  return (
+  const converter: ImageDataConverter<Blob> = (
     getImageData: LazyImageData,
     imageType: ImageConversionTypes = 'image/webp',
     quality?: number,
@@ -91,6 +91,11 @@ export function createWorkerPoolImageConverter(
       quality,
     );
   };
+
+  // Attach destroy method to clean up worker pool
+  converter.destroy = () => workerPool.destroy();
+
+  return converter;
 }
 
 /**
@@ -101,12 +106,12 @@ export function createWorkerPoolImageConverter(
  * - Fallback: Main-thread Canvas for older browsers without OffscreenCanvas in workers
  *
  * @param workerPool - Instance of ImageEncoderWorkerPool
- * @returns ImageDataConverter function
+ * @returns ImageDataConverter function with destroy() for cleanup
  */
 export function createHybridImageConverter(
   workerPool: ImageEncoderWorkerPool,
 ): ImageDataConverter<Blob> {
-  return async (
+  const converter: ImageDataConverter<Blob> = async (
     getImageData: LazyImageData,
     imageType: ImageConversionTypes = 'image/webp',
     quality?: number,
@@ -131,4 +136,9 @@ export function createHybridImageConverter(
       return browserImageDataToBlobConverter(getImageData, imageType, quality);
     }
   };
+
+  // Attach destroy method to clean up worker pool
+  converter.destroy = () => workerPool.destroy();
+
+  return converter;
 }

--- a/packages/engines/src/lib/converters/types.ts
+++ b/packages/engines/src/lib/converters/types.ts
@@ -9,12 +9,23 @@ export type { ImageConversionTypes } from '@embedpdf/models';
 export type LazyImageData = () => PdfImage;
 
 /**
- * Function type for converting ImageData to Blob or other format
+ * Callable interface for converting ImageData to Blob or other format.
  * In browser: uses OffscreenCanvas
  * In Node.js: can use Sharp or other image processing libraries
+ *
+ * The optional `destroy()` method allows converters with resources (like worker pools)
+ * to clean up when the engine is destroyed.
  */
-export type ImageDataConverter<T = Blob> = (
-  getImageData: LazyImageData,
-  imageType?: ImageConversionTypes,
-  imageQuality?: number,
-) => Promise<T>;
+export interface ImageDataConverter<T = Blob> {
+  (
+    getImageData: LazyImageData,
+    imageType?: ImageConversionTypes,
+    imageQuality?: number,
+  ): Promise<T>;
+
+  /**
+   * Optional cleanup method. Called when PdfEngine.destroy() is invoked.
+   * Converters with resources (e.g., worker pools) should implement this to release them.
+   */
+  destroy?: () => void;
+}

--- a/packages/engines/src/lib/orchestrator/pdf-engine.ts
+++ b/packages/engines/src/lib/orchestrator/pdf-engine.ts
@@ -137,6 +137,8 @@ export class PdfEngine<T = Blob> implements IPdfEngine<T> {
     const task = new Task<boolean, PdfErrorReason>();
     try {
       this.executor.destroy();
+      // Clean up image converter resources (e.g., encoder worker pool)
+      this.options.imageConverter.destroy?.();
       task.resolve(true);
     } catch (error) {
       task.reject({ code: PdfErrorCode.Unknown, message: String(error) });

--- a/viewers/snippet/src/web-components/container.tsx
+++ b/viewers/snippet/src/web-components/container.tsx
@@ -57,6 +57,9 @@ export class EmbedPdfContainer extends (BaseElement as typeof HTMLElement) {
     // Clean up system preference listener
     this.systemPreferenceCleanup?.();
     this.systemPreferenceCleanup = null;
+
+    // Unmount Preact components - triggers cleanup chain (engine destroy, plugin cleanup, etc.)
+    render(null, this.root);
   }
 
   /**


### PR DESCRIPTION
Fix a memory leak where image encoder workers remained running after viewer/engine destruction. Added an optional destroy() method to the ImageDataConverter interface and attached destroy implementations in createWorkerPoolImageConverter and createHybridImageConverter to call workerPool.destroy(). PdfEngine.destroy now invokes imageConverter.destroy?.(). Also unmount Preact components in EmbedPdfContainer.disconnectedCallback (render(null, this.root)) to trigger the full cleanup chain. Includes changeset files documenting the fixes.

This solves #415 