### PR TITLE
Expose annotation blendMode in PDFium engine

### DIFF
--- a/.changeset/pdfium-base-blend-mode.md
+++ b/.changeset/pdfium-base-blend-mode.md
@@ -1,0 +1,7 @@
+---
+'@embedpdf/engines': patch
+---
+
+Expose PDF annotation blend mode in base PDFium annotation properties.
+
+`PdfiumNative` now reads `EPDFAnnot_GetBlendMode` and includes `blendMode` in the shared base annotation payload, so all annotation types parsed through the PDFium engine consistently receive their blend mode metadata.

--- a/packages/engines/src/lib/pdfium/engine.ts
+++ b/packages/engines/src/lib/pdfium/engine.ts
@@ -124,6 +124,7 @@ import {
   PdfTextRun,
   PdfPageTextRuns,
   PdfAlphaColor,
+  PdfBlendMode,
 } from '@embedpdf/models';
 import { computeFormDrawParams, isValidCustomKey, readArrayBuffer, readString } from './helper';
 import { WrappedPdfiumModule } from '@embedpdf/pdfium';
@@ -6206,7 +6207,6 @@ export class PdfiumNative implements IPdfiumExecutor {
     const opacity = this.getAnnotationOpacity(annotationPtr);
     const { width: strokeWidth } = this.getBorderStyle(annotationPtr);
     const inkList = this.getInkList(doc, page, annotationPtr);
-    const blendMode = this.pdfiumModule.EPDFAnnot_GetBlendMode(annotationPtr);
     const intent = this.getAnnotIntent(annotationPtr);
 
     return {
@@ -6215,7 +6215,6 @@ export class PdfiumNative implements IPdfiumExecutor {
       type: PdfAnnotationSubtype.INK,
       rect,
       ...(intent && { intent }),
-      blendMode,
       strokeColor,
       color: strokeColor, // deprecated alias
       opacity,
@@ -6429,14 +6428,12 @@ export class PdfiumNative implements IPdfiumExecutor {
     const segmentRects = this.getQuadPointsAnno(doc, page, annotationPtr);
     const strokeColor = this.getAnnotationColor(annotationPtr) ?? '#FFFF00';
     const opacity = this.getAnnotationOpacity(annotationPtr);
-    const blendMode = this.pdfiumModule.EPDFAnnot_GetBlendMode(annotationPtr);
 
     return {
       pageIndex: page.index,
       id: index,
       type: PdfAnnotationSubtype.HIGHLIGHT,
       rect,
-      blendMode,
       segmentRects,
       strokeColor,
       color: strokeColor, // deprecated alias
@@ -6467,14 +6464,12 @@ export class PdfiumNative implements IPdfiumExecutor {
     const segmentRects = this.getQuadPointsAnno(doc, page, annotationPtr);
     const strokeColor = this.getAnnotationColor(annotationPtr) ?? '#FF0000';
     const opacity = this.getAnnotationOpacity(annotationPtr);
-    const blendMode = this.pdfiumModule.EPDFAnnot_GetBlendMode(annotationPtr);
 
     return {
       pageIndex: page.index,
       id: index,
       type: PdfAnnotationSubtype.UNDERLINE,
       rect,
-      blendMode,
       segmentRects,
       strokeColor,
       color: strokeColor, // deprecated alias
@@ -6505,14 +6500,12 @@ export class PdfiumNative implements IPdfiumExecutor {
     const segmentRects = this.getQuadPointsAnno(doc, page, annotationPtr);
     const strokeColor = this.getAnnotationColor(annotationPtr) ?? '#FF0000';
     const opacity = this.getAnnotationOpacity(annotationPtr);
-    const blendMode = this.pdfiumModule.EPDFAnnot_GetBlendMode(annotationPtr);
 
     return {
       pageIndex: page.index,
       id: index,
       type: PdfAnnotationSubtype.STRIKEOUT,
       rect,
-      blendMode,
       segmentRects,
       strokeColor,
       color: strokeColor, // deprecated alias
@@ -6543,14 +6536,12 @@ export class PdfiumNative implements IPdfiumExecutor {
     const segmentRects = this.getQuadPointsAnno(doc, page, annotationPtr);
     const strokeColor = this.getAnnotationColor(annotationPtr) ?? '#FF0000';
     const opacity = this.getAnnotationOpacity(annotationPtr);
-    const blendMode = this.pdfiumModule.EPDFAnnot_GetBlendMode(annotationPtr);
 
     return {
       pageIndex: page.index,
       id: index,
       type: PdfAnnotationSubtype.SQUIGGLY,
       rect,
-      blendMode,
       segmentRects,
       strokeColor,
       color: strokeColor, // deprecated alias
@@ -7329,6 +7320,7 @@ export class PdfiumNative implements IPdfiumExecutor {
     created: Date | undefined;
     flags: PdfAnnotationFlagName[];
     custom: unknown;
+    blendMode: PdfBlendMode;
     inReplyToId?: string;
     replyType?: PdfAnnotationReplyType;
   } {
@@ -7340,6 +7332,7 @@ export class PdfiumNative implements IPdfiumExecutor {
     const custom = this.getAnnotCustom(annotationPtr);
     const inReplyToId = this.getInReplyToId(annotationPtr);
     const replyType = this.getReplyType(annotationPtr);
+    const blendMode = this.pdfiumModule.EPDFAnnot_GetBlendMode(annotationPtr);
 
     // Read EmbedPDF extended rotation and convert from PDF CCW to UI CW convention
     const pdfRotation = this.getAnnotExtendedRotation(annotationPtr);
@@ -7358,6 +7351,7 @@ export class PdfiumNative implements IPdfiumExecutor {
       created,
       flags,
       custom,
+      blendMode,
       // Only include IRT if present
       ...(inReplyToId && { inReplyToId }),
       // Only include RT if present and not the default (Reply)


### PR DESCRIPTION
Import PdfBlendMode and surface annotation blend mode in the PDFium engine base payload. PdfiumNative now reads EPDFAnnot_GetBlendMode once for the shared base annotation and includes blendMode in the returned annotation object, removing duplicate per-annotation calls. Adds a changeset entry documenting the patch release.