### PR TITLE
feat: add cloud annotation tool

### DIFF
--- a/examples/react-mui/src/components/toolbar/annotation-toolbar.tsx
+++ b/examples/react-mui/src/components/toolbar/annotation-toolbar.tsx
@@ -5,6 +5,7 @@ import CheckCircleOutlinedIcon from '@mui/icons-material/CheckCircleOutlined';
 import CircleOutlinedIcon from '@mui/icons-material/CircleOutlined';
 import SquareOutlinedIcon from '@mui/icons-material/SquareOutlined';
 import NorthEastOutlinedIcon from '@mui/icons-material/NorthEastOutlined';
+import CloudOutlinedIcon from '@mui/icons-material/CloudOutlined';
 import { AnnotationTool, useAnnotationCapability } from '@embedpdf/plugin-annotation/react';
 import { useEffect, useState } from 'react';
 import { ToggleIconButton } from '../toggle-icon-button';
@@ -60,6 +61,12 @@ export const AnnotationToolbar = ({ documentId }: AnnotationToolbarProps) => {
     if (!annotationProvider) return;
     const currentId = activeTool?.id ?? null;
     annotationProvider.setActiveTool(currentId === 'lineArrow' ? null : 'lineArrow');
+  };
+
+  const handleCloudAnnotation = () => {
+    if (!annotationProvider) return;
+    const currentId = activeTool?.id ?? null;
+    annotationProvider.setActiveTool(currentId === 'cloud' ? null : 'cloud');
   };
 
   const handleStampApprovedAnnotation = () => {
@@ -119,6 +126,14 @@ export const AnnotationToolbar = ({ documentId }: AnnotationToolbarProps) => {
           aria-label="Line arrow annotation"
         >
           <NorthEastOutlinedIcon fontSize="small" />
+        </ToggleIconButton>
+        <ToggleIconButton
+          tone="light"
+          isOpen={activeTool?.id === 'cloud'}
+          onClick={handleCloudAnnotation}
+          aria-label="Cloud annotation"
+        >
+          <CloudOutlinedIcon fontSize="small" />
         </ToggleIconButton>
         <ToggleIconButton
           tone="light"

--- a/examples/react-tailwind/src/components/annotation-toolbar.tsx
+++ b/examples/react-tailwind/src/components/annotation-toolbar.tsx
@@ -12,6 +12,7 @@ import {
   CircleIcon,
   SquareIcon,
   PolygonIcon,
+  CloudIcon,
   PolylineIcon,
   LineIcon,
   ArrowIcon,
@@ -205,6 +206,15 @@ export function AnnotationToolbar({ documentId }: AnnotationToolbarProps) {
         title="Draw Polygon"
       >
         <PolygonIcon className="h-4 w-4" style={{ color: toolColors.polygon?.primaryColor }} />
+      </ToolbarButton>
+
+      <ToolbarButton
+        onClick={() => toggleTool('cloud')}
+        isActive={activeTool?.id === 'cloud'}
+        aria-label="Cloud annotation"
+        title="Draw Cloud"
+      >
+        <CloudIcon className="h-4 w-4" style={{ color: toolColors.cloud?.primaryColor }} />
       </ToolbarButton>
 
       <ToolbarButton

--- a/examples/react-tailwind/src/components/icons/index.tsx
+++ b/examples/react-tailwind/src/components/icons/index.tsx
@@ -851,6 +851,26 @@ export function PolygonIcon({ className, title, style }: IconProps) {
   );
 }
 
+export function CloudIcon({ className, title, style }: IconProps) {
+  return (
+    <svg
+      className={className}
+      style={style}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden={!title}
+      role={title ? 'img' : 'presentation'}
+    >
+      {title ? <title>{title}</title> : null}
+      <path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z" />
+    </svg>
+  );
+}
+
 export function SquigglyIcon({ className, title, style }: IconProps) {
   return (
     <svg

--- a/examples/svelte-tailwind/src/examples/headless/annotation-custom-ui-example-content.svelte
+++ b/examples/svelte-tailwind/src/examples/headless/annotation-custom-ui-example-content.svelte
@@ -11,7 +11,7 @@
   } from '@embedpdf/plugin-annotation/svelte';
   import { PagePointerProvider } from '@embedpdf/plugin-interaction-manager/svelte';
   import { SelectionLayer } from '@embedpdf/plugin-selection/svelte';
-  import { Pencil, Square, GitBranch, Stamp, Trash2 } from 'lucide-svelte';
+  import { Pencil, Square, GitBranch, Stamp, Cloud, Trash2 } from 'lucide-svelte';
 
   interface Props {
     documentId: string;
@@ -30,6 +30,7 @@
     { id: 'ink', name: 'Pen', icon: Pencil },
     { id: 'polyline', name: 'Polyline', icon: GitBranch },
     { id: 'stampImage', name: 'Stamp', icon: Stamp },
+    { id: 'cloud', name: 'Cloud', icon: Cloud },
   ];
 
   let unsubscribeToolChange: (() => void) | undefined;

--- a/examples/svelte-tailwind/src/examples/headless/annotation-example-content.svelte
+++ b/examples/svelte-tailwind/src/examples/headless/annotation-example-content.svelte
@@ -6,7 +6,7 @@
   import { AnnotationLayer, useAnnotationCapability } from '@embedpdf/plugin-annotation/svelte';
   import { PagePointerProvider } from '@embedpdf/plugin-interaction-manager/svelte';
   import { SelectionLayer } from '@embedpdf/plugin-selection/svelte';
-  import { Check, X, Pencil, Square, Highlighter, Trash2 } from 'lucide-svelte';
+  import { Check, X, Pencil, Square, Highlighter, Cloud, Trash2 } from 'lucide-svelte';
 
   interface Props {
     documentId: string;
@@ -26,6 +26,7 @@
     { id: 'ink', name: 'Pen', icon: Pencil },
     { id: 'square', name: 'Square', icon: Square },
     { id: 'highlight', name: 'Highlight', icon: Highlighter },
+    { id: 'cloud', name: 'Cloud', icon: Cloud },
   ];
 
   let unsubscribeToolChange: (() => void) | undefined;

--- a/examples/vue-tailwind/src/examples/headless/annotation-custom-ui-example-content.vue
+++ b/examples/vue-tailwind/src/examples/headless/annotation-custom-ui-example-content.vue
@@ -6,7 +6,7 @@ import { RenderLayer } from '@embedpdf/plugin-render/vue';
 import { AnnotationLayer, useAnnotationCapability } from '@embedpdf/plugin-annotation/vue';
 import { PagePointerProvider } from '@embedpdf/plugin-interaction-manager/vue';
 import { SelectionLayer } from '@embedpdf/plugin-selection/vue';
-import { Pencil, Square, GitBranch, Stamp, Trash2 } from 'lucide-vue-next';
+import { Pencil, Square, GitBranch, Stamp, Cloud, Trash2 } from 'lucide-vue-next';
 
 const props = defineProps<{
   documentId: string;
@@ -23,6 +23,7 @@ const tools = [
   { id: 'ink', name: 'Pen', icon: Pencil },
   { id: 'polyline', name: 'Polyline', icon: GitBranch },
   { id: 'stampImage', name: 'Stamp', icon: Stamp },
+  { id: 'cloud', name: 'Cloud', icon: Cloud },
 ];
 
 let unsubscribeToolChange: (() => void) | undefined;

--- a/examples/vue-tailwind/src/examples/headless/annotation-example-content.vue
+++ b/examples/vue-tailwind/src/examples/headless/annotation-example-content.vue
@@ -6,7 +6,7 @@ import { RenderLayer } from '@embedpdf/plugin-render/vue';
 import { AnnotationLayer, useAnnotationCapability } from '@embedpdf/plugin-annotation/vue';
 import { PagePointerProvider } from '@embedpdf/plugin-interaction-manager/vue';
 import { SelectionLayer } from '@embedpdf/plugin-selection/vue';
-import { Check, X, Pencil, Square, Highlighter, Trash2 } from 'lucide-vue-next';
+import { Check, X, Pencil, Square, Highlighter, Cloud, Trash2 } from 'lucide-vue-next';
 
 const props = defineProps<{
   documentId: string;
@@ -24,6 +24,7 @@ const tools = [
   { id: 'ink', name: 'Pen', icon: Pencil },
   { id: 'square', name: 'Square', icon: Square },
   { id: 'highlight', name: 'Highlight', icon: Highlighter },
+  { id: 'cloud', name: 'Cloud', icon: Cloud },
 ];
 
 let unsubscribeToolChange: (() => void) | undefined;

--- a/packages/plugin-annotation/src/lib/geometry/cloudy-border.ts
+++ b/packages/plugin-annotation/src/lib/geometry/cloudy-border.ts
@@ -477,6 +477,132 @@ function cloudyPolygonImpl(
 }
 
 // ---------------------------------------------------------------------------
+// Core polyline algorithm
+// ---------------------------------------------------------------------------
+
+function cloudyPolylineImpl(
+  vertices: Point[],
+  intensity: number,
+  lineWidth: number,
+  out: PathBuilder,
+): void {
+  let polygon = removeZeroLengthSegments(vertices);
+  const numPoints = polygon.length;
+
+  if (numPoints < 2) return;
+
+  const closed = [...polygon, polygon[0]];
+  if (polygonDirection(closed) < 0) {
+    polygon = [...polygon].reverse();
+  }
+
+  if (intensity <= 0) {
+    out.moveTo(polygon[0].x, polygon[0].y);
+    for (let i = 1; i < numPoints; i++) {
+      out.curveTo(
+        polygon[i].x,
+        polygon[i].y,
+        polygon[i].x,
+        polygon[i].y,
+        polygon[i].x,
+        polygon[i].y,
+      );
+    }
+    return;
+  }
+
+  let idealRadius = getPolygonCloudRadius(intensity, lineWidth);
+  if (idealRadius < 0.5) idealRadius = 0.5;
+
+  const k = Math.cos(ANGLE_34);
+
+  const edgeAlphas: number[] = [];
+  for (let j = 0; j + 1 < numPoints; j++) {
+    const len = distance(polygon[j], polygon[j + 1]);
+    if (len <= 0 || len >= 2 * k * idealRadius) {
+      edgeAlphas.push(ANGLE_34);
+    } else {
+      edgeAlphas.push(Math.acos(Math.min(1, len / (2 * idealRadius))));
+    }
+  }
+
+  let anglePrev = 0;
+  let outputStarted = false;
+
+  for (let j = 0; j + 1 < numPoints; j++) {
+    const pt = polygon[j];
+    const ptNext = polygon[j + 1];
+    const len = distance(pt, ptNext);
+    if (len === 0) continue;
+
+    const params = computeParamsPolygon(idealRadius, k, len);
+    if (params.n < 0) {
+      if (!outputStarted) {
+        out.moveTo(pt.x, pt.y);
+        outputStarted = true;
+      }
+      continue;
+    }
+
+    const edgeRadius = Math.max(0.5, params.adjustedRadius);
+    const intermAdvance = 2 * k * edgeRadius;
+    const firstAdvance = k * idealRadius + k * edgeRadius;
+
+    const angleCur = Math.atan2(ptNext.y - pt.y, ptNext.x - pt.x);
+
+    if (j === 0) {
+      anglePrev = angleCur;
+    }
+
+    const cos = cosine(ptNext.x - pt.x, len);
+    const sin = sine(ptNext.y - pt.y, len);
+    let x = pt.x;
+    let y = pt.y;
+
+    const alpha = edgeAlphas[j];
+    const alphaPrevEdge = j === 0 ? ANGLE_34 : (edgeAlphas[j - 1] ?? ANGLE_34);
+
+    addCornerCurl(
+      anglePrev,
+      angleCur,
+      idealRadius,
+      pt.x,
+      pt.y,
+      alpha,
+      alphaPrevEdge,
+      out,
+      !outputStarted,
+    );
+    outputStarted = true;
+
+    if (params.n === 0) {
+      x += len * cos;
+      y += len * sin;
+    } else {
+      x += firstAdvance * cos;
+      y += firstAdvance * sin;
+
+      let numInterm = params.n;
+      if (params.n >= 1) {
+        addFirstIntermediateCurl(angleCur, edgeRadius, ANGLE_34, x, y, out);
+        x += intermAdvance * cos;
+        y += intermAdvance * sin;
+        numInterm = params.n - 1;
+      }
+
+      const template = getIntermediateCurlTemplate(angleCur, edgeRadius);
+      for (let i = 0; i < numInterm; i++) {
+        outputCurlTemplate(template, x, y, out);
+        x += intermAdvance * cos;
+        y += intermAdvance * sin;
+      }
+    }
+
+    anglePrev = angleCur;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Ellipse flattening
 // ---------------------------------------------------------------------------
 
@@ -828,5 +954,34 @@ export function generateCloudyPolygonPath(
   cloudyPolygonImpl(localPts, false, intensity, lineWidth, out);
   out.close();
 
+  return out.build(lineWidth);
+}
+
+/**
+ * Generates a cloudy border SVG path for an open polyline.
+ *
+ * @param vertices - The polyline vertices in annotation-local coordinates
+ * @param rectOrigin - The annotation rect origin `{ x, y }` for coordinate translation
+ * @param intensity - Cloudy border intensity
+ * @param lineWidth - Stroke width of the annotation border
+ */
+export function generateCloudyPolylinePath(
+  vertices: ReadonlyArray<{ x: number; y: number }>,
+  rectOrigin: { x: number; y: number },
+  intensity: number,
+  lineWidth: number,
+): CloudyPathResult {
+  const out = new PathBuilder();
+
+  if (vertices.length < 2) {
+    return out.build(lineWidth);
+  }
+
+  const localPts: Point[] = vertices.map((v) => ({
+    x: v.x - rectOrigin.x,
+    y: -(v.y - rectOrigin.y),
+  }));
+
+  cloudyPolylineImpl(localPts, intensity, lineWidth, out);
   return out.build(lineWidth);
 }

--- a/packages/plugin-annotation/src/lib/tools/default-tools.ts
+++ b/packages/plugin-annotation/src/lib/tools/default-tools.ts
@@ -360,7 +360,8 @@ export const defaultTools = [
   {
     id: 'polygon' as const,
     name: 'Polygon',
-    matchScore: (a) => (a.type === PdfAnnotationSubtype.POLYGON ? 1 : 0),
+    matchScore: (a) =>
+      a.type === PdfAnnotationSubtype.POLYGON && a.intent !== 'PolygonCloud' ? 5 : 0,
     interaction: {
       exclusive: false,
       cursor: 'crosshair',
@@ -380,6 +381,33 @@ export const defaultTools = [
       opacity: 1,
       strokeWidth: 6,
       strokeColor: '#E44234',
+    },
+  },
+  {
+    id: 'cloud' as const,
+    name: 'Cloud',
+    matchScore: (a) =>
+      a.type === PdfAnnotationSubtype.POLYGON && a.intent === 'PolygonCloud' ? 10 : 0,
+    interaction: {
+      exclusive: false,
+      cursor: 'crosshair',
+      isDraggable: true,
+      isResizable: false,
+      lockAspectRatio: false,
+      isGroupResizable: true,
+      lockGroupAspectRatio: (a) => {
+        const r = (((a.rotation ?? 0) % 90) + 90) % 90;
+        return r >= 6 && r <= 84;
+      },
+    },
+    defaults: {
+      type: PdfAnnotationSubtype.POLYGON,
+      intent: 'PolygonCloud',
+      color: 'transparent',
+      opacity: 1,
+      strokeWidth: 3,
+      strokeColor: '#E44234',
+      cloudyBorderIntensity: 2,
     },
   },
 

--- a/packages/plugin-annotation/src/shared/components/annotations/polygon.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/polygon.tsx
@@ -1,6 +1,9 @@
 import { useMemo, MouseEvent } from '@framework';
 import { Rect, Position, PdfAnnotationBorderStyle } from '@embedpdf/models';
-import { generateCloudyPolygonPath } from '@embedpdf/plugin-annotation';
+import {
+  generateCloudyPolygonPath,
+  generateCloudyPolylinePath,
+} from '@embedpdf/plugin-annotation';
 
 const MIN_HIT_AREA_SCREEN_PX = 20;
 
@@ -61,9 +64,19 @@ export function Polygon({
   }, [localPts, currentVertex]);
 
   const cloudyPath = useMemo(() => {
-    if (!isCloudy || allPoints.length < 3) return null;
+    if (!isCloudy) return null;
+    if (currentVertex) {
+      if (allPoints.length < 2) return null;
+      return generateCloudyPolylinePath(
+        allPoints,
+        rect.origin,
+        cloudyBorderIntensity!,
+        strokeWidth,
+      );
+    }
+    if (allPoints.length < 3) return null;
     return generateCloudyPolygonPath(allPoints, rect.origin, cloudyBorderIntensity!, strokeWidth);
-  }, [isCloudy, allPoints, rect.origin, cloudyBorderIntensity, strokeWidth]);
+  }, [isCloudy, allPoints, rect.origin, cloudyBorderIntensity, strokeWidth, currentVertex]);
 
   const isPreviewing = currentVertex && vertices.length > 0;
 
@@ -108,17 +121,32 @@ export function Polygon({
       {!appearanceActive && (
         <>
           {isCloudy && cloudyPath ? (
-            <path
-              d={cloudyPath.path}
-              opacity={opacity}
-              style={{
-                fill: color,
-                stroke: strokeColor ?? color,
-                strokeWidth,
-                pointerEvents: 'none',
-                strokeLinejoin: 'round',
-              }}
-            />
+            <>
+              <path
+                d={cloudyPath.path}
+                opacity={opacity}
+                style={{
+                  fill: currentVertex ? 'none' : color,
+                  stroke: strokeColor ?? color,
+                  strokeWidth,
+                  pointerEvents: 'none',
+                  strokeLinejoin: 'round',
+                }}
+              />
+              {isPreviewing && vertices.length >= 2 && (
+                <rect
+                  x={localPts[0].x - handleSize / scale / 2}
+                  y={localPts[0].y - handleSize / scale / 2}
+                  width={handleSize / scale}
+                  height={handleSize / scale}
+                  fill={strokeColor}
+                  opacity={0.4}
+                  stroke={strokeColor}
+                  strokeWidth={strokeWidth / 2}
+                  style={{ pointerEvents: 'none' }}
+                />
+              )}
+            </>
           ) : (
             <>
               <path

--- a/packages/plugin-annotation/src/svelte/components/annotations/Polygon.svelte
+++ b/packages/plugin-annotation/src/svelte/components/annotations/Polygon.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Rect, Position } from '@embedpdf/models';
   import { PdfAnnotationBorderStyle } from '@embedpdf/models';
-  import { generateCloudyPolygonPath } from '@embedpdf/plugin-annotation';
+  import { generateCloudyPolygonPath, generateCloudyPolylinePath } from '@embedpdf/plugin-annotation';
 
   const MIN_HIT_AREA_SCREEN_PX = 20;
 
@@ -61,7 +61,12 @@
   });
 
   const cloudyPath = $derived.by(() => {
-    if (!isCloudy || allPoints.length < 3) return null;
+    if (!isCloudy) return null;
+    if (currentVertex) {
+      if (allPoints.length < 2) return null;
+      return generateCloudyPolylinePath(allPoints, rect.origin, cloudyBorderIntensity!, strokeWidth);
+    }
+    if (allPoints.length < 3) return null;
     return generateCloudyPolygonPath(allPoints, rect.origin, cloudyBorderIntensity!, strokeWidth);
   });
 
@@ -108,12 +113,25 @@
       <path
         d={cloudyPath.path}
         {opacity}
-        style:fill={color}
+        style:fill={currentVertex ? 'none' : color}
         style:stroke={strokeColor ?? color}
         style:stroke-width={strokeWidth}
         style:pointer-events="none"
         style:stroke-linejoin="round"
       />
+      {#if isPreviewing && vertices.length >= 2}
+        <rect
+          x={localPts[0].x - handleSize / scale / 2}
+          y={localPts[0].y - handleSize / scale / 2}
+          width={handleSize / scale}
+          height={handleSize / scale}
+          fill={strokeColor}
+          opacity={0.4}
+          stroke={strokeColor}
+          stroke-width={strokeWidth / 2}
+          style:pointer-events="none"
+        />
+      {/if}
     {:else}
       <path
         d={pathData}

--- a/packages/plugin-annotation/src/vue/components/annotations/polygon.vue
+++ b/packages/plugin-annotation/src/vue/components/annotations/polygon.vue
@@ -29,18 +29,31 @@
 
     <!-- Visual -- hidden when AP active, never interactive -->
     <template v-if="!appearanceActive">
-      <path
-        v-if="isCloudy && cloudyPath"
-        :d="cloudyPath.path"
-        :opacity="opacity"
-        :style="{
-          fill: color,
-          stroke: strokeColor ?? color,
-          strokeWidth,
-          pointerEvents: 'none',
-          strokeLinejoin: 'round',
-        }"
-      />
+      <template v-if="isCloudy && cloudyPath">
+        <path
+          :d="cloudyPath.path"
+          :opacity="opacity"
+          :style="{
+            fill: currentVertex ? 'none' : color,
+            stroke: strokeColor ?? color,
+            strokeWidth,
+            pointerEvents: 'none',
+            strokeLinejoin: 'round',
+          }"
+        />
+        <rect
+          v-if="isPreviewing && vertices.length >= 2"
+          :x="localPts[0].x - handleSize / scale / 2"
+          :y="localPts[0].y - handleSize / scale / 2"
+          :width="handleSize / scale"
+          :height="handleSize / scale"
+          :fill="strokeColor"
+          :opacity="0.4"
+          :stroke="strokeColor"
+          :stroke-width="strokeWidth / 2"
+          style="pointer-events: none"
+        />
+      </template>
       <template v-else>
         <path
           :d="pathData"
@@ -95,7 +108,7 @@ export default { inheritAttrs: false };
 <script setup lang="ts">
 import { computed } from 'vue';
 import { Rect, Position, PdfAnnotationBorderStyle } from '@embedpdf/models';
-import { generateCloudyPolygonPath } from '@embedpdf/plugin-annotation';
+import { generateCloudyPolygonPath, generateCloudyPolylinePath } from '@embedpdf/plugin-annotation';
 
 const MIN_HIT_AREA_SCREEN_PX = 20;
 
@@ -152,7 +165,17 @@ const pathData = computed(() => {
 });
 
 const cloudyPath = computed(() => {
-  if (!isCloudy.value || allPoints.value.length < 3) return null;
+  if (!isCloudy.value) return null;
+  if (props.currentVertex) {
+    if (allPoints.value.length < 2) return null;
+    return generateCloudyPolylinePath(
+      allPoints.value,
+      props.rect.origin,
+      props.cloudyBorderIntensity!,
+      props.strokeWidth,
+    );
+  }
+  if (allPoints.value.length < 3) return null;
   return generateCloudyPolygonPath(
     allPoints.value,
     props.rect.origin,


### PR DESCRIPTION
Cloud annotations are one of the most requested markup tools in PDF viewers. Professionals use them to call out areas on blueprints and floor plans that need revision or to mark regions for review

## Summary

- New Cloud drawing tool that creates polygon annotations with a scalloped/cloudy border
- Live preview shows the cloud effect as you draw, starting from the very first edge
- Follows the PDF specification for cloud annotations (PolygonCloud intent + Border Effect dictionary)

## Changes
- Added cloud tool definition alongside the existing polygon tool
- Built a new open path cloudy border generator so the scallop effect renders during drawing, not just after committing
- Added Cloud button to all example toolbars (React, MUI, Svelte, Vue)

## Example
<img width="692" height="353" alt="image" src="https://github.com/user-attachments/assets/4ccaa441-e5fc-4f1d-a6fd-7260a090922b" />
