### PR TITLE
Make signature creation fonts configurable

### DIFF
--- a/viewers/snippet/src/components/app.tsx
+++ b/viewers/snippet/src/components/app.tsx
@@ -127,7 +127,10 @@ import { RedactionSidebar } from '@/components/redaction-sidebar';
 import { WidgetEditSidebar } from '@/components/widget-edit-sidebar';
 import { RubberStampSidebar } from '@/components/rubber-stamp-sidebar';
 import { SignatureSidebar } from '@/components/signature-sidebar';
-import { SignatureCreateModal } from '@/components/signature-create-modal';
+import {
+  SignatureCreateModal,
+  SignatureFont,
+} from '@/components/signature-create-modal';
 import { SchemaSelectionMenu } from '@/ui/schema-selection-menu';
 import { SchemaOverlay } from '@/ui/schema-overlay';
 import { PrintModal } from '@/components/print-modal';
@@ -295,6 +298,39 @@ export interface PDFViewerConfig {
   // Signatures
   /** Signature options (mode, default size) */
   signature?: Partial<SignaturePluginConfig>;
+  /**
+   * Signature creation modal options.
+   *
+   * Use this to customize the fonts shown in the "Type" tab and control how the
+   * fonts stylesheet is loaded. By default, a Google Fonts stylesheet is injected
+   * for Dancing Script, Great Vibes, Pacifico, and Caveat.
+   *
+   * @example
+   * // Self-hosted fonts — skip the Google Fonts stylesheet entirely
+   * signatureCreate: {
+   *   fonts: [
+   *     { name: 'My Script', family: "'My Script', cursive" },
+   *   ],
+   *   fontsStylesheetUrl: null,
+   * }
+   *
+   * @example
+   * // Custom stylesheet URL
+   * signatureCreate: {
+   *   fonts: [{ name: 'Inter', family: "'Inter', sans-serif" }],
+   *   fontsStylesheetUrl: 'https://example.com/fonts.css',
+   * }
+   */
+  signatureCreate?: {
+    /** Fonts available in the "Type" tab. Defaults to Dancing Script, Great Vibes, Pacifico, Caveat. */
+    fonts?: SignatureFont[];
+    /**
+     * URL to a stylesheet to inject when the modal opens. Set to `null` to skip
+     * injection (e.g. when fonts are loaded via your own CSS). Defaults to a
+     * Google Fonts URL matching the default fonts.
+     */
+    fontsStylesheetUrl?: string | null;
+  };
 
   // Infrastructure
   /** History/undo options */
@@ -509,6 +545,9 @@ export function PDFViewer({ config, onRegistryReady }: PDFViewerProps) {
     logger: config.log ? logger : undefined,
   });
 
