### PR TITLE
Fixed non-working stamp example

### DIFF
--- a/website/src/content/docs/snippet/plugins/plugin-annotation.mdx
+++ b/website/src/content/docs/snippet/plugins/plugin-annotation.mdx
@@ -100,7 +100,8 @@ const pngBuffer = await fetch('/my-stamp.png').then(r => r.arrayBuffer());
 annotationApi.importAnnotations([
   {
     annotation: {
-      type: 26, // PdfAnnotationSubtype.STAMP
+      id: "fd6605fe-8deb-4596-8984-eb04c8a4f2b0", //ID is required and must be UUID, if using crypto.randomUUID()  make sure you're in localhost or secure HTTPS context.
+      type: 13, // PdfAnnotationSubtype.STAMP
       rect: { origin: { x: 100, y: 200 }, size: { width: 50, height: 50 } },
       // ... other annotation properties
     },

--- a/website/src/content/docs/snippet/plugins/plugin-annotation.mdx
+++ b/website/src/content/docs/snippet/plugins/plugin-annotation.mdx
@@ -100,7 +100,7 @@ const pngBuffer = await fetch('/my-stamp.png').then(r => r.arrayBuffer());
 annotationApi.importAnnotations([
   {
     annotation: {
-      id: "fd6605fe-8deb-4596-8984-eb04c8a4f2b0", //ID is required and must be UUID, if using crypto.randomUUID()  make sure you're in localhost or secure HTTPS context.
+      id: "fd6605fe-8deb-4596-8984-eb04c8a4f2b0",
       type: 13, // PdfAnnotationSubtype.STAMP
       rect: { origin: { x: 100, y: 200 }, size: { width: 50, height: 50 } },
       // ... other annotation properties


### PR DESCRIPTION
The example in the documentation for importing stamps is incorrect. It doesn't explain that you need an ID, that ID needs to be a UUID format, and also the type is wrong (should be 13 not 26).  Caused lots of confusion for us in development.