### PR TITLE
fix(build): keep precompiled Svelte output valid across all of Svelte 5

### DIFF
--- a/.changeset/plain-apes-repeat.md
+++ b/.changeset/plain-apes-repeat.md
@@ -1,0 +1,9 @@
+---
+'@embedpdf/core': patch
+---
+
+Make the precompiled Svelte output work on every Svelte 5 runtime
+
+Svelte 5.56 changed the `exclude` argument of the private `rest_props` runtime helper from an array (`exclude.includes(key)`) to a `Set` (`exclude.has(key)`). The `*/svelte` entry points ship precompiled component code, so output built against one side of that change throws on the other: the currently published packages fail with `TypeError: exclude.has is not a function` on Svelte >= 5.56, which aborts the render of every EmbedPDF Svelte component.
+
+The Svelte build now routes those calls through a wrapper that hands the runtime an `exclude` value satisfying both contracts, so one published build stays valid across the whole `svelte: ">=5 <6"` peer range.

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -18,6 +18,7 @@
     "@sveltejs/vite-plugin-svelte": "^6.0.0",
     "@vitejs/plugin-vue": "^6.0.3",
     "glob": "^13.0.0",
+    "magic-string": "^0.30.21",
     "svelte": "^5.39.5",
     "svelte2tsx": "~0.7.33",
     "unplugin-dts": "1.0.0-beta.6",

--- a/packages/build/src/vite/index.ts
+++ b/packages/build/src/vite/index.ts
@@ -5,6 +5,7 @@ import vue from '@vitejs/plugin-vue';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import dts from 'unplugin-dts/vite';
 import { SvelteDtsResolver } from './svelte-dts-resolver.js';
+import { svelteRestPropsCompat } from './svelte-rest-props-compat.js';
 
 const sharedExternal = [/^@embedpdf\/(?!.*\/@framework$)/];
 
@@ -175,7 +176,7 @@ export function defineLibrary() {
           entryPath: 'svelte/index.ts',
           outputPrefix: 'svelte',
           external: [/^svelte($|\/)/],
-          additionalPlugins: [svelte()]
+          additionalPlugins: [svelte(), svelteRestPropsCompat()]
         });
 
       default: // base

