### PR TITLE
fix(engines): guard usePdfiumEngine success path against cancellation (Strict Mode)

### DIFF
--- a/.changeset/pdfium-engine-strict-mode-guard.md
+++ b/.changeset/pdfium-engine-strict-mode-guard.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/engines': patch
+---
+
+fix(engines): `usePdfiumEngine` now discards the engine it created if the effect was torn down before init resolved, instead of committing it. This stops React Strict Mode's dev remount from creating two engines, remounting engine-keyed consumers (e.g. `<EmbedPDF>`) mid-load, and leaking the first engine. Engine teardown also captures its target locally so a `wasmUrl` change mid-init can no longer destroy the replacement engine.

--- a/packages/engines/src/shared/hooks/use-pdfium-engine.ts
+++ b/packages/engines/src/shared/hooks/use-pdfium-engine.ts
@@ -16,6 +16,12 @@ interface UsePdfiumEngineProps {
   fontFallback?: FontFallbackConfig | null;
 }
 
+function disposeEngine(engine: PdfEngine | null) {
+  engine?.closeAllDocuments?.().wait(() => {
+    engine?.destroy?.();
+  }, ignore);
+}
+
 export function usePdfiumEngine(config?: UsePdfiumEngineProps) {
   const {
     wasmUrl = defaultWasmUrl,
@@ -44,6 +50,14 @@ export function usePdfiumEngine(config?: UsePdfiumEngineProps) {
           encoderPoolSize,
           fontFallback,
         });
+
+        // Effect torn down before we resolved (e.g. Strict Mode's dev
+        // remount): discard this engine instead of committing it.
+        if (cancelled) {
+          disposeEngine(pdfEngine);
+          return;
+        }
+
         engineRef.current = pdfEngine;
         setEngine(pdfEngine);
         setLoading(false);
@@ -57,10 +71,8 @@ export function usePdfiumEngine(config?: UsePdfiumEngineProps) {
 
     return () => {
       cancelled = true;
-      engineRef.current?.closeAllDocuments?.().wait(() => {
-        engineRef.current?.destroy?.();
-        engineRef.current = null;
-      }, ignore);
+      disposeEngine(engineRef.current);
+      engineRef.current = null;
     };
   }, [wasmUrl, worker, logger, fontFallback]);
 


### PR DESCRIPTION
## Problem

`usePdfiumEngine`'s init effect only checks its `cancelled` flag on the error path — the success path always calls `setEngine`. Under React Strict Mode (Next.js dev default), the effect mounts → cleans up → remounts before the first `createPdfiumEngine` resolves. Cleanup ran while `engineRef.current` was still `null`, so it disposed nothing; then both invocations resolve and call `setEngine` with two different engine identities.

Result: any consumer keyed on the engine (e.g. `<EmbedPDF>`, keyed on `[engine, plugins]`) remounts, abandoning an in-flight document load, and the first engine leaks.

## Fix

Check `cancelled` after the engine is created; if the effect was already torn down, dispose the freshly created engine and return before committing it. Engine disposal is factored into a small `disposeEngine(engine)` helper, which also captures the engine locally in the teardown path — so a `wasmUrl` change mid-init can no longer destroy the replacement engine from inside the old close callback.

`ignore` is already imported and used, so no new imports. This is the shared React/Preact hook; the Svelte/Vue variants don't share it and are untouched. Includes a patch changeset for `@embedpdf/engines`.