### PR TITLE
Fix the "Shapes" mode tab and its overflow-menu entry staying visible…

### DIFF
--- a/.changeset/snippet-shapes-tab-visibility.md
+++ b/.changeset/snippet-shapes-tab-visibility.md
@@ -1,0 +1,5 @@
+---
+"@embedpdf/snippet": patch
+---
+
+Fix the "Shapes" mode tab and its overflow-menu entry staying visible when `annotation-shape` is added to `disabledCategories`. The shapes mode entries now carry the `annotation-shape` category (matching the convention used by the insert/form/redact modes), so disabling that category hides the tab and disables the `mode:shapes` command alongside the already-hidden shape tools.

--- a/viewers/snippet/src/config/commands.ts
+++ b/viewers/snippet/src/config/commands.ts
@@ -852,7 +852,7 @@ export const commands: Record<string, Command<State>> = {
   'mode:shapes': {
     id: 'mode:shapes',
     labelKey: 'mode.shapes',
-    categories: ['mode', 'mode-shapes', 'annotation'],
+    categories: ['mode', 'mode-shapes', 'annotation', 'annotation-shape'],
     action: ({ registry, documentId }) => {
       const ui = registry.getPlugin<UIPlugin>('ui')?.provides();
       if (!ui) return;

--- a/viewers/snippet/src/config/ui-schema.ts
+++ b/viewers/snippet/src/config/ui-schema.ts
@@ -297,7 +297,7 @@ export const viewerUISchema: UISchema = {
               id: 'shapes-mode',
               commandId: 'mode:shapes',
               variant: 'text',
-              categories: ['mode', 'mode-shapes', 'annotation'],
+              categories: ['mode', 'mode-shapes', 'annotation', 'annotation-shape'],
             },
             {
               id: 'insert-mode',
@@ -995,7 +995,7 @@ export const viewerUISchema: UISchema = {
           type: 'command',
           id: 'mode:shapes',
           commandId: 'mode:shapes',
-          categories: ['mode', 'mode-shapes', 'annotation'],
+          categories: ['mode', 'mode-shapes', 'annotation', 'annotation-shape'],
         },
         {
           type: 'command',


### PR DESCRIPTION
… when `annotation-shape` is added to `disabledCategories`