### PR TITLE
Normalize repository URLs, add bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,13 +64,13 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v5
         with:
-          version: 10.4.0
+          version: 10.34.0
           run_install: false
 
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 

--- a/cloudpdf/admin-api/package.json
+++ b/cloudpdf/admin-api/package.json
@@ -27,7 +27,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/embedpdf/embed-pdf-viewer",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
     "directory": "cloudpdf/admin-api"
   },
   "homepage": "https://www.cloudpdf.com",

--- a/cloudpdf/admin/package.json
+++ b/cloudpdf/admin/package.json
@@ -27,7 +27,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/embedpdf/embed-pdf-viewer",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
     "directory": "cloudpdf/admin"
   },
   "homepage": "https://www.cloudpdf.com",

--- a/cloudpdf/engine/package.json
+++ b/cloudpdf/engine/package.json
@@ -29,7 +29,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/embedpdf/embed-pdf-viewer",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
     "directory": "cloudpdf/engine"
   },
   "homepage": "https://www.cloudpdf.com",

--- a/cloudpdf/server/package.json
+++ b/cloudpdf/server/package.json
@@ -34,7 +34,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/embedpdf/embed-pdf-viewer",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
     "directory": "cloudpdf/server"
   },
   "homepage": "https://www.embedpdf.com",

--- a/cloudpdf/viewer/main/package.json
+++ b/cloudpdf/viewer/main/package.json
@@ -30,7 +30,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/embedpdf/embed-pdf-viewer",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
     "directory": "cloudpdf/viewer/main"
   },
   "homepage": "https://www.cloudpdf.com",

--- a/cloudpdf/viewer/react/package.json
+++ b/cloudpdf/viewer/react/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/embedpdf/embed-pdf-viewer",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
     "directory": "cloudpdf/viewer/react"
   },
   "homepage": "https://www.cloudpdf.com",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "embedpdf",
   "private": true,
   "version": "0.0.0",
-  "packageManager": "pnpm@10.4.0",
+  "packageManager": "pnpm@10.34.0",
   "license": "MIT",
   "scripts": {
     "dev": "turbo run dev --parallel",
@@ -17,6 +17,7 @@
     "build:cloudpdf": "turbo run build --filter=\"./cloudpdf/**\" --filter=\"!@cloudpdf/website\"",
     "build:release": "turbo run build --filter=\"./packages/**\" && pnpm run build:cloudpdf",
     "verify:consume": "pnpm --filter @embedpdf/tooling-consume-fixtures run verify",
+    "bootstrap:package": "node scripts/bootstrap-package.mjs",
     "verify:engine-runtime-packages": "pnpm --filter @embedpdf/engine-runtime run verify:packages",
     "changeset": "changeset",
     "ci:publish": "node scripts/assert-publish-phase.mjs && pnpm publish -r --access public --tag next --publish-branch main --report-summary"

--- a/packages/core/acrojs/package.json
+++ b/packages/core/acrojs/package.json
@@ -41,5 +41,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/core/acrojs"
+  }
 }

--- a/packages/core/annotation/package.json
+++ b/packages/core/annotation/package.json
@@ -43,5 +43,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/core/annotation"
+  }
 }

--- a/packages/core/geometry/package.json
+++ b/packages/core/geometry/package.json
@@ -38,5 +38,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/core/geometry"
+  }
 }

--- a/packages/core/js-sandbox/package.json
+++ b/packages/core/js-sandbox/package.json
@@ -56,5 +56,10 @@
   "sideEffects": false,
   "inlinedDependencies": {
     "@jitl/quickjs-wasmfile-release-sync": "0.32.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/core/js-sandbox"
   }
 }

--- a/packages/core/main/package.json
+++ b/packages/core/main/package.json
@@ -41,5 +41,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/core/main"
+  }
 }

--- a/packages/core/stage/package.json
+++ b/packages/core/stage/package.json
@@ -41,5 +41,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/core/stage"
+  }
 }

--- a/packages/core/ui/package.json
+++ b/packages/core/ui/package.json
@@ -38,5 +38,10 @@
     "vitest": "^2.1.9",
     "@embedpdf/tooling-build": "workspace:*"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/core/ui"
