### PR TITLE
perf(engines): use Transferable in postMessage for worker communication

### DIFF
--- a/packages/engines/src/lib/image-encoder/worker-pool.ts
+++ b/packages/engines/src/lib/image-encoder/worker-pool.ts
@@ -1,5 +1,6 @@
 import { Logger, NoopLogger } from '@embedpdf/models';
 import type { EncodeImageRequest, EncodeImageResponse } from './image-encoder-worker';
+import { collectTransferables } from '../transferables';
 
 const LOG_SOURCE = 'ImageEncoderPool';
 const LOG_CATEGORY = 'Encoder';
@@ -149,7 +150,7 @@ export class ImageEncoderWorkerPool {
       );
 
       // Transfer the buffer for better performance
-      worker.postMessage(request, [imageData.data.buffer]);
+      worker.postMessage(request, { transfer: collectTransferables(request) });
     });
   }
 

--- a/packages/engines/src/lib/image-encoder/worker-pool.ts
+++ b/packages/engines/src/lib/image-encoder/worker-pool.ts
@@ -150,7 +150,7 @@ export class ImageEncoderWorkerPool {
       );
 
       // Transfer the buffer for better performance
-      worker.postMessage(request, { transfer: collectTransferables(request) });
+      worker.postMessage(request, { transfer: collectTransferables(request.data) });
     });
   }
 

