### PR TITLE
Fix stamp (and other annotation type) handlers not working for custom…

### DIFF
--- a/.changeset/fix-stamp-handler-regression.md
+++ b/.changeset/fix-stamp-handler-regression.md
@@ -1,0 +1,7 @@
+---
+'@embedpdf/plugin-annotation': patch
+---
+
+Fix stamp (and other annotation type) handlers not working for custom tools added via `addTool()`.
+
+The #537 merge moved handler factory lookup from a centralized subtype-based registry to a `pointerHandler` property on each tool object. Custom tools that didn't specify `pointerHandler` lost their pointer interaction entirely. This restores a default handler registry as a fallback so tools without an explicit `pointerHandler` automatically get the canonical handler for their annotation subtype.

--- a/packages/plugin-annotation/src/lib/annotation-plugin.ts
+++ b/packages/plugin-annotation/src/lib/annotation-plugin.ts
@@ -7,6 +7,7 @@ import {
 import {
   ignore,
   PdfAnnotationObject,
+  PdfAnnotationSubtype,
   PdfDocumentObject,
   PdfErrorReason,
   Task,
@@ -108,10 +109,23 @@ import { AnnotationTool, AnnotationToolMap, ToolById, ToolId } from './tools/typ
 import {
   PreviewState,
   HandlerContext,
+  HandlerFactory,
   HandlerServices,
   SelectionHandlerContext,
 } from './handlers/types';
-import { textMarkupSelectionHandler } from './handlers';
+import {
+  textMarkupSelectionHandler,
+  circleHandlerFactory,
+  squareHandlerFactory,
+  stampHandlerFactory,
+  polygonHandlerFactory,
+  polylineHandlerFactory,
+  lineHandlerFactory,
+  inkHandlerFactory,
+  freeTextHandlerFactory,
+  textHandlerFactory,
+  linkHandlerFactory,
+} from './handlers';
 import {
   rectsIntersect,
   isSidebarAnnotation,
@@ -136,6 +150,22 @@ export class AnnotationPlugin extends BasePlugin<
 > {
   static readonly id = 'annotation' as const;
   private readonly ANNOTATION_HISTORY_TOPIC = 'annotations';
+
+  private static readonly defaultHandlerFactories = new Map<
+    PdfAnnotationSubtype,
+    HandlerFactory<any>
+  >([
+    [PdfAnnotationSubtype.CIRCLE, circleHandlerFactory],
+    [PdfAnnotationSubtype.SQUARE, squareHandlerFactory],
+    [PdfAnnotationSubtype.STAMP, stampHandlerFactory],
+    [PdfAnnotationSubtype.POLYGON, polygonHandlerFactory],
+    [PdfAnnotationSubtype.POLYLINE, polylineHandlerFactory],
+    [PdfAnnotationSubtype.LINE, lineHandlerFactory],
+    [PdfAnnotationSubtype.INK, inkHandlerFactory],
+    [PdfAnnotationSubtype.FREETEXT, freeTextHandlerFactory],
+    [PdfAnnotationSubtype.TEXT, textHandlerFactory],
+    [PdfAnnotationSubtype.LINK, linkHandlerFactory],
+  ]);
 
   public readonly config: AnnotationPluginConfig;
   private readonly state$ = createScopedEmitter<
@@ -591,7 +621,11 @@ export class AnnotationPlugin extends BasePlugin<
       4) as Rotation;
 
     for (const tool of this.state.tools) {
-      const factory = tool.pointerHandler;
+      const factory =
+        tool.pointerHandler ??
+        (tool.defaults?.type
+          ? AnnotationPlugin.defaultHandlerFactories.get(tool.defaults.type)
+          : undefined);
       if (!factory) continue;
 
       const context: HandlerContext<PdfAnnotationObject> = {


### PR DESCRIPTION
… tools added via `addTool()`.