+  }
 }

--- a/packages/engine/core/package.json
+++ b/packages/engine/core/package.json
@@ -45,8 +45,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/embedpdf/embed-pdf-viewer",
-    "directory": "packages/engine-core"
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/engine/core"
   },
   "homepage": "https://www.embedpdf.com",
   "bugs": {

--- a/packages/engine/main/package.json
+++ b/packages/engine/main/package.json
@@ -39,8 +39,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/embedpdf/embed-pdf-viewer",
-    "directory": "packages/engine"
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/engine/main"
   },
   "homepage": "https://www.embedpdf.com",
   "bugs": {

--- a/packages/engine/runtime/npm/darwin-arm64/package.json
+++ b/packages/engine/runtime/npm/darwin-arm64/package.json
@@ -16,5 +16,10 @@
     "lib",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/engine/runtime/npm/darwin-arm64"
+  }
 }

--- a/packages/engine/runtime/npm/darwin-x64/package.json
+++ b/packages/engine/runtime/npm/darwin-x64/package.json
@@ -16,5 +16,10 @@
     "lib",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/engine/runtime/npm/darwin-x64"
+  }
 }

--- a/packages/engine/runtime/npm/linux-arm64/package.json
+++ b/packages/engine/runtime/npm/linux-arm64/package.json
@@ -19,5 +19,10 @@
     "lib",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/engine/runtime/npm/linux-arm64"
+  }
 }

--- a/packages/engine/runtime/npm/linux-x64/package.json
+++ b/packages/engine/runtime/npm/linux-x64/package.json
@@ -19,5 +19,10 @@
     "lib",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/engine/runtime/npm/linux-x64"
+  }
 }

--- a/packages/engine/runtime/npm/linuxmusl-arm64/package.json
+++ b/packages/engine/runtime/npm/linuxmusl-arm64/package.json
@@ -19,5 +19,10 @@
     "lib",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/engine/runtime/npm/linuxmusl-arm64"
+  }
 }

--- a/packages/engine/runtime/npm/linuxmusl-x64/package.json
+++ b/packages/engine/runtime/npm/linuxmusl-x64/package.json
@@ -19,5 +19,10 @@
     "lib",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/engine/runtime/npm/linuxmusl-x64"
+  }
 }

--- a/packages/engine/runtime/npm/wasm32/package.json
+++ b/packages/engine/runtime/npm/wasm32/package.json
@@ -28,5 +28,10 @@
     "wasm-url.d.ts",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/engine/runtime/npm/wasm32"
+  }
 }

--- a/packages/engine/runtime/npm/win32-arm64/package.json
+++ b/packages/engine/runtime/npm/win32-arm64/package.json
@@ -16,5 +16,10 @@
     "lib",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/engine/runtime/npm/win32-arm64"
+  }
 }

--- a/packages/engine/runtime/npm/win32-x64/package.json
+++ b/packages/engine/runtime/npm/win32-x64/package.json
@@ -16,5 +16,10 @@
     "lib",
     "README.md",
     "LICENSE"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/engine/runtime/npm/win32-x64"
+  }
 }

--- a/packages/engine/runtime/package.json
+++ b/packages/engine/runtime/package.json
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/embedpdf/embed-pdf-viewer",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
     "directory": "packages/engine/runtime"
   },
   "homepage": "https://www.embedpdf.com",

--- a/packages/engine/services/package.json
+++ b/packages/engine/services/package.json
@@ -29,8 +29,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/embedpdf/embed-pdf-viewer",
-    "directory": "packages/engine-services"
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/engine/services"
   },
   "homepage": "https://www.embedpdf.com",
   "bugs": {

--- a/packages/framework/angular/package.json
+++ b/packages/framework/angular/package.json
@@ -55,5 +55,10 @@
     "rxjs": "^7.8.0",
     "typescript": "~5.8.3"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/framework/angular"
+  }
 }

--- a/packages/framework/react/package.json
+++ b/packages/framework/react/package.json
@@ -179,5 +179,10 @@
   "license": "Apache-2.0",
   "inlinedDependencies": {
     "zod": "3.25.76"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/framework/react"
   }
 }

