### PR TITLE
Ensure new annotations use dictMode

### DIFF
--- a/.changeset/fix-new-annotation-dictmode.md
+++ b/.changeset/fix-new-annotation-dictmode.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-annotation': patch
+---
+
+Fix newly created annotations showing their appearance stream instead of dict-based rendering. New annotations now consistently start with `dictMode: true` across all framework wrappers (React, Vue, Svelte).

--- a/packages/plugin-annotation/src/lib/reducer.ts
+++ b/packages/plugin-annotation/src/lib/reducer.ts
@@ -347,7 +347,7 @@ export const reducer: Reducer<AnnotationState, AnnotationAction> = (state, actio
             },
             byUid: {
               ...docState.byUid,
-              [uid]: { commitState: 'new', object: annotation },
+              [uid]: { commitState: 'new', object: annotation, dictMode: true },
             },
             hasPendingChanges: true,
           },


### PR DESCRIPTION
Add a changeset for @embedpdf/plugin-annotation and set dictMode: true for newly created annotations in the reducer. This prevents new annotations from showing their appearance stream and enforces dict-based rendering consistently across framework wrappers (React, Vue, Svelte). Files changed: .changeset/fix-new-annotation-dictmode.md and packages/plugin-annotation/src/lib/reducer.ts.