### PR TITLE
Fix normalizeRotation page size retrieval

### DIFF
--- a/packages/engines/src/lib/pdfium/engine.ts
+++ b/packages/engines/src/lib/pdfium/engine.ts
@@ -352,17 +352,14 @@ export class PdfiumNative implements IPdfiumExecutor {
     const pages: PdfPageObject[] = [];
     const sizePtr = this.memoryManager.malloc(8);
     for (let index = 0; index < pageCount; index++) {
-      // Use normalized size function when normalizeRotation is enabled
-      const result = normalizeRotation
-        ? this.pdfiumModule.EPDF_GetPageSizeByIndexNormalized(docPtr, index, sizePtr)
-        : this.pdfiumModule.FPDF_GetPageSizeByIndexF(docPtr, index, sizePtr);
+      const result = this.pdfiumModule.FPDF_GetPageSizeByIndexF(docPtr, index, sizePtr);
 
       if (!result) {
         const lastError = this.pdfiumModule.FPDF_GetLastError();
         this.logger.error(
           LOG_SOURCE,
           LOG_CATEGORY,
-          `${normalizeRotation ? 'EPDF_GetPageSizeByIndexNormalized' : 'FPDF_GetPageSizeByIndexF'} failed with ${lastError}`,
+          `FPDF_GetPageSizeByIndexF failed with ${lastError}`,
         );
         this.memoryManager.free(sizePtr);
         this.pdfiumModule.FPDF_CloseDocument(docPtr);
@@ -370,18 +367,24 @@ export class PdfiumNative implements IPdfiumExecutor {
         this.logger.perf(LOG_SOURCE, LOG_CATEGORY, `OpenDocumentBuffer`, 'End', file.id);
         return PdfTaskHelper.reject<PdfDocumentObject>({
           code: lastError,
-          message: `${normalizeRotation ? 'EPDF_GetPageSizeByIndexNormalized' : 'FPDF_GetPageSizeByIndexF'} failed`,
+          message: `FPDF_GetPageSizeByIndexF failed`,
         });
       }
 
       const rotation = this.pdfiumModule.EPDF_GetPageRotationByIndex(docPtr, index) as Rotation;
 
+      // FPDF_GetPageSizeByIndexF returns rotation-applied size.
+      // When normalizeRotation is enabled, we need the raw (unrotated) size
+      // to match the coordinate space used by EPDF_LoadPageNormalized.
+      let width = this.pdfiumModule.pdfium.getValue(sizePtr, 'float');
+      let height = this.pdfiumModule.pdfium.getValue(sizePtr + 4, 'float');
+      if (normalizeRotation && (rotation & 1) === 1) {
+        [width, height] = [height, width];
+      }
+
       const page = {
         index,
-        size: {
-          width: this.pdfiumModule.pdfium.getValue(sizePtr, 'float'),
-          height: this.pdfiumModule.pdfium.getValue(sizePtr + 4, 'float'),
-        },
+        size: { width, height },
         rotation,
       };
 


### PR DESCRIPTION
fix https://github.com/embedpdf/embed-pdf-viewer/issues/521

## Summary

  Replace `EPDF_GetPageSizeByIndexNormalized` with `FPDF_GetPageSizeByIndexF` + application-side dimension swap for `normalizeRotation` mode.

## Problem

  Page dimensions were incorrectly retrieved for certain PDFs when opened with `normalizeRotation: true`.

### Root Cause

  `EPDF_GetPageSizeByIndexNormalized` was designed to be lightweight by reading MediaBox/CropBox directly from the page dictionary via
  `dict->GetRectFor()` without constructing a `CPDF_Page`. However, this **does not resolve PDF page tree attribute inheritance**.


### Affected PDFs

  - PDFs with MediaBox defined on parent /Pages node -- when the page dictionary lacks its own /MediaBox, the fallback 612x792 (US Letter) is
   used instead of the inherited value
  - PDFs with CropBox inherited from the page tree -- similarly fails to retrieve the correct CropBox

[Construction_plan_partial_render_demo.pdf](https://github.com/user-attachments/files/25904824/Construction_plan_partial_render_demo.pdf)
[H21_OilPan.pdf](https://github.com/user-attachments/files/25904830/H21_OilPan.pdf)
