### PR TITLE
Guard tooltip positioning after unmount

### DIFF
--- a/.changeset/quiet-tooltips-move.md
+++ b/.changeset/quiet-tooltips-move.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/snippet': patch
+---
+
+Guard tooltip positioning when the tooltip unmounts before Floating UI resolves.

--- a/viewers/snippet/src/components/ui/tooltip.tsx
+++ b/viewers/snippet/src/components/ui/tooltip.tsx
@@ -49,23 +49,31 @@ export function Tooltip({
     if (!reference.current?.base || !floating.current) return;
 
     return autoUpdate(reference.current.base, floating.current, () => {
-      computePosition(reference.current!.base, floating.current!, {
+      const referenceEl = reference.current?.base;
+      const floatingEl = floating.current;
+      const arrowEl = arrow.current;
+
+      if (!referenceEl || !floatingEl || !arrowEl) return;
+
+      computePosition(referenceEl, floatingEl, {
         placement: position,
         middleware: [
           offset(8),
           flip(),
           shift({ padding: 8 }),
-          arrowMw({ element: arrow.current!, padding: 6 }),
+          arrowMw({ element: arrowEl, padding: 6 }),
         ],
       }).then(({ x, y, placement, middlewareData }) => {
-        Object.assign(floating.current!.style, { left: `${x}px`, top: `${y}px` });
+        if (!floating.current || !arrow.current) return;
+
+        Object.assign(floating.current.style, { left: `${x}px`, top: `${y}px` });
 
         const { x: ax, y: ay } = middlewareData.arrow ?? {};
         const side = placement.split('-')[0] as 'top' | 'bottom' | 'left' | 'right';
         const staticSide = { top: 'bottom', bottom: 'top', left: 'right', right: 'left' }[side];
 
         /* --- **critical change**: clear the axis we don't use --- */
-        Object.assign(arrow.current!.style, {
+        Object.assign(arrow.current.style, {
           left: ax != null ? `${ax}px` : '',
           top: ay != null ? `${ay}px` : '',
           right: '',


### PR DESCRIPTION
Fixes #666.

## Summary
- Guard tooltip reference, floating, and arrow refs before starting Floating UI positioning.
- Re-check refs after `computePosition` resolves so unmounted tooltips do not throw while async positioning is settling.
- Add a patch changeset for `@embedpdf/snippet`.

## Verification
- `pnpm prettier --check viewers/snippet/src/components/ui/tooltip.tsx .changeset/quiet-tooltips-move.md`

`pnpm --filter @embedpdf/snippet build` could not be completed in this handover environment because a fresh clone needed workspace package dist outputs; the broader `pnpm build:packages` ran very long and surfaced unrelated existing TypeScript diagnostics in other packages.