--- a/packages/build/src/vite/svelte-rest-props-compat.ts
+++ b/packages/build/src/vite/svelte-rest-props-compat.ts
@@ -1,0 +1,71 @@
+/**
+ * Svelte 5.56 changed the `exclude` argument of the private `rest_props` runtime helper from an
+ * array (`exclude.includes(key)`) to a Set (`exclude.has(key)`). We publish the Svelte entry points
+ * precompiled, so output built against one side of that change throws on the other —
+ * `TypeError: exclude.has is not a function` on >= 5.56, `exclude.includes is not a function` on
+ * < 5.56 — for every consumer in our `svelte: ">=5 <6"` peer range.
+ *
+ * Routing the call through a wrapper that passes a Set carrying an `includes` alias satisfies both
+ * runtimes from a single build. The non-legacy handler only ever reads `exclude` through those two
+ * methods, so nothing else needs to be emulated.
+ */
+import MagicString from 'magic-string';
+import type { Plugin } from 'vite';
+
+const SVELTE_MODULE = /\.svelte(?:\?|$)/;
+const INTERNAL_NAMESPACE =
+  /import\s*\*\s*as\s+([A-Za-z_$][\w$]*)\s*from\s*['"]svelte\/internal\/client['"]/;
+
+const HELPER = '$$rest_props_compat';
+
+const helper = (namespace: string) => `
+function ${HELPER}(props, exclude, name) {
+	// svelte < 5.56 reads \`exclude\` as an array (\`exclude.includes(key)\`), >= 5.56 as a Set
+	// (\`exclude.has(key)\`). We publish precompiled components, so hand the runtime a value that
+	// answers both and keep a single build valid across the whole \`svelte: ">=5 <6"\` peer range.
+	const set = exclude instanceof Set ? exclude : new Set(exclude);
+	if (typeof set.includes !== 'function') set.includes = Set.prototype.has.bind(set);
+	return ${namespace}.rest_props(props, set, name);
+}
+`;
+
+/**
+ * Routes compiled `rest_props` calls through a wrapper that normalises the `exclude` argument.
+ * Returns `null` when the module has no call to rewrite.
+ *
+ * Exported so the rewrite can be exercised on its own; builds use {@link svelteRestPropsCompat}.
+ */
+export function rewriteRestPropsCalls(
+  code: string,
+  id: string,
+): { code: string; map: ReturnType<MagicString['generateMap']> } | null {
+  const namespace = code.match(INTERNAL_NAMESPACE)?.[1];
+  if (!namespace) return null;
+
+  // `legacy_rest_props` is deliberately not matched: its array contract is unchanged in 5.56.
+  const call = new RegExp(`(?<![$\\w])${namespace.replace(/\$/g, '\\$')}\\.rest_props\\(`, 'g');
+  const s = new MagicString(code);
+  let found = false;
+
+  for (const match of code.matchAll(call)) {
+    const start = match.index!;
+    s.overwrite(start, start + match[0].length, `${HELPER}(`);
+    found = true;
+  }
+
+  if (!found) return null;
+
+  s.append(helper(namespace));
+  return { code: s.toString(), map: s.generateMap({ source: id, hires: true }) };
+}
+
+export function svelteRestPropsCompat(): Plugin {
+  return {
+    name: 'embedpdf:svelte-rest-props-compat',
+    enforce: 'post',
+    transform(code, id) {
+      if (!SVELTE_MODULE.test(id)) return null;
+      return rewriteRestPropsCalls(code, id);
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -819,6 +819,9 @@ importers:
       glob:
         specifier: ^13.0.0
         version: 13.0.2
+      magic-string:
+        specifier: ^0.30.21
+        version: 0.30.21
       svelte:
         specifier: ^5.39.5
         version: 5.50.1


### PR DESCRIPTION
Fixes #702.

## Problem

Svelte **5.56.0** changed the `exclude` argument of the private `rest_props` runtime helper from an **array** to a **`Set`** (`src/internal/client/reactivity/props.js`): all four traps of `rest_props_handler` went from `target.exclude.includes(key)` to `target.exclude.has(key)`, and the compiler started hoisting `new Set([...])` instead of emitting an array literal at the call site.

The `*/svelte` entry points ship precompiled component JS. `2.14.4` was built with the pinned `svelte@5.50.1`, so its output passes an array into a runtime that now calls `.has()` on it — every EmbedPDF Svelte component throws `TypeError: exclude.has is not a function` at mount on Svelte >= 5.56, and Svelte aborts the render.

A rebuild against a newer Svelte alone would only move the failure: the peer range is `svelte: ">=5 <6"`, and no single precompiled bundle satisfies both sides of the 5.56 boundary.

## Fix

A small post-compile step in the Svelte build mode (`@embedpdf/build`) rewrites

```js
let restProps = $.rest_props($$props, ['$$slots', '$$events', '$$legacy', 'documentId', 'class']);
```

to call a wrapper appended to the same module:

```js
function $$rest_props_compat(props, exclude, name) {
	const set = exclude instanceof Set ? exclude : new Set(exclude);
	if (typeof set.includes !== 'function') set.includes = Set.prototype.has.bind(set);
	return $.rest_props(props, set, name);
}
```

A `Set` with an `includes` alias satisfies both runtimes: in the non-legacy handler `exclude` is only ever read through `.includes`/`.has` — never iterated, sized or mutated — so nothing else needs emulating. `legacy_rest_props` is deliberately left alone; its array contract did not change.

This keeps `svelte: ">=5 <6"` truthful without dropping support for anyone, and it is source-compatible either way: the same rewrite works whether the compiler emits an array (< 5.56) or a hoisted Set (>= 5.56), so it stays correct when you bump the build toolchain.

## Verification

Same component compiled with each compiler, then mounted (jsdom) against each runtime, asserting rest-prop passthrough and exclusion (the `{...restProps}` spread exercises the `get`, `has`, `ownKeys` and `getOwnPropertyDescriptor` traps):

| component built with | runtime 5.50.1 | runtime 5.56.7 |
|---|---|---|
| 5.50.1, unpatched | ✅ | ❌ `exclude.has is not a function` |
| 5.56.7, unpatched | ❌ `exclude.includes is not a function` | ✅ |
| 5.50.1, **patched** | ✅ | ✅ |
| 5.56.7, **patched** | ✅ | ✅ |

Also built for real through the repo's own pipeline (`@embedpdf/build` → `models` → `core` → `plugin-viewport`, `vite build --mode svelte`, on the lockfile's `svelte@5.50.1`): `plugin-viewport/dist/svelte/index.js` contains no bare `rest_props` call site left, and `pnpm install --frozen-lockfile` is clean.

Two notes from working in the repo, unrelated to this PR: `typescript: "latest"` at the root now resolves to TypeScript 7, which fails `@embedpdf/build`'s `tsc` (`svelte-dts-resolver.ts`) on a fresh install — I pinned 5.9.3 locally to run the build, but left that out of the diff. And `packages/build`'s `svelte: ^5.39.5` resolves to 5.56.x on a fresh resolution, so the next lockfile refresh would have shipped Set-form output and broken users below 5.56 — this change makes that safe either way.

## The longer-term fix

The durable answer is publishing the Svelte layer as uncompiled `.svelte` source (`svelte-package` + the `svelte` export condition), so the consuming app's compiler generates internals matching its own Svelte version. `svelte/internal/client` is explicitly not a stable API, and 5.56 won't be the last change to it. That's a bigger, all-at-once migration of every `*/svelte` subpath (a source-compiled component importing a precompiled one reproduces this exact class of bug), so I kept this PR to the immediate unblock — happy to help with the migration if it's a direction you want to take.

---

I'm happy to add a regression test if you'd like one — I didn't see a test runner wired up in the repo, so I left the verification out of the diff rather than introduce one unasked.

*Investigated and prepared with [Claude Code](https://claude.com/claude-code); every claim above was verified by running it.*