--- a/packages/engines/src/lib/orchestrator/pdfium-native-runner.ts
+++ b/packages/engines/src/lib/orchestrator/pdfium-native-runner.ts
@@ -256,13 +256,9 @@ export class PdfiumNativeRunner {
   /**
    * Send response back to main thread
    */
-  private respond(response: WorkerResponse, transferables?: Transferable[]): void {
+  private respond(response: WorkerResponse, transferables: Transferable[] = []): void {
     this.logger.debug(LOG_SOURCE, LOG_CATEGORY, 'Sending response:', response.type);
-    if (transferables && transferables.length > 0) {
-      self.postMessage(response, { transfer: transferables });
-    } else {
-      self.postMessage(response);
-    }
+    self.postMessage(response, { transfer: transferables });
   }
 
   /**

--- a/packages/engines/src/lib/orchestrator/pdfium-native-runner.ts
+++ b/packages/engines/src/lib/orchestrator/pdfium-native-runner.ts
@@ -1,6 +1,7 @@
 import { Logger, NoopLogger, Task, TaskError, PdfErrorCode } from '@embedpdf/models';
 import { PdfiumNative } from '../pdfium/engine';
 import { init } from '@embedpdf/pdfium';
+import { collectTransferables } from '../transferables';
 
 const LOG_SOURCE = 'PdfiumNativeRunner';
 const LOG_CATEGORY = 'Worker';
@@ -212,11 +213,12 @@ export class PdfiumNativeRunner {
         task.wait(
           (data) => {
             this.logger.debug(LOG_SOURCE, LOG_CATEGORY, `Method ${method} resolved`);
+            const transferables = collectTransferables(data);
             this.respond({
               id: request.id,
               type: 'result',
               data,
-            });
+            }, transferables);
             this.activeTasks.delete(request.id);
           },
           (error) => {
@@ -231,11 +233,12 @@ export class PdfiumNativeRunner {
         );
       } else {
         // Synchronous result
+        const transferables = collectTransferables(result);
         this.respond({
           id: request.id,
           type: 'result',
           data: result,
-        });
+        }, transferables);
       }
     } catch (error) {
       this.logger.error(LOG_SOURCE, LOG_CATEGORY, `Error executing ${method}:`, error);
@@ -253,9 +256,13 @@ export class PdfiumNativeRunner {
   /**
    * Send response back to main thread
    */
-  private respond(response: WorkerResponse): void {
+  private respond(response: WorkerResponse, transferables?: Transferable[]): void {
     this.logger.debug(LOG_SOURCE, LOG_CATEGORY, 'Sending response:', response.type);
-    self.postMessage(response);
+    if (transferables && transferables.length > 0) {
+      self.postMessage(response, { transfer: transferables });
+    } else {
+      self.postMessage(response);
+    }
   }
 
   /**

--- a/packages/engines/src/lib/orchestrator/remote-executor.ts
+++ b/packages/engines/src/lib/orchestrator/remote-executor.ts
@@ -42,6 +42,7 @@ import {
 } from '@embedpdf/models';
 import type { WorkerRequest, WorkerResponse } from './pdfium-native-runner';
 import type { FontFallbackConfig } from '../pdfium/font-fallback';
+import { collectTransferables } from '../transferables';
 
 /**
  * Options for creating a RemoteExecutor
@@ -187,7 +188,8 @@ export class RemoteExecutor implements IPdfiumExecutor {
       () => {
         this.pendingRequests.set(id, task);
         this.logger.debug(LOG_SOURCE, LOG_CATEGORY, `Sending ${method} request:`, id);
-        this.worker.postMessage(request);
+        const transferables = collectTransferables(args);
+        this.worker.postMessage(request, transferables);
       },
       (error) => {
         this.logger.error(

--- a/packages/engines/src/lib/orchestrator/remote-executor.ts
+++ b/packages/engines/src/lib/orchestrator/remote-executor.ts
@@ -189,7 +189,7 @@ export class RemoteExecutor implements IPdfiumExecutor {
         this.pendingRequests.set(id, task);
         this.logger.debug(LOG_SOURCE, LOG_CATEGORY, `Sending ${method} request:`, id);
         const transferables = collectTransferables(args);
-        this.worker.postMessage(request, transferables);
+        this.worker.postMessage(request, { transfer: transferables });
       },
       (error) => {
         this.logger.error(

--- a/packages/engines/src/lib/transferables.ts
+++ b/packages/engines/src/lib/transferables.ts
@@ -10,10 +10,13 @@ function walk(value: unknown, seen: Set<ArrayBuffer>, depth: number): void {
     return;
   }
 
+  // SharedArrayBuffer is not transferable — skip
+  if (typeof SharedArrayBuffer !== 'undefined' && value instanceof SharedArrayBuffer) {
+    return;
+  }
+
   if (ArrayBuffer.isView(value)) {
-    if (value.buffer instanceof ArrayBuffer) {
-      seen.add(value.buffer);
-    }
+    seen.add(value.buffer as ArrayBuffer);
     return;
   }
 
@@ -24,15 +27,12 @@ function walk(value: unknown, seen: Set<ArrayBuffer>, depth: number): void {
     return;
   }
 
-  const obj = value as Record<string, unknown>;
-  for (const key in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
-      walk(obj[key], seen, depth + 1);
-    }
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    walk((value as Record<string, unknown>)[key], seen, depth + 1);
   }
 }
 
-export function collectTransferables(value: unknown): ArrayBuffer[] {
+export function collectTransferables(value: unknown): Transferable[] {
   const seen = new Set<ArrayBuffer>();
   walk(value, seen, 0);
   return Array.from(seen);

--- a/packages/engines/src/lib/transferables.ts
+++ b/packages/engines/src/lib/transferables.ts
@@ -1,0 +1,39 @@
+const MAX_DEPTH = 6;
+
+function walk(value: unknown, seen: Set<ArrayBuffer>, depth: number): void {
+  if (depth > MAX_DEPTH || value == null || typeof value !== 'object') {
+    return;
+  }
+
+  if (value instanceof ArrayBuffer) {
+    seen.add(value);
+    return;
+  }
+
+  if (ArrayBuffer.isView(value)) {
+    if (value.buffer instanceof ArrayBuffer) {
+      seen.add(value.buffer);
+    }
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      walk(value[i], seen, depth + 1);
+    }
+    return;
+  }
+
+  const obj = value as Record<string, unknown>;
+  for (const key in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      walk(obj[key], seen, depth + 1);
+    }
+  }
+}
+
+export function collectTransferables(value: unknown): ArrayBuffer[] {
+  const seen = new Set<ArrayBuffer>();
+  walk(value, seen, 0);
+  return Array.from(seen);
+}

--- a/packages/engines/src/lib/webworker/engine.ts
+++ b/packages/engines/src/lib/webworker/engine.ts
@@ -1197,7 +1197,6 @@ export class WebWorkerEngine implements PdfEngine {
    * Send the request to webworker inside and register the task
    * @param task - task that waiting for the response
    * @param request - request that needs send to web worker
-   * @param transferables - transferables that need to transfer to webworker
    * @returns
    *
    * @internal

--- a/packages/engines/src/lib/webworker/engine.ts
+++ b/packages/engines/src/lib/webworker/engine.ts
@@ -254,7 +254,7 @@ export class WebWorkerEngine implements PdfEngine {
     const task = new WorkerTask<PdfDocumentObject>(this.worker, requestId);
 
     const request: ExecuteRequest = createRequest(requestId, 'openDocumentBuffer', [file, options]);
-    this.proxy(task, request, collectTransferables([file]));
+    this.proxy(task, request);
 
     return task;
   }
@@ -757,7 +757,7 @@ export class WebWorkerEngine implements PdfEngine {
     const task = new WorkerTask<boolean>(this.worker, requestId);
 
     const request: ExecuteRequest = createRequest(requestId, 'addAttachment', [doc, params]);
-    this.proxy(task, request, collectTransferables([params]));
+    this.proxy(task, request);
 
     return task;
   }
@@ -1029,7 +1029,7 @@ export class WebWorkerEngine implements PdfEngine {
     const task = new WorkerTask<PdfFile>(this.worker, requestId);
 
     const request: ExecuteRequest = createRequest(requestId, 'merge', [files]);
-    this.proxy(task, request, collectTransferables(files));
+    this.proxy(task, request);
 
     return task;
   }
@@ -1202,19 +1202,19 @@ export class WebWorkerEngine implements PdfEngine {
    *
    * @internal
    */
-  proxy<R>(task: WorkerTask<R>, request: ExecuteRequest, transferables: any[] = []) {
+  proxy<R>(task: WorkerTask<R>, request: ExecuteRequest) {
     this.logger.debug(
       LOG_SOURCE,
       LOG_CATEGORY,
       'send request to worker',
       task,
       request,
-      transferables,
     );
     this.logger.perf(LOG_SOURCE, LOG_CATEGORY, `${request.data.name}`, 'Begin', request.id);
     this.readyTask.wait(
       () => {
-        this.worker.postMessage(request, transferables);
+        const transferables = collectTransferables(request.data.args);
+        this.worker.postMessage(request, { transfer: transferables });
         task.wait(
           () => {
             this.logger.perf(LOG_SOURCE, LOG_CATEGORY, `${request.data.name}`, 'End', request.id);

--- a/packages/engines/src/lib/webworker/engine.ts
+++ b/packages/engines/src/lib/webworker/engine.ts
@@ -44,6 +44,7 @@ import {
   ImageDataLike,
 } from '@embedpdf/models';
 import { ExecuteRequest, Response, SpecificExecuteRequest } from './runner';
+import { collectTransferables } from '../transferables';
 
 const LOG_SOURCE = 'WebWorkerEngine';
 const LOG_CATEGORY = 'Engine';
@@ -253,7 +254,7 @@ export class WebWorkerEngine implements PdfEngine {
     const task = new WorkerTask<PdfDocumentObject>(this.worker, requestId);
 
     const request: ExecuteRequest = createRequest(requestId, 'openDocumentBuffer', [file, options]);
-    this.proxy(task, request);
+    this.proxy(task, request, collectTransferables([file]));
 
     return task;
   }
@@ -756,7 +757,7 @@ export class WebWorkerEngine implements PdfEngine {
     const task = new WorkerTask<boolean>(this.worker, requestId);
 
     const request: ExecuteRequest = createRequest(requestId, 'addAttachment', [doc, params]);
-    this.proxy(task, request);
+    this.proxy(task, request, collectTransferables([params]));
 
     return task;
   }
@@ -1028,7 +1029,7 @@ export class WebWorkerEngine implements PdfEngine {
     const task = new WorkerTask<PdfFile>(this.worker, requestId);
 
     const request: ExecuteRequest = createRequest(requestId, 'merge', [files]);
-    this.proxy(task, request);
+    this.proxy(task, request, collectTransferables(files));
 
     return task;
   }

--- a/packages/engines/src/lib/webworker/runner.ts
+++ b/packages/engines/src/lib/webworker/runner.ts
@@ -9,6 +9,7 @@ import {
   PdfErrorCode,
   TaskReturn,
 } from '@embedpdf/models';
+import { collectTransferables } from '../transferables';
 
 /**
  * Request body that represent method calls of PdfEngine, it contains the
@@ -440,6 +441,7 @@ export class EngineRunner {
 
     task.wait(
       (result) => {
+        const transferables = collectTransferables(result);
         const response: ExecuteResponse = {
           id: request.id,
           type: 'ExecuteResponse',
@@ -448,7 +450,7 @@ export class EngineRunner {
             value: result,
           },
         };
-        this.respond(response);
+        this.respond(response, transferables);
       },
       (error) => {
         const response: ExecuteResponse = {
@@ -470,8 +472,12 @@ export class EngineRunner {
    *
    * @protected
    */
-  respond(response: Response) {
+  respond(response: Response, transferables?: Transferable[]) {
     this.logger.debug(LOG_SOURCE, LOG_CATEGORY, 'runner respond: ', response);
-    self.postMessage(response);
+    if (transferables && transferables.length > 0) {
+      self.postMessage(response, { transfer: transferables });
+    } else {
+      self.postMessage(response);
+    }
   }
 }

--- a/packages/engines/src/lib/webworker/runner.ts
+++ b/packages/engines/src/lib/webworker/runner.ts
@@ -472,12 +472,8 @@ export class EngineRunner {
    *
    * @protected
    */
-  respond(response: Response, transferables?: Transferable[]) {
+  respond(response: Response, transferables: Transferable[] = []) {
     this.logger.debug(LOG_SOURCE, LOG_CATEGORY, 'runner respond: ', response);
-    if (transferables && transferables.length > 0) {
-      self.postMessage(response, { transfer: transferables });
-    } else {
-      self.postMessage(response);
-    }
+    self.postMessage(response, { transfer: transferables });
   }
 }


### PR DESCRIPTION
## Problem

All `postMessage` calls between the main thread and Web Workers in the engines package use structured cloning by default. For large payloads containing `ArrayBuffer` data (rendered page pixels, PDF file buffers, encoded images), this means the entire buffer is copied byte-by-byte across the thread boundary — doubling memory usage and adding latency proportional to buffer size.

## Solution

Introduce a `collectTransferables` utility that walks message payloads to discover `ArrayBuffer` instances, then passes them in the `{ transfer }` option of `postMessage`. Transferred buffers are moved zero-copy to the receiving thread (the sender's reference is detached).

Key design decisions:
- **Depth-limited walk (MAX_DEPTH=6)** prevents stack overflow on deep/circular-adjacent structures while covering all real payload shapes in the codebase
- **`Set<ArrayBuffer>` deduplication** prevents `DataCloneError` from listing the same buffer twice in the transfer list
- **Scoped collection** — each call site passes only the payload subtree (e.g. `request.data`, `args`, `result`) rather than the full message envelope, minimizing unnecessary traversal and preventing accidental transfer of metadata buffers
- **Simplified `respond()` methods** use a default parameter (`transferables: Transferable[] = []`) and always pass `{ transfer }`, eliminating conditional branching
- **SharedArrayBuffer guard** explicitly skips non-transferable shared buffers