### PR TITLE
fix(plugin-annotation): mark FreeText as editing on input so blur doesn't drop changes

### DIFF
--- a/.changeset/fancy-oranges-clap.md
+++ b/.changeset/fancy-oranges-clap.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-annotation': patch
+---
+
+Fix FreeText/CalloutFreeText losing typed text when edited after non-isEditing blur

--- a/packages/plugin-annotation/src/shared/components/annotations/callout-free-text.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/callout-free-text.tsx
@@ -136,6 +136,10 @@ export function CalloutFreeText({
     });
   };
 
+  const handleInput = () => {
+    editingRef.current = true;
+  };
+
   const width = rect.size.width * scale;
   const height = rect.size.height * scale;
   const hitStrokeWidth = Math.max(strokeWidth, MIN_HIT_AREA_SCREEN_PX / scale);
@@ -261,6 +265,7 @@ export function CalloutFreeText({
       <span
         ref={editorRef}
         onBlur={handleBlur}
+        onInput={handleInput}
         tabIndex={0}
         style={{
           position: 'absolute',

--- a/packages/plugin-annotation/src/shared/components/annotations/free-text.tsx
+++ b/packages/plugin-annotation/src/shared/components/annotations/free-text.tsx
@@ -73,6 +73,10 @@ export function FreeText({
     });
   };
 
+  const handleInput = () => {
+    editingRef.current = true;
+  };
+
   return (
     <div
       style={{
@@ -89,6 +93,7 @@ export function FreeText({
       <span
         ref={editorRef}
         onBlur={handleBlur}
+        onInput={handleInput}
         tabIndex={0}
         style={{
           color: annotation.object.fontColor,


### PR DESCRIPTION
Closes #681 

## Root cause

In `packages/plugin-annotation/src/shared/components/annotations/free-text.tsx` (and `callout-free-text.tsx`), the commit-on-blur is gated by `editingRef.current`:

```ts
const handleBlur = () => {
  if (!editingRef.current) return;        // gate
  editingRef.current = false;
  ...
  annotationProvides.updateAnnotation(pageIndex, annotation.object.id, {
    contents: editorRef.current.innerText.replace(/\u00A0/g, ' '),
  });
};
```

`editingRef.current` is **only ever armed inside the `[isEditing]` effect**:

```ts
useEffect(() => {
  if (isEditing && editorRef.current) {
    editingRef.current = true;
    editor.focus();
    ...
  }
}, [isEditing]);   // runs only when isEditing CHANGES
```

When the style-panel interaction blurs the editor, `handleBlur` runs and sets `editingRef.current = false`. The annotation stays selected, so `isEditing` never changes and the effect doesn't re-run. Re-focusing the still-`contentEditable` span does not re-arm the gate (there is no `onFocus` handler), so the next blur bails out before committing.

## Proposed fix

Re-arm the gate whenever the user actually edits the text, on the contentEditable element in both `free-text.tsx` and `callout-free-text.tsx`:

```tsx
<span
  ref={editorRef}
  onBlur={handleBlur}
  onInput={() => {
    editingRef.current =
 true;
  }}
  tabIndex={0}
  ...
>
```

A single `onInput` handler is sufficient. A contentEditable only emits `input` when it's editable and its content actually changes, so "the user typed something" guarantees `editingRef.current` is armed before the next blur — which is the only case where text would otherwise be lost. (Verified against the repro above; re-arming on `onFocus` instead/additionally isn't needed, since a focus/blur with no typing has nothing new to commit.)

## Testing

Ran the snippet viewer `@embedpdf/snippet` and added a FreeText annotation, typed text, blurred — text persists.

Re-edited the existing annotation, typed more, blurred — change is saved and the comment sidebar reflects the updated text (this is the path that previously dropped the edit).

<img width="2840" height="2026" alt="output_fix" src="https://github.com/user-attachments/assets/8220b831-33f2-4b4c-8f4c-bd0562683f8d" />