### PR TITLE
fix: handle numeric defaultZoomLevel on document load

### DIFF
--- a/packages/plugin-zoom/src/lib/zoom-plugin.ts
+++ b/packages/plugin-zoom/src/lib/zoom-plugin.ts
@@ -529,14 +529,7 @@ export class ZoomPlugin extends BasePlugin<
   private recalcAuto(documentId: string, focus?: VerticalZoomFocus) {
     const docState = this.getDocumentState(documentId);
     if (!docState) return;
-
-    if (
-      docState.zoomLevel === ZoomMode.Automatic ||
-      docState.zoomLevel === ZoomMode.FitPage ||
-      docState.zoomLevel === ZoomMode.FitWidth
-    ) {
-      this.handleRequest({ level: docState.zoomLevel, focus }, documentId);
-    }
+    this.handleRequest({ level: docState.zoomLevel, focus }, documentId);
   }
 
   // ─────────────────────────────────────────────────────────

--- a/packages/plugin-zoom/src/lib/zoom-plugin.ts
+++ b/packages/plugin-zoom/src/lib/zoom-plugin.ts
@@ -85,12 +85,24 @@ export class ZoomPlugin extends BasePlugin<
 
     // Keep automatic modes up to date per document
     this.viewport.onViewportResize(
-      (event) => this.recalcAuto(event.documentId, VerticalZoomFocus.Top),
-      {
-        mode: 'debounce',
-        wait: 150,
-        keyExtractor: (event) => event.documentId,
-      },
+        (event) => {
+          const docState = this.getDocumentState(event.documentId);
+          if (!docState) return;
+
+          if (typeof docState.zoomLevel === 'number') {
+            this.handleRequest(
+                { level: docState.zoomLevel, focus: VerticalZoomFocus.Top },
+                event.documentId
+            );
+            return;
+          }
+          this.recalcAuto(event.documentId, VerticalZoomFocus.Top);
+        },
+        {
+          mode: 'debounce',
+          wait: 150,
+          keyExtractor: (event) => event.documentId,
+        },
     );
 
     // Subscribe to spread changes
@@ -529,7 +541,13 @@ export class ZoomPlugin extends BasePlugin<
   private recalcAuto(documentId: string, focus?: VerticalZoomFocus) {
     const docState = this.getDocumentState(documentId);
     if (!docState) return;
-    this.handleRequest({ level: docState.zoomLevel, focus }, documentId);
+    if (
+        docState.zoomLevel === ZoomMode.Automatic ||
+        docState.zoomLevel === ZoomMode.FitPage ||
+        docState.zoomLevel === ZoomMode.FitWidth
+    ) {
+      this.handleRequest({ level: docState.zoomLevel, focus }, documentId);
+    }
   }
 
   // ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #271

### Problem
Numeric zoom is applied before viewport metrics are available (clientWidth/clientHeight = 0),
causing handleRequest to exit early and resulting in no zoom being applied.

Auto zoom modes work because they are recalculated on viewport resize.

### Solution
Handle numeric zoom levels on viewport resize, similar to auto zoom modes.

Previously, numeric zoom was applied only once during document load,
when viewport metrics could be zero, causing it to be skipped.

Now numeric zoom is reapplied on viewport resize,
ensuring it is applied when metrics are available.