### PR TITLE
Hide group menu during rotation

### DIFF
--- a/.changeset/hide-group-menu-on-rotate.md
+++ b/.changeset/hide-group-menu-on-rotate.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-annotation': patch
+---
+
+Hide the group selection menu while group rotation is active. Previously the menu remained visible during rotation, which could overlap with rotation guide lines and the tooltip. This aligns the group selection box behavior with the single-annotation container, which already hides its menu during rotation.

--- a/packages/plugin-annotation/src/shared/components/group-selection-box.tsx
+++ b/packages/plugin-annotation/src/shared/components/group-selection-box.tsx
@@ -551,7 +551,7 @@ export function GroupSelectionBox({
         )}
 
       {/* Group selection menu */}
-      {groupSelectionMenu && (
+      {groupSelectionMenu && !rotationActive && (
         <CounterRotate
           rect={{
             origin: {

--- a/packages/plugin-annotation/src/svelte/components/GroupSelectionBox.svelte
+++ b/packages/plugin-annotation/src/svelte/components/GroupSelectionBox.svelte
@@ -582,7 +582,7 @@
     {/if}
 
     <!-- Group selection menu -->
-    {#if shouldShowMenu}
+    {#if shouldShowMenu && !rotationActive}
       <CounterRotate
         rect={{
           origin: {

--- a/packages/plugin-annotation/src/vue/components/group-selection-box.vue
+++ b/packages/plugin-annotation/src/vue/components/group-selection-box.vue
@@ -88,7 +88,7 @@
     </div>
 
     <!-- Group selection menu -->
-    <CounterRotate v-if="shouldShowMenu" :rect="menuRect" :rotation="rotation">
+    <CounterRotate v-if="shouldShowMenu && !rotationActive" :rect="menuRect" :rotation="rotation">
       <template #default="{ rect, menuWrapperProps }">
         <!-- Priority 1: Render function prop (schema-driven) -->
         <component v-if="groupSelectionMenu" :is="renderGroupMenu(rect, menuWrapperProps)" />


### PR DESCRIPTION
Prevent the group selection menu from rendering while group rotation is active to avoid overlapping rotation guide lines and tooltips. Added a rotationActive guard to the group selection box in shared TSX, Svelte, and Vue components, and included a changeset to publish a patch for @embedpdf/plugin-annotation. This aligns group behavior with the single-annotation container which already hides its menu during rotation.