### PR TITLE
Unpin pnpm/action-setup version in workflows

### DIFF
--- a/.github/workflows/build-engine-runtime.yml
+++ b/.github/workflows/build-engine-runtime.yml
@@ -83,8 +83,6 @@ jobs:
       - uses: actions/checkout@v6
       - if: ${{ !contains(matrix.target, 'linuxmusl') }}
         uses: pnpm/action-setup@v5
-        with:
-          version: 10.4.0
       - if: ${{ !contains(matrix.target, 'linuxmusl') }}
         uses: actions/setup-node@v6
         with:
@@ -166,8 +164,6 @@ jobs:
       - uses: actions/checkout@v6
       - if: ${{ !contains(matrix.target, 'linuxmusl') }}
         uses: pnpm/action-setup@v5
-        with:
-          version: 10.4.0
       - if: ${{ !contains(matrix.target, 'linuxmusl') }}
         uses: actions/setup-node@v6
         with:
@@ -240,8 +236,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5
-        with:
-          version: 10.4.0
       - uses: actions/setup-node@v6
         with:
           node-version: 22
@@ -298,8 +292,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v5
-        with:
-          version: 10.4.0
       - uses: actions/setup-node@v6
         with:
           node-version: 22

--- a/.github/workflows/engine-conformance.yml
+++ b/.github/workflows/engine-conformance.yml
@@ -47,8 +47,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: 10.4.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/license-security.yml
+++ b/.github/workflows/license-security.yml
@@ -44,8 +44,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v5
-        with:
-          version: 10.4.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v5
         with:
-          version: 10.34.0
           run_install: false
 
       - name: Setup Node


### PR DESCRIPTION
Remove explicit `version` inputs for pnpm/action-setup across multiple GitHub workflow files (.github/workflows/build-engine-runtime.yml, engine-conformance.yml, license-security.yml, release.yml). This removes hardcoded pins (previously 10.4.0 and 10.34.0) so the action will use its defaults/latest behavior, simplifying maintenance and avoiding the need to update these workflow files for pnpm action version changes.