--- a/packages/framework/web/package.json
+++ b/packages/framework/web/package.json
@@ -38,5 +38,10 @@
     "vitest": "^2.1.9",
     "@embedpdf/tooling-build": "workspace:*"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/framework/web"
+  }
 }

--- a/packages/plugin/annotation/package.json
+++ b/packages/plugin/annotation/package.json
@@ -51,5 +51,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/annotation"
+  }
 }

--- a/packages/plugin/commands/package.json
+++ b/packages/plugin/commands/package.json
@@ -44,5 +44,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/commands"
+  }
 }

--- a/packages/plugin/form/package.json
+++ b/packages/plugin/form/package.json
@@ -47,5 +47,10 @@
     "@embedpdf/engine": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/form"
+  }
 }

--- a/packages/plugin/i18n/package.json
+++ b/packages/plugin/i18n/package.json
@@ -41,5 +41,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/i18n"
+  }
 }

--- a/packages/plugin/interaction/package.json
+++ b/packages/plugin/interaction/package.json
@@ -42,5 +42,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/interaction"
+  }
 }

--- a/packages/plugin/link/package.json
+++ b/packages/plugin/link/package.json
@@ -47,5 +47,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/link"
+  }
 }

--- a/packages/plugin/metadata/package.json
+++ b/packages/plugin/metadata/package.json
@@ -41,5 +41,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/metadata"
+  }
 }

--- a/packages/plugin/page-edit/package.json
+++ b/packages/plugin/page-edit/package.json
@@ -41,5 +41,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/page-edit"
+  }
 }

--- a/packages/plugin/redaction/package.json
+++ b/packages/plugin/redaction/package.json
@@ -45,5 +45,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/redaction"
+  }
 }

--- a/packages/plugin/render/package.json
+++ b/packages/plugin/render/package.json
@@ -42,5 +42,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/render"
+  }
 }

--- a/packages/plugin/search/package.json
+++ b/packages/plugin/search/package.json
@@ -44,5 +44,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/search"
+  }
 }

--- a/packages/plugin/selection/package.json
+++ b/packages/plugin/selection/package.json
@@ -44,5 +44,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/selection"
+  }
 }

--- a/packages/plugin/shell/package.json
+++ b/packages/plugin/shell/package.json
@@ -41,5 +41,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/shell"
+  }
 }

--- a/packages/plugin/stage/package.json
+++ b/packages/plugin/stage/package.json
@@ -44,5 +44,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/stage"
+  }
 }

--- a/packages/plugin/stamp/package.json
+++ b/packages/plugin/stamp/package.json
@@ -46,5 +46,10 @@
     "@embedpdf/engine": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/stamp"
+  }
 }

--- a/packages/plugin/view-manager/package.json
+++ b/packages/plugin/view-manager/package.json
@@ -39,5 +39,10 @@
     "@embedpdf/tooling-build": "workspace:*"
   },
   "license": "Apache-2.0",
-  "sideEffects": false
+  "sideEffects": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/plugin/view-manager"
+  }
 }

--- a/packages/viewer/chrome/package.json
+++ b/packages/viewer/chrome/package.json
@@ -61,5 +61,10 @@
       "./package.json": "./package.json",
       "./styles.css": "./src/styles.css"
     }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/viewer/chrome"
   }
 }

--- a/packages/viewer/main/package.json
+++ b/packages/viewer/main/package.json
@@ -58,5 +58,10 @@
     "./src/doors/*.ts",
     "./dist/*.js",
     "./dist/**/*.js"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/viewer/main"
+  }
 }

--- a/packages/viewer/react/package.json
+++ b/packages/viewer/react/package.json
@@ -55,5 +55,10 @@
       },
       "./package.json": "./package.json"
     }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
+    "directory": "packages/viewer/react"
   }
 }

