### PR TITLE
fix(plugin-form): render list box options at natural height with opaque background

### DIFF
--- a/.changeset/form-listbox-rendering.md
+++ b/.changeset/form-listbox-rendering.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-form': patch
+---
+
+Fix list box form widgets rendering unusably when the option count exceeds the widget height. Option rows now carry `flexShrink: 0`, so they keep their natural line height and the container scrolls instead of the flex column crushing all rows into the box. The overlay background now treats a missing or `transparent` annotation color as opaque white, so the widget's appearance-stream image no longer shows through and doubles the option text. Applied to both the interactive form-fill list box and the annotation-mode renderer.

--- a/packages/plugin-form/src/shared/components/annotations/form-listbox.tsx
+++ b/packages/plugin-form/src/shared/components/annotations/form-listbox.tsx
@@ -33,7 +33,9 @@ export function FormListbox({ annotation, isSelected, scale, onClick, style }: F
       style={{
         position: 'absolute',
         inset: 0,
-        background: object.color ?? '#FFFFFF',
+        // The overlay redraws the option list itself, so it must fully cover the
+        // appearance-stream image behind it — treat 'transparent' as opaque white.
+        background: !object.color || object.color === 'transparent' ? '#FFFFFF' : object.color,
         border: `${borderWidth}px solid ${object.strokeColor ?? '#000000'}`,
         outline: isHovered || isSelected ? '1px solid rgba(66, 133, 244, 0.5)' : 'none',
         outlineOffset: -1,
@@ -50,6 +52,7 @@ export function FormListbox({ annotation, isSelected, scale, onClick, style }: F
         <div
           key={i}
           style={{
+            flexShrink: 0,
             padding: `0 ${4 * scale}px`,
             fontSize,
             lineHeight: `${lineHeight}px`,

--- a/packages/plugin-form/src/shared/components/fields/listbox.tsx
+++ b/packages/plugin-form/src/shared/components/fields/listbox.tsx
@@ -23,7 +23,10 @@ export function ListboxField(props: ListboxFieldProps) {
       left: 0,
       width: '100%',
       height: '100%',
-      background: annotation.color ?? '#FFFFFF',
+      // The overlay redraws the option list itself, so it must fully cover the
+      // appearance-stream image behind it — treat 'transparent' as opaque white.
+      background:
+        !annotation.color || annotation.color === 'transparent' ? '#FFFFFF' : annotation.color,
       borderStyle: 'solid',
       borderColor: annotation.strokeColor ?? '#000000',
       borderWidth: bw,
@@ -63,6 +66,7 @@ export function ListboxField(props: ListboxFieldProps) {
           key={i}
           onClick={() => handleOptionClick(i)}
           style={{
+            flexShrink: 0,
             padding: `0 ${4 * scale}px`,
             fontSize,
             lineHeight: `${lineHeight}px`,


### PR DESCRIPTION
## Problem

Interactive List Box (AcroForm LISTBOX) widgets render unusably when the option count × line height exceeds the widget rect height (e.g. 12 month options in a ~67pt-tall box) and the widget has no explicit background color:

- All option rows are squeezed vertically into the box and overlap each other instead of scrolling.
- The overlay is transparent, so the widget's static appearance-stream rendering shows through from behind — two copies of the option text overlay each other (one scrolled, one not).

## Root cause

Two independent style bugs in the list box components:

1. **Rows are flex-shrunk.** The container is a fixed-height flex column and the option rows had no `flexShrink: 0`. When total row height exceeds the container, the browser shrinks every row equally instead of letting `overflow: auto` scroll, and each row's text overflows its shrunken box.
2. **`background: annotation.color ?? '#FFFFFF'` doesn't handle `'transparent'`.** The `??` fallback only catches `null`/`undefined`, but for widgets without an explicit background the engine supplies the string `"transparent"`, leaving the overlay see-through over the appearance-stream image.

## Fix

- Add `flexShrink: 0` to the option-row styles so rows keep their natural `1.2 × fontSize` line height and the container scrolls.
- Treat a missing or `'transparent'` annotation color as opaque white, since the overlay fully re-draws the list content and must cover the appearance image behind it.

Applied to both the interactive form-fill list box (`fields/listbox.tsx`) and the annotation-mode renderer (`annotations/form-listbox.tsx`), which shared the same two hazards. The COMBOBOX widget is unaffected (native `<select>` at `opacity: 0`).

Includes a patch changeset for `@embedpdf/plugin-form`. Option click handling (single-select and `CHOICE_MULTL_SELECT`) is untouched — the changes are style-only.

<img width="744" height="976" alt="Screenshot 2026-07-07 at 14 48 37" src="https://github.com/user-attachments/assets/3e0b51ef-a20d-49c7-a7da-d56d9617d9df" />
<img width="817" height="982" alt="Screenshot 2026-07-07 at 14 47 53" src="https://github.com/user-attachments/assets/e54f8981-73e2-453f-a670-e6a8161af236" />