+  const signatureCreateFonts = config.signatureCreate?.fonts;
+  const signatureCreateFontsStylesheetUrl = config.signatureCreate?.fontsStylesheetUrl;
+
   // Memoize UIProvider props to prevent unnecessary remounts
   const uiComponents: UIComponents = useMemo(
     () => ({
@@ -523,7 +562,16 @@ export function PDFViewer({ config, onRegistryReady }: PDFViewerProps) {
       'widget-edit-sidebar': WidgetEditSidebar,
       'print-modal': PrintModal,
       'link-modal': LinkModal,
-      'signature-create-modal': SignatureCreateModal,
+      'signature-create-modal': (props) => (
+        <SignatureCreateModal
+          documentId={props.documentId}
+          isOpen={props.isOpen as boolean | undefined}
+          onClose={props.onClose as (() => void) | undefined}
+          onExited={props.onExited as (() => void) | undefined}
+          fonts={signatureCreateFonts}
+          fontsStylesheetUrl={signatureCreateFontsStylesheetUrl}
+        />
+      ),
       'protect-modal': ProtectModal,
       'unlock-owner-overlay': UnlockOwnerOverlay,
       'page-controls': PageControls,
@@ -531,7 +579,7 @@ export function PDFViewer({ config, onRegistryReady }: PDFViewerProps) {
       'view-permissions-modal': ViewPermissionsModal,
       'redaction-sidebar': RedactionSidebar,
     }),
-    [],
+    [signatureCreateFonts, signatureCreateFontsStylesheetUrl],
   );
 
   const uiRenderers = useMemo(

--- a/viewers/snippet/src/components/signature-create-modal.tsx
+++ b/viewers/snippet/src/components/signature-create-modal.tsx
@@ -13,14 +13,26 @@ import {
 } from '@embedpdf/plugin-signature/preact';
 import { Dialog } from './ui/dialog';
 
-const SIGNATURE_FONTS_URL =
+export interface SignatureFont {
+  name: string;
+  family: string;
+}
+
+export const DEFAULT_SIGNATURE_FONTS_URL =
   'https://fonts.googleapis.com/css2?family=Caveat&family=Dancing+Script&family=Great+Vibes&family=Pacifico&display=swap';
 
-function ensureSignatureFonts() {
-  if (document.querySelector(`link[href="${SIGNATURE_FONTS_URL}"]`)) return;
+export const DEFAULT_SIGNATURE_FONTS: SignatureFont[] = [
+  { name: 'Dancing Script', family: "'Dancing Script', cursive" },
+  { name: 'Great Vibes', family: "'Great Vibes', cursive" },
+  { name: 'Pacifico', family: "'Pacifico', cursive" },
+  { name: 'Caveat', family: "'Caveat', cursive" },
+];
+
+function ensureSignatureFonts(url: string) {
+  if (document.querySelector(`link[href="${url}"]`)) return;
   const link = document.createElement('link');
   link.rel = 'stylesheet';
-  link.href = SIGNATURE_FONTS_URL;
+  link.href = url;
   document.head.appendChild(link);
 }
 
@@ -29,6 +41,8 @@ interface SignatureCreateModalProps {
   isOpen?: boolean;
   onClose?: () => void;
   onExited?: () => void;
+  fonts?: SignatureFont[];
+  fontsStylesheetUrl?: string | null;
 }
 
 type CreationTab = 'draw' | 'type' | 'upload';
@@ -36,13 +50,6 @@ type CreationTab = 'draw' | 'type' | 'upload';
 interface FieldResult {
   field: SignatureFieldDefinition;
 }
-
-const FONTS = [
-  { name: 'Dancing Script', family: "'Dancing Script', cursive" },
-  { name: 'Great Vibes', family: "'Great Vibes', cursive" },
-  { name: 'Pacifico', family: "'Pacifico', cursive" },
-  { name: 'Caveat', family: "'Caveat', cursive" },
-];
 
 const COLORS = [
   { name: 'Black', value: '#000000' },
@@ -55,6 +62,8 @@ export function SignatureCreateModal({
   isOpen,
   onClose,
   onExited,
+  fonts = DEFAULT_SIGNATURE_FONTS,
+  fontsStylesheetUrl = DEFAULT_SIGNATURE_FONTS_URL,
 }: SignatureCreateModalProps) {
   const { translate } = useTranslations(documentId);
   const { provides: signatureCapability } = useSignatureCapability();
@@ -63,7 +72,7 @@ export function SignatureCreateModal({
   const needsInitials = mode === SignatureMode.SignatureAndInitials;
 
   const [activeTab, setActiveTab] = useState<CreationTab>('draw');
-  const [selectedFont, setSelectedFont] = useState(FONTS[0].family);
+  const [selectedFont, setSelectedFont] = useState(fonts[0]?.family ?? '');
   const [selectedColor, setSelectedColor] = useState(COLORS[0].value);
   const [sigResult, setSigResult] = useState<FieldResult | null>(null);
   const [iniResult, setIniResult] = useState<FieldResult | null>(null);
@@ -74,8 +83,8 @@ export function SignatureCreateModal({
   const iniTypeRef = useRef<SignatureTypePadHandle | null>(null);
 
   useEffect(() => {
-    if (isOpen) ensureSignatureFonts();
-  }, [isOpen]);
+    if (isOpen && fontsStylesheetUrl) ensureSignatureFonts(fontsStylesheetUrl);
+  }, [isOpen, fontsStylesheetUrl]);
 
   const handleSigResult = useCallback((result: SignatureFieldDefinition | null) => {
     setSigResult(result ? { field: result } : null);
@@ -101,10 +110,10 @@ export function SignatureCreateModal({
 
   const resetState = useCallback(() => {
     setActiveTab('draw');
-    setSelectedFont(FONTS[0].family);
+    setSelectedFont(fonts[0]?.family ?? '');
     setSelectedColor(COLORS[0].value);
     clearAll();
-  }, [clearAll]);
+  }, [clearAll, fonts]);
 
   const handleTabChange = useCallback(
     (tab: CreationTab) => {
@@ -297,7 +306,7 @@ export function SignatureCreateModal({
                     setSelectedFont((e.target as HTMLSelectElement).value);
                   }}
                 >
-                  {FONTS.map((f) => (
+                  {fonts.map((f) => (
                     <option key={f.family} value={f.family} style={{ fontFamily: f.family }}>
                       {f.name}
                     </option>


### PR DESCRIPTION
Adds a signatureCreate option to PDFViewerConfig letting consumers customize the fonts shown in the signature modal's "Type" tab and control how the fonts stylesheet is loaded. Passing fontsStylesheetUrl: null skips stylesheet injection entirely, so hosts that load their own fonts via CSS can avoid the Google Fonts dependency. Defaults preserve the existing behavior.

fixes #586 