### PR TITLE
Proposed fix for zoom out issue #384

### DIFF
--- a/packages/plugin-zoom/src/shared/components/zoom-gesture-wrapper.tsx
+++ b/packages/plugin-zoom/src/shared/components/zoom-gesture-wrapper.tsx
@@ -9,6 +9,8 @@ type ZoomGestureWrapperProps = Omit<HTMLAttributes<HTMLDivElement>, 'style'> & {
   enablePinch?: boolean;
   /** Enable wheel zoom with ctrl/cmd key (default: true) */
   enableWheel?: boolean;
+  /** Override wheel zoom step; 0.1 = 10% (default: 0.1) */
+  zoomStep?: number;
 };
 
 export function ZoomGestureWrapper({
@@ -17,11 +19,12 @@ export function ZoomGestureWrapper({
   style,
   enablePinch = true,
   enableWheel = true,
+  zoomStep = 0.1,
   ...props
 }: ZoomGestureWrapperProps) {
   const options = useMemo<ZoomGestureOptions>(
-    () => ({ enablePinch, enableWheel }),
-    [enablePinch, enableWheel],
+    () => ({ enablePinch, enableWheel, zoomStep }),
+    [enablePinch, enableWheel, zoomStep],
   );
   const { elementRef } = useZoomGesture(documentId, options);
 

--- a/packages/plugin-zoom/src/shared/hooks/use-pinch-zoom.ts
+++ b/packages/plugin-zoom/src/shared/hooks/use-pinch-zoom.ts
@@ -36,6 +36,7 @@ export function useZoomGesture(documentId: string, options: ZoomGestureOptions =
     viewportElementRef,
     options.enablePinch,
     options.enableWheel,
+    options.zoomStep,
   ]);
 
   return { elementRef };

--- a/packages/plugin-zoom/src/shared/hooks/use-zoom-gesture.ts
+++ b/packages/plugin-zoom/src/shared/hooks/use-zoom-gesture.ts
@@ -37,6 +37,7 @@ export function useZoomGesture(documentId: string, options: ZoomGestureOptions =
     viewportElementRef,
     options.enablePinch,
     options.enableWheel,
+    options.zoomStep,
   ]);
 
   return { elementRef };

--- a/packages/plugin-zoom/src/shared/utils/pinch-zoom-logic.ts
+++ b/packages/plugin-zoom/src/shared/utils/pinch-zoom-logic.ts
@@ -6,6 +6,8 @@ export interface ZoomGestureOptions {
   enablePinch?: boolean;
   /** Enable wheel zoom with ctrl/cmd key (default: true) */
   enableWheel?: boolean;
+  /** Override wheel zoom step; 0.1 = 10% (default: 0.1) */
+  zoomStep?: number;
 }
 
 export interface ZoomGestureDeps {
@@ -41,7 +43,7 @@ export function setupZoomGestures({
   zoomProvides,
   options = {},
 }: ZoomGestureDeps) {
-  const { enablePinch = true, enableWheel = true } = options;
+  const { enablePinch = true, enableWheel = true, zoomStep = 0.1 } = options;
   if (typeof window === 'undefined') {
     return () => {};
   }
@@ -244,9 +246,10 @@ export function setupZoomGestures({
       clearTimeout(wheelZoomTimeout);
     }
 
-    const zoomFactor = 1 - e.deltaY * 0.01;
+    // Utilizing deltaY sign instead of raw value to eliminate discrepancies between browsers
+    const zoomFactor = 1 - Math.sign(e.deltaY) * zoomStep; // Should this use zoomStep configured by the plugin config?
     accumulatedWheelScale *= zoomFactor;
-    accumulatedWheelScale = Math.max(0.1, Math.min(10, accumulatedWheelScale));
+    accumulatedWheelScale = clamp(accumulatedWheelScale, 0.1, 10);
     updateTransform(accumulatedWheelScale);
 
     wheelZoomTimeout = setTimeout(() => {

--- a/packages/plugin-zoom/src/shared/utils/zoom-gesture-logic.ts
+++ b/packages/plugin-zoom/src/shared/utils/zoom-gesture-logic.ts
@@ -5,6 +5,8 @@ export interface ZoomGestureOptions {
   enablePinch?: boolean;
   /** Enable wheel zoom with ctrl/cmd key (default: true) */
   enableWheel?: boolean;
+  /** Override wheel zoom step; 0.1 = 10% (default: 0.1) */
+  zoomStep?: number;
 }
 
 export interface ZoomGestureDeps {
@@ -41,7 +43,7 @@ export function setupZoomGestures({
   viewportGap = 0,
   options = {},
 }: ZoomGestureDeps) {
-  const { enablePinch = true, enableWheel = true } = options;
+  const { enablePinch = true, enableWheel = true, zoomStep = 0.1 } = options;
   if (typeof window === 'undefined') {
     return () => {};
   }
@@ -228,9 +230,10 @@ export function setupZoomGestures({
       clearTimeout(wheelZoomTimeout);
     }
 
-    const zoomFactor = 1 - e.deltaY * 0.01;
+    // Utilizing deltaY sign instead of raw value to eliminate discrepancies between browsers
+    const zoomFactor = 1 - Math.sign(e.deltaY) * zoomStep; // Should this use zoomStep configured by the plugin config?
     accumulatedWheelScale *= zoomFactor;
-    accumulatedWheelScale = Math.max(0.1, Math.min(10, accumulatedWheelScale));
+    accumulatedWheelScale = clamp(accumulatedWheelScale, 0.1, 10);
     updateTransform(accumulatedWheelScale);
 
     wheelZoomTimeout = setTimeout(() => {

--- a/packages/plugin-zoom/src/svelte/components/ZoomGestureWrapper.svelte
+++ b/packages/plugin-zoom/src/svelte/components/ZoomGestureWrapper.svelte
@@ -11,6 +11,8 @@
     enablePinch?: boolean;
     /** Enable wheel zoom with ctrl/cmd key (default: true) */
     enableWheel?: boolean;
+    /** Override wheel zoom step; 0.1 = 10% (default: 0.1) */
+    zoomStep?: number;
   };
 
   let {
@@ -19,12 +21,14 @@
     class: propsClass,
     enablePinch = true,
     enableWheel = true,
+    zoomStep = 0.1,
     ...restProps
   }: ZoomGestureWrapperProps = $props();
 
   const zoomGesture = useZoomGesture(() => documentId, {
     enablePinch: () => enablePinch,
     enableWheel: () => enableWheel,
+    zoomStep: () => zoomStep,
   });
 </script>
 

--- a/packages/plugin-zoom/src/svelte/hooks/use-pinch-zoom.svelte.ts
+++ b/packages/plugin-zoom/src/svelte/hooks/use-pinch-zoom.svelte.ts
@@ -14,6 +14,8 @@ export interface UseZoomGestureOptions {
   enablePinch?: () => boolean;
   /** Enable wheel zoom with ctrl/cmd key (default: true) */
   enableWheel?: () => boolean;
+  /** Override wheel zoom step; 0.1 = 10% (default: 0.1) */
+  zoomStep?: () => number;
 }
 
 /**
@@ -36,6 +38,7 @@ export function useZoomGesture(
   const documentId = $derived(getDocumentId());
   const enablePinch = $derived(options.enablePinch?.() ?? true);
   const enableWheel = $derived(options.enableWheel?.() ?? true);
+  const zoomStep = $derived(options.zoomStep?.() ?? 0.1);
 
   $effect(() => {
     const element = elementRef;
@@ -63,7 +66,7 @@ export function useZoomGesture(
       documentId: docId,
       viewportProvides: viewport,
       zoomProvides: zoom,
-      options: { enablePinch: pinchEnabled, enableWheel: wheelEnabled },
+      options: { enablePinch: pinchEnabled, enableWheel: wheelEnabled, zoomStep },
     });
 
     return () => {

--- a/packages/plugin-zoom/src/svelte/hooks/use-zoom-gesture.svelte.ts
+++ b/packages/plugin-zoom/src/svelte/hooks/use-zoom-gesture.svelte.ts
@@ -14,6 +14,8 @@ export interface UseZoomGestureOptions {
   enablePinch?: () => boolean;
   /** Enable wheel zoom with ctrl/cmd key (default: true) */
   enableWheel?: () => boolean;
+  /** Override wheel zoom step; 0.1 = 10% (default: 0.1) */
+  zoomStep?: () => number;
 }
 
 /**
@@ -36,6 +38,7 @@ export function useZoomGesture(
   const documentId = $derived(getDocumentId());
   const enablePinch = $derived(options.enablePinch?.() ?? true);
   const enableWheel = $derived(options.enableWheel?.() ?? true);
+  const zoomStep = $derived(options.zoomStep?.() ?? 0.1);
 
   $effect(() => {
     const element = elementRef;
@@ -63,7 +66,7 @@ export function useZoomGesture(
       documentId: docId,
       zoomProvides: zoom,
       viewportGap: viewport?.getViewportGap() || 0,
-      options: { enablePinch: pinchEnabled, enableWheel: wheelEnabled },
+      options: { enablePinch: pinchEnabled, enableWheel: wheelEnabled, zoomStep },
     });
 
     return () => {

--- a/packages/plugin-zoom/src/vue/components/zoom-gesture-wrapper.vue
+++ b/packages/plugin-zoom/src/vue/components/zoom-gesture-wrapper.vue
@@ -22,15 +22,19 @@ interface Props {
   enablePinch?: boolean;
   /** Enable wheel zoom with ctrl/cmd key (default: true) */
   enableWheel?: boolean;
+  /** Override wheel zoom step; 0.1 = 10% (default: 0.1) */
+  zoomStep?: number;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   enablePinch: true,
   enableWheel: true,
+  zoomStep: 0.1,
 });
 
 const { elementRef } = useZoomGesture(() => props.documentId, {
   enablePinch: toRef(() => props.enablePinch),
   enableWheel: toRef(() => props.enableWheel),
+  zoomStep: toRef(() => props.zoomStep),
 });
 </script>

--- a/packages/plugin-zoom/src/vue/hooks/use-pinch-zoom.ts
+++ b/packages/plugin-zoom/src/vue/hooks/use-pinch-zoom.ts
@@ -13,6 +13,8 @@ export interface UseZoomGestureOptions {
   enablePinch?: MaybeRefOrGetter<boolean>;
   /** Enable wheel zoom with ctrl/cmd key (default: true) */
   enableWheel?: MaybeRefOrGetter<boolean>;
+  /** Override wheel zoom step; 0.1 = 10% (default: 0.1) */
+  zoomStep?: number;
 }
 
 /**
@@ -39,14 +41,16 @@ export function useZoomGesture(
       () => toValue(documentId),
       () => toValue(options.enablePinch ?? true),
       () => toValue(options.enableWheel ?? true),
+      () => toValue(options.zoomStep ?? 0.1),
     ],
-    ([element, viewport, zoom, docId, enablePinch, enableWheel]: [
+    ([element, viewport, zoom, docId, enablePinch, enableWheel, zoomStep]: [
       HTMLDivElement | null,
       ViewportCapability | null,
       ZoomCapability | null,
       string,
       boolean,
       boolean,
+      number,
     ]) => {
       // Clean up previous setup
       if (cleanup) {
@@ -67,7 +71,7 @@ export function useZoomGesture(
         documentId: docId,
         viewportProvides: viewport,
         zoomProvides: zoom,
-        options: { enablePinch, enableWheel },
+        options: { enablePinch, enableWheel, zoomStep },
       });
     },
     { immediate: true },

--- a/packages/plugin-zoom/src/vue/hooks/use-zoom-gesture.ts
+++ b/packages/plugin-zoom/src/vue/hooks/use-zoom-gesture.ts
@@ -13,6 +13,8 @@ export interface UseZoomGestureOptions {
   enablePinch?: MaybeRefOrGetter<boolean>;
   /** Enable wheel zoom with ctrl/cmd key (default: true) */
   enableWheel?: MaybeRefOrGetter<boolean>;
+  /** Override wheel zoom step; 0.1 = 10% (default: 0.1) */
+  zoomStep?: number;
 }
 
 /**
@@ -39,14 +41,16 @@ export function useZoomGesture(
       () => toValue(documentId),
       () => toValue(options.enablePinch ?? true),
       () => toValue(options.enableWheel ?? true),
+      () => toValue(options.zoomStep ?? 0.1),
     ],
-    ([element, viewport, zoom, docId, enablePinch, enableWheel]: [
+    ([element, viewport, zoom, docId, enablePinch, enableWheel, zoomStep]: [
       HTMLDivElement | null,
       ViewportCapability | null,
       ZoomCapability | null,
       string,
       boolean,
       boolean,
+      number,
     ]) => {
       // Clean up previous setup
       if (cleanup) {
@@ -67,7 +71,7 @@ export function useZoomGesture(
         documentId: docId,
         zoomProvides: zoom,
         viewportGap: viewport?.getViewportGap() || 0,
-        options: { enablePinch, enableWheel },
+        options: { enablePinch, enableWheel, zoomStep },
       });
     },
     { immediate: true },


### PR DESCRIPTION
### This is a proposed fix for #384.

I am not sure about the original intention of the math or the feature, but the issue arises due to differences between how browsers report `deltaY` with mouse wheel scrolling.

I believe the values that are reported for various browser:
Chromium: +/-100
Firefox: +/-3
Safari: Hardware accelerated, aka, values are provided by mouse

When users with Chromium browsers attempt to Ctrl + scroll, `accumulatedWheelScale` ends up being clamped to 2/0.1, hence the reported zoom out by 10%:

```
const handleWheel = (e: WheelEvent) => {
    if (!e.ctrlKey && !e.metaKey) return;
    e.preventDefault();

    if (wheelZoomTimeout === null) {
      initialZoom = getState().currentZoomLevel;
      accumulatedWheelScale = 1;
      initializeGestureState(e.clientX, e.clientY);
    } else {
      clearTimeout(wheelZoomTimeout);
    }
   
    // the deltaY always = 100 then zoomFactor always =0, so the accumulatedWheelScale always = 0.1
    // the deltaY always = 100 then zoomFactor always =0, so the accumulatedWheelScale always = 0.1
    // the deltaY always = 100 then zoomFactor always =0, so the accumulatedWheelScale always = 0.1

    const zoomFactor = 1 - e.deltaY * 0.01;
    accumulatedWheelScale *= zoomFactor;
    accumulatedWheelScale = Math.max(0.1, Math.min(10, accumulatedWheelScale));
    updateTransform(accumulatedWheelScale);

    wheelZoomTimeout = setTimeout(() => {
      wheelZoomTimeout = null;
      commitZoom();
      accumulatedWheelScale = 1;
    }, 150);
  };
```
_(Special thanks to [lystormenvoy](https://github.com/lystormenvoy) who helped point to the source code where the issue resides.)_

---

### The proposed solution is as follows:

```
// Utilizing deltaY sign instead of raw value to eliminate discrepancies between browsers
const zoomFactor = 1 - Math.sign(e.deltaY) * zoomStep; // Should this use zoomStep configured by the plugin config?
accumulatedWheelScale *= zoomFactor;
accumulatedWheelScale = clamp(accumulatedWheelScale, 0.1, 10);
```

I changed the `zoomFactor` calculation to utilize only the sign, or direction, from the scroll and apply a static `zoomStep` (which perhaps should be utilizing the `zoomStep` config from the zoom plugin config, as you can see in my comment).

I also changed to the `clamp` function that I saw defined above for limiting `accumulatedWheelScale`.

I attempted to modify all corresponding props and APIs for the various frameworks, but I am really only a React dev and it would be good to review all of the code before merging!

Lastly, this is my **first ever** FOSS pull request, so please feel free to give gentle feedback! 😃 