--- a/scripts/bootstrap-package.mjs
+++ b/scripts/bootstrap-package.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+// New-package name bootstrap — the local half of trusted publishing.
+//
+// npm cannot attach a trusted-publisher configuration to a package that does
+// not exist yet, and CI has no long-lived token (by design). So a brand-new
+// package is born in two steps:
+//
+//   1. THIS SCRIPT (run by a human, locally): publish a tiny claim stub —
+//      version 0.0.0-bootstrap.0 under the `bootstrap` dist-tag — using your
+//      interactive npm session + 2FA OTP. No token is involved anywhere;
+//      the OTP prompt is the one publish path npm never restricts.
+//   2. Attach the trusted publisher to the now-existing name (command is
+//      printed on success), after which the next release train publishes the
+//      real package from CI via OIDC like every other workspace package.
+//
+// The stub is synthesized in a temp directory OUTSIDE the repo: the repo
+// .npmrc wires auth to ${NPM_TOKEN}, and this flow must work with no token
+// in the environment at all. Only your user-level npm login applies.
+//
+// Usage:
+//   pnpm bootstrap:package <@scope/name | workspace/dir> [--dry-run]
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CANONICAL_REPO_URL = 'git+https://github.com/embedpdf/embed-pdf-viewer.git';
+const STUB_VERSION = '0.0.0-bootstrap.0';
+const STUB_TAG = 'bootstrap';
+
+function fail(lines) {
+  console.error(['✖ bootstrap aborted (scripts/bootstrap-package.mjs):', ...lines].join('\n'));
+  process.exit(1);
+}
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const target = args.find((a) => !a.startsWith('--'));
+
+if (!target) {
+  console.log('Usage: pnpm bootstrap:package <@scope/name | workspace/dir> [--dry-run]');
+  process.exit(args.length === 0 ? 1 : 0);
+}
+if (process.env.CI) {
+  fail(['  this is a local human ritual (interactive 2FA OTP); it must not run in CI.']);
+}
+
+// Ask the workspace, never reconstruct: resolve the target to a workspace
+// package whether the caller passed a name or a directory.
+const projects = JSON.parse(
+  execFileSync('pnpm', ['ls', '-r', '--depth', '-1', '--json'], {
+    cwd: root,
+    encoding: 'utf8',
+    // stderr suppressed: the repo .npmrc references ${NPM_TOKEN}, which is
+    // deliberately unset in this flow and would only print scary warnings.
+    stdio: ['ignore', 'pipe', 'ignore'],
+  }),
+).filter((p) => p.name && p.path);
+
+const project = target.startsWith('@')
+  ? projects.find((p) => p.name === target)
+  : projects.find((p) => path.resolve(root, target) === p.path);
+if (!project) {
+  fail([
+    `  ${target} is not a workspace package (checked name and path).`,
+    '  Create the package directory with its package.json first.',
+  ]);
+}
+
+const manifest = JSON.parse(readFileSync(path.join(project.path, 'package.json'), 'utf8'));
+if (manifest.private === true) {
+  fail([`  ${manifest.name} is private — private packages are never published or bootstrapped.`]);
+}
+
+const relDir = path.relative(root, project.path);
+const repository = {
+  type: 'git',
+  url: normalizeGitUrl(manifest.repository?.url ?? CANONICAL_REPO_URL),
+  directory: manifest.repository?.directory ?? relDir,
+};
+if (!manifest.repository?.url || !manifest.repository?.directory) {
+  console.warn(
+    `⚠ ${manifest.name}: package.json is missing repository.url/.directory — the stub derives\n` +
+      `  them (${repository.url} @ ${repository.directory}), but the REAL manifest needs the\n` +
+      '  fields before its first CI publish (npm provenance requires them).',
+  );
+}
+
+// A temp cwd keeps the repo .npmrc (and its ${NPM_TOKEN} substitution) out of
+// scope for every registry interaction below.
+const workDir = mkdtempSync(path.join(os.tmpdir(), 'epdf-bootstrap-'));
+process.on('exit', () => rmSync(workDir, { recursive: true, force: true }));
+
+// Already published? Then there is nothing to claim — go straight to trust.
+const view = spawnSync('npm', ['view', manifest.name, 'versions', '--json'], {
+  cwd: workDir,
+  encoding: 'utf8',
+});
+const missing = view.status !== 0 && /E404|not found/i.test(view.stderr + view.stdout);
+if (view.status === 0) {
+  console.log(`✔ ${manifest.name} already exists on the registry — no bootstrap needed.`);
+  printTrustSteps(manifest.name);
+  process.exit(0);
+}
+if (!missing) {
+  fail([
+    `  could not determine whether ${manifest.name} exists on the registry:`,
+    ...(view.stderr || 'no error output').trim().split('\n').map((l) => `    ${l}`),
+  ]);
+}
+
+const stub = {
+  name: manifest.name,
+  version: STUB_VERSION,
+  description: `${manifest.description ?? manifest.name} (name claim — real releases are published from CI via npm trusted publishing)`,
+  license: manifest.license ?? 'Apache-2.0',
+  repository,
+};
+writeFileSync(path.join(workDir, 'package.json'), `${JSON.stringify(stub, null, 2)}\n`);
+writeFileSync(
+  path.join(workDir, 'README.md'),
+  [
+    `# ${manifest.name}`,
+    '',
+    `This version (\`${STUB_VERSION}\`, dist-tag \`${STUB_TAG}\`) is a name claim so npm`,
+    'trusted publishing can be attached to the package. Real releases are published',
+    `from CI: https://github.com/embedpdf/embed-pdf-viewer (${relDir}).`,
+    '',
+  ].join('\n'),
+);
+
+console.log(
+  `▸ publishing claim stub ${manifest.name}@${STUB_VERSION} (dist-tag: ${STUB_TAG})` +
+    `${dryRun ? ' [dry-run]' : ' — npm will prompt for your 2FA OTP'}`,
+);
+const publish = spawnSync(
+  'npm',
+  ['publish', '--access', 'public', '--tag', STUB_TAG, ...(dryRun ? ['--dry-run'] : [])],
+  { cwd: workDir, stdio: 'inherit' },
+);
+if (publish.status !== 0) {
+  fail([
+    '  npm publish failed (see output above).',
+    '  Not logged in? Run `npm login` first — the whole point of this flow is that it',
+    '  uses your interactive session + OTP, never a token.',
+  ]);
+}
+
+console.log(`✔ ${dryRun ? 'dry-run complete for' : 'claimed'} ${manifest.name}`);
+printTrustSteps(manifest.name);
+
+function printTrustSteps(name) {
+  // Mirror the workflow's actual environment so the trusted-publisher config
+  // can never disagree with what release.yml presents at publish time.
+  const releaseYml = readFileSync(path.join(root, '.github/workflows/release.yml'), 'utf8');
+  const environment = releaseYml.match(/^\s*environment:\s*([\w-]+)\s*$/m)?.[1];
+  console.log(
+    [
+      '',
+      'Next: attach the trusted publisher (needs account 2FA; npm >= 11.15 via npx):',
+      '',
+      `  npx npm@latest trust github ${name} \\`,
+      '    --repo embedpdf/embed-pdf-viewer \\',
+      `    --file release.yml \\`,
+      ...(environment ? [`    --environment ${environment} \\`] : []),
+      '    --allow-publish',
+      '',
+      ...(environment
+        ? []
+        : [
+            'note: release.yml pins no GitHub environment yet — once it gains one',
+            '(e.g. npm-release), re-run trust with --environment to match.',
+            '',
+          ]),
+      'or via the web UI: npmjs.com package page → Settings → Trusted Publisher.',
+      'The next release train then publishes the real package from CI via OIDC.',
+    ].join('\n'),
+  );
+}
+
+function normalizeGitUrl(url) {
+  // npm normalizes repository URLs to `git+https://…​.git` at publish time;
+  // do it up front so the stub publishes without manifest-correction warnings.
+  let out = url;
+  if (!out.startsWith('git+')) out = `git+${out}`;
+  if (!out.endsWith('.git')) out = `${out}.git`;
+  return out;
+}


### PR DESCRIPTION
Update CI and workspace metadata: bump PNPM and Node versions in release workflow and update root packageManager to pnpm@10.34.0. Add a new interactive bootstrap script (scripts/bootstrap-package.mjs) and a pnpm script (bootstrap:package) to publish a name-claim stub for new packages. Normalize and add repository blocks across many package.json files (git+https://github.com/embedpdf/embed-pdf-viewer.git plus proper directory fields) and fix several package repository.directory paths so npm provenance and CI publishing work correctly.