### PR TITLE
Normalize SDK branding to CloudPDF

### DIFF
--- a/.github/workflows/sdk-generate.yml
+++ b/.github/workflows/sdk-generate.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-      - run: node --test fern/scripts/sdk-version.test.mjs fern/scripts/sdk-repositories.test.mjs
+      - run: node --test fern/scripts/*.test.mjs
 
   generate:
     needs: version-policy
@@ -188,9 +188,16 @@ jobs:
             php)
               find src -type f -name '*.php' -print0 | xargs -0 -P 4 -n1 php -l >/dev/null
               composer validate --no-check-publish --no-interaction
+              php_package_test="$(mktemp -d)"
+              tar --exclude=.git --exclude=vendor -cf - . | tar -xf - -C "$php_package_test"
+              (
+                cd "$php_package_test"
+                composer dump-autoload --no-dev --no-interaction --optimize --strict-psr --quiet
+                php -r "require 'vendor/autoload.php'; \$base = new CloudPDF\Exceptions\CloudPDFException('test'); \$api = new CloudPDF\Exceptions\CloudPDFApiException('test', 500, null); if (!(\$base instanceof Exception) || !(\$api instanceof CloudPDF\Exceptions\CloudPDFException)) { throw new RuntimeException('CloudPDF exception autoload verification failed'); }"
+              )
               ;;
             csharp)
-              dotnet build src/CloudpdfApi/CloudpdfApi.csproj -c Release -f net8.0
+              dotnet build src/CloudPDF/CloudPDF.csproj -c Release -f net8.0
               ;;
             go)
               go test -run '^$' ./...
@@ -201,6 +208,9 @@ jobs:
             ruby)
               ruby -e 'Dir["lib/**/*.rb"].each { |file| RubyVM::InstructionSequence.compile_file(file) }'
               gem build cloudpdf.gemspec --output /tmp/cloudpdf-ruby.gem
+              ruby_gem_home="$(mktemp -d)"
+              gem install /tmp/cloudpdf-ruby.gem --local --no-document --install-dir "$ruby_gem_home"
+              GEM_HOME="$ruby_gem_home" GEM_PATH="$ruby_gem_home" ruby -e 'require "cloudpdf"; abort "CloudPDF::Client was not packaged" unless defined?(CloudPDF::Client)'
               ;;
           esac
 

--- a/fern/README.md
+++ b/fern/README.md
@@ -19,6 +19,39 @@ published by this workflow.
 | Java       | `embedpdf/cloudpdf-sdk-java`       |
 | Ruby       | `embedpdf/cloudpdf-sdk-ruby`       |
 
+## Public package identities
+
+CloudPDF is treated as an indivisible brand name in generated documentation,
+namespaces, modules, and root client types. Registry identifiers still follow
+each ecosystem's casing and scoping conventions.
+
+| SDK        | Package identity                         | Primary client                           |
+| ---------- | ---------------------------------------- | ---------------------------------------- |
+| TypeScript | `@cloudpdf/sdk`                          | `CloudPDFClient`                         |
+| Python     | `cloudpdf`                               | `CloudPDFClient` / `AsyncCloudPDFClient` |
+| PHP        | `cloudpdf/sdk`                           | `CloudPDF\CloudPDFClient`                |
+| .NET       | `CloudPDF`                               | `CloudPDF.CloudPDFClient`                |
+| Go         | `github.com/embedpdf/cloudpdf-sdk-go/v3` | idiomatic `NewClient`                    |
+| Java       | `com.cloudpdf:sdk`                       | `com.cloudpdf.api.CloudPDFClient`        |
+| Ruby       | `cloudpdf`                               | `CloudPDF::Client`                       |
+
+Fern derives some human-readable branding and identifiers from its lowercase
+organization slug. The required post-generation metadata step therefore
+structurally normalizes generated README titles, descriptions, and visible code
+without rewriting link destinations. It also corrects PHP's non-configurable
+base exception casing, removes Fern's stale PHP formatter caches, and separates
+Ruby's lowercase gem and require identity (`cloudpdf`) from its public module
+(`CloudPDF`). Generator configuration controls all other public code
+identifiers.
+
+Validation recursively checks generated text and paths. Every case-insensitive
+brand match must use the registry form `cloudpdf` or the public form `CloudPDF`;
+Markdown link destinations and binary files are excluded. The PHP build also
+proves Composer PSR-4 loading by constructing both renamed exception classes.
+The Ruby build installs the generated gem into an isolated `GEM_HOME` and
+requires `cloudpdf`, proving the packaged require graph rather than only the
+source checkout.
+
 The normal pull-request and `main` triggers are read-only validation. The
 release workflow calls the same generation workflow with repository sync
 enabled only after the multi-architecture server manifest exists and passes

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -25,6 +25,14 @@ groups:
           reference-url: https://www.cloudpdf.com
           license: Apache-2.0
         config:
+          naming:
+            namespace: CloudPDF
+            client: CloudPDFClient
+            error: CloudPDFError
+            timeoutError: CloudPDFTimeoutError
+            environment: CloudPDFEnvironment
+            environmentUrls: CloudPDFEnvironmentUrls
+            version: CloudPDFVersion
           packageJson:
             name: '@cloudpdf/sdk'
             description: The official TypeScript SDK for the CloudPDF API.
@@ -47,6 +55,8 @@ groups:
           license: Apache-2.0
         config:
           package_name: cloudpdf
+          client_class_name: CloudPDFClient
+          environment_class_name: CloudPDFEnvironment
   php:
     generators:
       - name: fern-php-sdk
@@ -61,8 +71,9 @@ groups:
           reference-url: https://www.cloudpdf.com
           license: Apache-2.0
         config:
-          namespace: Cloudpdf
-          packageName: cloudpdf/cloudpdf
+          namespace: CloudPDF
+          clientName: CloudPDFClient
+          packageName: cloudpdf/sdk
           composerJson:
             license: Apache-2.0
             homepage: https://www.cloudpdf.com
@@ -80,8 +91,12 @@ groups:
           reference-url: https://www.cloudpdf.com
           license: Apache-2.0
         config:
-          namespace: CloudpdfApi
-          package-id: CloudpdfApi
+          namespace: CloudPDF
+          package-id: CloudPDF
+          client-class-name: CloudPDFClient
+          environment-class-name: CloudPDFEnvironment
+          base-exception-class-name: CloudPDFException
+          base-api-exception-class-name: CloudPDFApiException
   go:
     generators:
       - name: fern-go-sdk
@@ -115,8 +130,11 @@ groups:
           license: Apache-2.0
         config:
           group: com.cloudpdf
-          artifact: cloudpdf
-          package-prefix: com.cloudpdf.api
+          artifact: sdk
+          package-prefix: com.cloudpdf
+          client-class-name: CloudPDFClient
+          base-exception-class-name: CloudPDFException
+          base-api-exception-class-name: CloudPDFApiException
   ruby:
     generators:
       - name: fern-ruby-sdk
@@ -130,3 +148,5 @@ groups:
           package-description: The official Ruby SDK for the CloudPDF API.
           reference-url: https://www.cloudpdf.com
           license: Apache-2.0
+        config:
+          moduleName: CloudPDF

--- a/fern/repository-overlays/csharp/.github/workflows/sdk-ci.yml
+++ b/fern/repository-overlays/csharp/.github/workflows/sdk-ci.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
-      - run: dotnet build src/CloudpdfApi/CloudpdfApi.csproj -c Release -f net8.0
+      - run: dotnet build src/CloudPDF/CloudPDF.csproj -c Release -f net8.0

--- a/fern/repository-overlays/php/.github/workflows/sdk-ci.yml
+++ b/fern/repository-overlays/php/.github/workflows/sdk-ci.yml
@@ -20,3 +20,10 @@ jobs:
           tools: composer
       - run: find src -type f -name '*.php' -print0 | xargs -0 -P 4 -n1 php -l >/dev/null
       - run: composer validate --no-check-publish --no-interaction
+      - name: Verify packaged autoloading
+        run: |
+          php_package_test="$(mktemp -d)"
+          tar --exclude=.git --exclude=vendor -cf - . | tar -xf - -C "$php_package_test"
+          cd "$php_package_test"
+          composer dump-autoload --no-dev --no-interaction --optimize --strict-psr --quiet
+          php -r "require 'vendor/autoload.php'; \$base = new CloudPDF\Exceptions\CloudPDFException('test'); \$api = new CloudPDF\Exceptions\CloudPDFApiException('test', 500, null); if (!(\$base instanceof Exception) || !(\$api instanceof CloudPDF\Exceptions\CloudPDFException)) { throw new RuntimeException('CloudPDF exception autoload verification failed'); }"

--- a/fern/repository-overlays/ruby/.github/workflows/sdk-ci.yml
+++ b/fern/repository-overlays/ruby/.github/workflows/sdk-ci.yml
@@ -19,3 +19,8 @@ jobs:
           ruby-version: '3.3'
       - run: ruby -e 'Dir["lib/**/*.rb"].each { |file| RubyVM::InstructionSequence.compile_file(file) }'
       - run: gem build cloudpdf.gemspec --output /tmp/cloudpdf-ruby.gem
+      - name: Verify packaged require graph
+        run: |
+          ruby_gem_home="$(mktemp -d)"
+          gem install /tmp/cloudpdf-ruby.gem --local --no-document --install-dir "$ruby_gem_home"
+          GEM_HOME="$ruby_gem_home" GEM_PATH="$ruby_gem_home" ruby -e 'require "cloudpdf"; abort "CloudPDF::Client was not packaged" unless defined?(CloudPDF::Client)'

--- a/fern/scripts/record-sdk-metadata.mjs
+++ b/fern/scripts/record-sdk-metadata.mjs
@@ -5,6 +5,7 @@ import { copyFileSync, readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 import { LANGUAGES, mapSdkVersion, readCanonicalVersion } from './sdk-version.mjs';
+import { normalizeSdkBranding } from './sdk-branding.mjs';
 
 const language = process.argv[2];
 if (!LANGUAGES.includes(language)) {
@@ -45,6 +46,7 @@ writeFileSync(
 );
 
 copyFileSync(`${repositoryDirectory}cloudpdf/contract/LICENSE`, `${outputDirectory}/LICENSE`);
+normalizeSdkBranding(outputDirectory, language);
 
 // The Ruby generator intentionally leaves registry metadata in its generated
 // custom.gemspec.rb hook. Fill that hook deterministically until each SDK has
@@ -69,7 +71,7 @@ end
 // prerelease SDKs fail to compile. Preserve the NuGet package version and use a
 // stable numeric binary version for the current major/minor/patch line.
 if (language === 'csharp') {
-  const projectPath = `${outputDirectory}/src/CloudpdfApi/CloudpdfApi.csproj`;
+  const projectPath = `${outputDirectory}/src/CloudPDF/CloudPDF.csproj`;
   const numericBinaryVersion = `${canonicalVersion.split('-')[0]}.0`;
   const project = readFileSync(projectPath, 'utf8')
     .replace(

--- a/fern/scripts/sdk-branding.mjs
+++ b/fern/scripts/sdk-branding.mjs
@@ -1,0 +1,143 @@
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+
+const LANGUAGE_NAMES = Object.freeze({
+  typescript: 'TypeScript',
+  python: 'Python',
+  php: 'PHP',
+  csharp: '.NET',
+  go: 'Go',
+  java: 'Java',
+  ruby: 'Ruby',
+});
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function normalizeSdkReadme(readme, language) {
+  const languageName = LANGUAGE_NAMES[language];
+  if (!languageName) throw new Error(`Unsupported SDK language ${language}`);
+
+  const generatedLanguageName = language === 'csharp' ? 'C#' : languageName;
+  const escapedGeneratedLanguageName = escapeRegExp(generatedLanguageName);
+  const expectedTitle = `# CloudPDF ${languageName} SDK`;
+  const lines = readme.split('\n');
+  const generatedTitle = new RegExp(`^# Cloud(?:pdf|Pdf) ${escapedGeneratedLanguageName} Library$`);
+  if (lines[0] !== expectedTitle && !generatedTitle.test(lines[0])) {
+    throw new Error(`${language}: generated README title format changed`);
+  }
+  lines[0] = expectedTitle;
+
+  const generatedDescription = new RegExp(
+    `^The Cloud(?:pdf|Pdf) ${escapedGeneratedLanguageName} library provides convenient access to the Cloud(?:pdf|Pdf) APIs from ${escapedGeneratedLanguageName}\\.$`,
+  );
+  const descriptionIndex = lines.findIndex((line) => generatedDescription.test(line));
+  const officialDescription = `The official ${languageName} SDK for the CloudPDF API.`;
+  if (descriptionIndex === -1 && !lines.includes(officialDescription)) {
+    throw new Error(`${language}: generated README description format changed`);
+  }
+  if (descriptionIndex !== -1) lines[descriptionIndex] = officialDescription;
+
+  return normalizeMarkdownCodeIdentifiers(lines.join('\n'), language);
+}
+
+function normalizeCodeIdentifiers(code, language) {
+  let normalized = code.replaceAll(/Cloud(?:pdf|Pdf)/g, 'CloudPDF');
+  if (language === 'ruby') {
+    normalized = normalized.replaceAll('require "CloudPDF"', 'require "cloudpdf"');
+  }
+  return normalized;
+}
+
+function normalizeMarkdownCodeIdentifiers(markdown, language) {
+  let fenceMarker = null;
+  return markdown
+    .split('\n')
+    .map((line) => {
+      const fence = /^\s*(`{3,}|~{3,})/.exec(line)?.[1];
+      if (fence != null) {
+        if (fenceMarker == null) fenceMarker = fence[0];
+        else if (fence[0] === fenceMarker) fenceMarker = null;
+        return line;
+      }
+      if (fenceMarker != null) return normalizeCodeIdentifiers(line, language);
+      return line.replace(/(`+)([^`]*?)\1/g, (_match, ticks, code) => {
+        return `${ticks}${normalizeCodeIdentifiers(code, language)}${ticks}`;
+      });
+    })
+    .join('\n');
+}
+
+function filesBelow(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = `${directory}/${entry.name}`;
+    return entry.isDirectory() ? filesBelow(path) : [path];
+  });
+}
+
+function renameCaseAware(source, destination) {
+  if (!existsSync(source)) {
+    if (existsSync(destination)) return;
+    throw new Error(`Expected generated file ${source}`);
+  }
+  const temporary = `${source}.cloudpdf-normalizing`;
+  renameSync(source, temporary);
+  renameSync(temporary, destination);
+}
+
+function normalizePhpExceptions(outputDirectory) {
+  const sourceDirectory = `${outputDirectory}/src`;
+  for (const path of filesBelow(outputDirectory)) {
+    if (path.endsWith('/.php-cs-fixer.cache')) {
+      unlinkSync(path);
+      continue;
+    }
+    if (!statSync(path).isFile() || !path.endsWith('.php')) continue;
+    const source = readFileSync(path, 'utf8');
+    const normalized = source
+      .replaceAll('CloudpdfApiException', 'CloudPDFApiException')
+      .replaceAll('CloudpdfException', 'CloudPDFException');
+    if (normalized !== source) writeFileSync(path, normalized);
+  }
+
+  renameCaseAware(
+    `${sourceDirectory}/Exceptions/CloudpdfApiException.php`,
+    `${sourceDirectory}/Exceptions/CloudPDFApiException.php`,
+  );
+  renameCaseAware(
+    `${sourceDirectory}/Exceptions/CloudpdfException.php`,
+    `${sourceDirectory}/Exceptions/CloudPDFException.php`,
+  );
+}
+
+function normalizeRubyPackage(outputDirectory) {
+  renameCaseAware(`${outputDirectory}/CloudPDF.gemspec`, `${outputDirectory}/cloudpdf.gemspec`);
+  renameCaseAware(`${outputDirectory}/lib/CloudPDF.rb`, `${outputDirectory}/lib/cloudpdf.rb`);
+
+  const gemspecPath = `${outputDirectory}/cloudpdf.gemspec`;
+  const gemspec = readFileSync(gemspecPath, 'utf8').replace(
+    'spec.name = "CloudPDF"',
+    'spec.name = "cloudpdf"',
+  );
+  if (!gemspec.includes('spec.name = "cloudpdf"')) {
+    throw new Error('ruby: generated gemspec package-name format changed');
+  }
+  writeFileSync(gemspecPath, gemspec);
+}
+
+export function normalizeSdkBranding(outputDirectory, language) {
+  if (language === 'php') normalizePhpExceptions(outputDirectory);
+  if (language === 'ruby') normalizeRubyPackage(outputDirectory);
+
+  const readmePath = `${outputDirectory}/README.md`;
+  const readme = readFileSync(readmePath, 'utf8');
+  writeFileSync(readmePath, normalizeSdkReadme(readme, language));
+}

--- a/fern/scripts/sdk-branding.test.mjs
+++ b/fern/scripts/sdk-branding.test.mjs
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+
+import { normalizeSdkBranding, normalizeSdkReadme } from './sdk-branding.mjs';
+
+test('normalizes generated SDK README branding', () => {
+  const generated = `# Cloudpdf PHP Library
+
+[badge](https://example.com?utm_source=Cloudpdf%2FPHP)
+
+The Cloudpdf PHP library provides convenient access to the Cloudpdf APIs from PHP.
+
+~~~php
+use Cloudpdf\\CloudpdfClient;
+~~~
+`;
+
+  assert.equal(
+    normalizeSdkReadme(generated, 'php'),
+    `# CloudPDF PHP SDK
+
+[badge](https://example.com?utm_source=Cloudpdf%2FPHP)
+
+The official PHP SDK for the CloudPDF API.
+
+~~~php
+use CloudPDF\\CloudPDFClient;
+~~~
+`,
+  );
+});
+
+test('normalizes inline code without changing Markdown link destinations', () => {
+  const generated = `# Cloudpdf PHP Library
+
+[Cloudpdf docs](https://example.com/Cloudpdf?utm_source=Cloudpdf)
+
+The Cloudpdf PHP library provides convenient access to the Cloudpdf APIs from PHP.
+
+Catch \`CloudpdfException\`.
+`;
+
+  const normalized = normalizeSdkReadme(generated, 'php');
+  assert.match(
+    normalized,
+    /\[Cloudpdf docs\]\(https:\/\/example\.com\/Cloudpdf\?utm_source=Cloudpdf\)/,
+  );
+  assert.match(normalized, /Catch `CloudPDFException`\./);
+});
+
+test('uses .NET rather than the generator C# label', () => {
+  const generated = `# Cloudpdf C# Library
+
+The Cloudpdf C# library provides convenient access to the Cloudpdf APIs from C#.
+`;
+
+  assert.match(normalizeSdkReadme(generated, 'csharp'), /^# CloudPDF \.NET SDK$/m);
+  assert.match(
+    normalizeSdkReadme(generated, 'csharp'),
+    /^The official \.NET SDK for the CloudPDF API\.$/m,
+  );
+});
+
+test('fails visibly if Fern changes its generated README description', () => {
+  assert.throws(
+    () => normalizeSdkReadme('# Cloudpdf Ruby Library\n\nUnexpected copy.\n', 'ruby'),
+    /generated README description format changed/,
+  );
+});
+
+test('fails visibly if Fern changes its generated README title', () => {
+  assert.throws(
+    () =>
+      normalizeSdkReadme(
+        '# Unexpected Ruby heading\n\nThe Cloudpdf Ruby library provides convenient access to the Cloudpdf APIs from Ruby.\n',
+        'ruby',
+      ),
+    /generated README title format changed/,
+  );
+});
+
+test('normalizes PHP exception identifiers that the generator cannot configure', () => {
+  const outputDirectory = mkdtempSync(`${tmpdir()}/cloudpdf-php-sdk-`);
+  try {
+    mkdirSync(`${outputDirectory}/src/Exceptions`, { recursive: true });
+    mkdirSync(`${outputDirectory}/src/Documents`, { recursive: true });
+    mkdirSync(`${outputDirectory}/tests`, { recursive: true });
+    writeFileSync(
+      `${outputDirectory}/src/.php-cs-fixer.cache`,
+      '{"hashes":{"Exceptions/CloudpdfException.php":"hash"}}\n',
+    );
+    writeFileSync(
+      `${outputDirectory}/README.md`,
+      '# Cloudpdf PHP Library\n\nThe Cloudpdf PHP library provides convenient access to the Cloudpdf APIs from PHP.\n',
+    );
+    writeFileSync(
+      `${outputDirectory}/src/Exceptions/CloudpdfException.php`,
+      'class CloudpdfException {}\n',
+    );
+    writeFileSync(
+      `${outputDirectory}/src/Exceptions/CloudpdfApiException.php`,
+      'class CloudpdfApiException extends CloudpdfException {}\n',
+    );
+    writeFileSync(
+      `${outputDirectory}/src/Documents/Client.php`,
+      'use CloudPDF\\Exceptions\\CloudpdfApiException;\n',
+    );
+    writeFileSync(
+      `${outputDirectory}/tests/ExceptionTest.php`,
+      'use CloudPDF\\Exceptions\\CloudpdfException;\n',
+    );
+
+    normalizeSdkBranding(outputDirectory, 'php');
+    normalizeSdkBranding(outputDirectory, 'php');
+
+    assert.match(
+      readFileSync(`${outputDirectory}/src/Exceptions/CloudPDFException.php`, 'utf8'),
+      /class CloudPDFException/,
+    );
+    assert.match(
+      readFileSync(`${outputDirectory}/src/Exceptions/CloudPDFApiException.php`, 'utf8'),
+      /extends CloudPDFException/,
+    );
+    assert.match(
+      readFileSync(`${outputDirectory}/src/Documents/Client.php`, 'utf8'),
+      /CloudPDFApiException/,
+    );
+    assert.match(
+      readFileSync(`${outputDirectory}/tests/ExceptionTest.php`, 'utf8'),
+      /CloudPDFException/,
+    );
+    assert.throws(
+      () => readFileSync(`${outputDirectory}/src/.php-cs-fixer.cache`, 'utf8'),
+      /ENOENT/,
+    );
+  } finally {
+    rmSync(outputDirectory, { recursive: true, force: true });
+  }
+});
+
+test('keeps the Ruby gem and require path lowercase with a CloudPDF module', () => {
+  const outputDirectory = mkdtempSync(`${tmpdir()}/cloudpdf-ruby-sdk-`);
+  try {
+    mkdirSync(`${outputDirectory}/lib`, { recursive: true });
+    writeFileSync(
+      `${outputDirectory}/README.md`,
+      '# Cloudpdf Ruby Library\n\nThe Cloudpdf Ruby library provides convenient access to the Cloudpdf APIs from Ruby.\n\n```ruby\nrequire "CloudPDF"\n```\n',
+    );
+    writeFileSync(`${outputDirectory}/CloudPDF.gemspec`, 'spec.name = "CloudPDF"\n');
+    writeFileSync(`${outputDirectory}/lib/CloudPDF.rb`, 'module CloudPDF\nend\n');
+
+    normalizeSdkBranding(outputDirectory, 'ruby');
+    normalizeSdkBranding(outputDirectory, 'ruby');
+
+    assert.equal(
+      readFileSync(`${outputDirectory}/cloudpdf.gemspec`, 'utf8'),
+      'spec.name = "cloudpdf"\n',
+    );
+    assert.match(readFileSync(`${outputDirectory}/lib/cloudpdf.rb`, 'utf8'), /module CloudPDF/);
+    assert.match(readFileSync(`${outputDirectory}/README.md`, 'utf8'), /require "cloudpdf"/);
+  } finally {
+    rmSync(outputDirectory, { recursive: true, force: true });
+  }
+});

--- a/fern/scripts/sdk-casing.mjs
+++ b/fern/scripts/sdk-casing.mjs
@@ -1,0 +1,111 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+const ALLOWED_CASINGS = new Set(['cloudpdf', 'CloudPDF']);
+const textDecoder = new TextDecoder('utf-8', { fatal: true });
+
+function maskCharacters(value, start, end) {
+  return `${value.slice(0, start)}${value
+    .slice(start, end)
+    .replace(/[^\n]/g, ' ')}${value.slice(end)}`;
+}
+
+export function maskMarkdownLinkDestinations(markdown) {
+  let masked = markdown;
+
+  for (let index = 0; index < masked.length - 1; index += 1) {
+    if (masked[index] !== ']' || masked[index + 1] !== '(') continue;
+
+    let depth = 1;
+    let cursor = index + 2;
+    for (; cursor < masked.length && depth > 0; cursor += 1) {
+      if (masked[cursor] === '\\') {
+        cursor += 1;
+        continue;
+      }
+      if (masked[cursor] === '(') depth += 1;
+      if (masked[cursor] === ')') depth -= 1;
+    }
+    if (depth === 0) masked = maskCharacters(masked, index + 2, cursor - 1);
+    index = cursor - 1;
+  }
+
+  masked = masked.replace(/<https?:\/\/[^>]+>/g, (url) => ' '.repeat(url.length));
+  masked = masked.replace(
+    /^(\s*\[[^\]]+\]:\s*)(.*)$/gm,
+    (_line, prefix, destination) => `${prefix}${destination.replace(/[^\n]/g, ' ')}`,
+  );
+  masked = masked.replace(/\b(?:href|src)=(['"])(.*?)\1/gi, (attribute, _quote, destination) =>
+    attribute.replace(destination, ' '.repeat(destination.length)),
+  );
+
+  return masked;
+}
+
+function noncanonicalMatches(value) {
+  return [...value.matchAll(/cloudpdf/gi)].filter((match) => !ALLOWED_CASINGS.has(match[0]));
+}
+
+function decodeTextFile(path) {
+  const contents = readFileSync(path);
+  if (contents.includes(0)) return null;
+  try {
+    return textDecoder.decode(contents);
+  } catch {
+    return null;
+  }
+}
+
+function entriesBelow(rootDirectory, directory = rootDirectory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const absolutePath = join(directory, entry.name);
+    const relativePath = relative(rootDirectory, absolutePath);
+    if (entry.isDirectory()) {
+      return [
+        { absolutePath, relativePath, isFile: false },
+        ...entriesBelow(rootDirectory, absolutePath),
+      ];
+    }
+    return entry.isFile() ? [{ absolutePath, relativePath, isFile: true }] : [];
+  });
+}
+
+export function findNoncanonicalCloudPdfCasings(outputDirectory) {
+  const violations = [];
+
+  for (const entry of entriesBelow(outputDirectory)) {
+    for (const match of noncanonicalMatches(entry.relativePath)) {
+      violations.push(`${entry.relativePath}: path contains ${JSON.stringify(match[0])}`);
+    }
+    if (!entry.isFile) continue;
+
+    const contents = decodeTextFile(entry.absolutePath);
+    if (contents == null) continue;
+    const inspectedContents = /\.md(?:own)?$/i.test(entry.relativePath)
+      ? maskMarkdownLinkDestinations(contents)
+      : contents;
+    for (const match of noncanonicalMatches(inspectedContents)) {
+      const line = inspectedContents.slice(0, match.index).split('\n').length;
+      violations.push(
+        `${entry.relativePath}:${line}: contains noncanonical casing ${JSON.stringify(match[0])}`,
+      );
+    }
+  }
+
+  return violations;
+}
+
+export function assertCanonicalCloudPdfCasing(outputDirectory) {
+  const violations = findNoncanonicalCloudPdfCasings(outputDirectory);
+  if (violations.length === 0) return;
+
+  const displayed = violations.slice(0, 20).map((violation) => `- ${violation}`);
+  if (violations.length > displayed.length) {
+    displayed.push(`- ...and ${violations.length - displayed.length} more`);
+  }
+  throw new Error(
+    `Generated SDK contains noncanonical CloudPDF casing. Allowed forms: ${[
+      ...ALLOWED_CASINGS,
+    ].join(', ')}\n${displayed.join('\n')}`,
+  );
+}

--- a/fern/scripts/sdk-casing.test.mjs
+++ b/fern/scripts/sdk-casing.test.mjs
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+
+import {
+  assertCanonicalCloudPdfCasing,
+  findNoncanonicalCloudPdfCasings,
+  maskMarkdownLinkDestinations,
+} from './sdk-casing.mjs';
+
+test('allows canonical package and brand casing while ignoring Markdown link destinations', () => {
+  const outputDirectory = mkdtempSync(`${tmpdir()}/cloudpdf-casing-`);
+  try {
+    mkdirSync(`${outputDirectory}/src/CloudPDF`, { recursive: true });
+    writeFileSync(
+      `${outputDirectory}/README.md`,
+      '# CloudPDF SDK\n\n[CloudPDF](https://example.com/Cloudpdf?utm_source=CloudPdf)\n',
+    );
+    writeFileSync(
+      `${outputDirectory}/src/CloudPDF/client.ts`,
+      'export class CloudPDFClient {}\nexport const packageName = "cloudpdf";\n',
+    );
+    writeFileSync(`${outputDirectory}/binary.jar`, Buffer.from([0, 67, 108, 111, 117, 100]));
+
+    assert.deepEqual(findNoncanonicalCloudPdfCasings(outputDirectory), []);
+    assert.doesNotThrow(() => assertCanonicalCloudPdfCasing(outputDirectory));
+  } finally {
+    rmSync(outputDirectory, { recursive: true, force: true });
+  }
+});
+
+test('rejects mixed casing in generated text and paths', () => {
+  const outputDirectory = mkdtempSync(`${tmpdir()}/cloudpdf-casing-`);
+  try {
+    mkdirSync(`${outputDirectory}/src/CloudpdfHelpers`, { recursive: true });
+    writeFileSync(
+      `${outputDirectory}/src/client.php`,
+      'class CloudPdfPagination {}\nconst CLOUDPDF_API_KEY = "value";\n',
+    );
+
+    const violations = findNoncanonicalCloudPdfCasings(outputDirectory);
+    assert(violations.some((violation) => violation.includes('CloudpdfHelpers')));
+    assert(violations.some((violation) => violation.includes('CloudPdf')));
+    assert(violations.some((violation) => violation.includes('CLOUDPDF')));
+    assert.throws(
+      () => assertCanonicalCloudPdfCasing(outputDirectory),
+      /Generated SDK contains noncanonical CloudPDF casing/,
+    );
+  } finally {
+    rmSync(outputDirectory, { recursive: true, force: true });
+  }
+});
+
+test('masks inline, reference, autolink, and HTML destinations but not visible labels', () => {
+  const markdown = `[CloudPdf](https://example.com/Cloudpdf)
+[reference]: https://example.com/Cloudpdf
+<https://example.com/Cloudpdf>
+<a href="https://example.com/Cloudpdf">CloudPdf</a>
+`;
+  const masked = maskMarkdownLinkDestinations(markdown);
+
+  assert.match(masked, /^\[CloudPdf\]/);
+  assert.match(masked, />CloudPdf<\/a>/);
+  assert.doesNotMatch(masked, /example\.com\/Cloudpdf/);
+});

--- a/fern/scripts/validate-sdk.mjs
+++ b/fern/scripts/validate-sdk.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
 import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 import { LANGUAGES, mapSdkVersion, readCanonicalVersion } from './sdk-version.mjs';
+import { assertCanonicalCloudPdfCasing } from './sdk-casing.mjs';
 
 const language = process.argv[2];
 if (!LANGUAGES.includes(language)) {
@@ -16,6 +17,15 @@ const repositoryDirectory = fileURLToPath(new URL('../../', import.meta.url));
 const outputDirectory = `${repositoryDirectory}sdks/${language}`;
 const canonicalVersion = readCanonicalVersion();
 const expectedVersion = mapSdkVersion(canonicalVersion, language);
+const languageNames = {
+  typescript: 'TypeScript',
+  python: 'Python',
+  php: 'PHP',
+  csharp: '.NET',
+  go: 'Go',
+  java: 'Java',
+  ruby: 'Ruby',
+};
 
 function read(path) {
   return readFileSync(`${outputDirectory}/${path}`, 'utf8');
@@ -39,13 +49,19 @@ assert(
   `.fern/metadata.json requestedVersion is ${fernMetadata.requestedVersion}, expected ${expectedVersion}`,
 );
 includes('LICENSE', 'Apache License');
+includes('README.md', `# CloudPDF ${languageNames[language]} SDK`);
+assertCanonicalCloudPdfCasing(outputDirectory);
 
 switch (language) {
   case 'typescript': {
     const manifest = readJson('package.json');
     assert(manifest.name === '@cloudpdf/sdk', `package.json name is ${manifest.name}`);
     assert(manifest.version === expectedVersion, `package.json version is ${manifest.version}`);
+    assert(manifest.license === 'Apache-2.0', `package.json license is ${manifest.license}`);
     includes('src/version.ts', expectedVersion);
+    includes('src/Client.ts', 'export class CloudPDFClient');
+    includes('src/errors/CloudPDFError.ts', 'export class CloudPDFError');
+    includes('src/errors/CloudPDFTimeoutError.ts', 'export class CloudPDFTimeoutError');
     break;
   }
   case 'python': {
@@ -65,22 +81,28 @@ switch (language) {
       'pyproject.toml license is not Apache-2.0',
     );
     includes('src/cloudpdf/core/client_wrapper.py', expectedVersion);
+    includes('src/cloudpdf/client.py', 'class CloudPDFClient:');
+    includes('src/cloudpdf/client.py', 'class AsyncCloudPDFClient:');
     break;
   }
   case 'php': {
     const manifest = readJson('composer.json');
-    assert(manifest.name === 'cloudpdf/cloudpdf', `composer.json name is ${manifest.name}`);
+    assert(manifest.name === 'cloudpdf/sdk', `composer.json name is ${manifest.name}`);
     assert(manifest.version === expectedVersion, `composer.json version is ${manifest.version}`);
     assert(manifest.license === 'Apache-2.0', `composer.json license is ${manifest.license}`);
-    includes('src/CloudpdfClient.php', expectedVersion);
+    includes('src/CloudPDFClient.php', expectedVersion);
+    includes('src/CloudPDFClient.php', 'class CloudPDFClient');
+    includes('src/Exceptions/CloudPDFException.php', 'class CloudPDFException');
+    includes('src/Exceptions/CloudPDFApiException.php', 'class CloudPDFApiException');
+    assert(
+      !readdirSync(`${outputDirectory}/src/Exceptions`).includes('CloudpdfException.php'),
+      'incorrectly cased CloudpdfException.php still exists',
+    );
     break;
   }
   case 'csharp': {
-    const project = read('src/CloudpdfApi/CloudpdfApi.csproj');
-    assert(
-      project.includes('<PackageId>CloudpdfApi</PackageId>'),
-      'NuGet package ID is not CloudpdfApi',
-    );
+    const project = read('src/CloudPDF/CloudPDF.csproj');
+    assert(project.includes('<PackageId>CloudPDF</PackageId>'), 'NuGet package ID is not CloudPDF');
     assert(
       project.includes(`<Version>${expectedVersion}</Version>`),
       `project version is not ${expectedVersion}`,
@@ -98,31 +120,49 @@ switch (language) {
       project.includes('<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>'),
       'NuGet license is not Apache-2.0',
     );
-    includes('src/CloudpdfApi/Core/Public/Version.cs', expectedVersion);
+    includes('src/CloudPDF/Core/Public/Version.cs', expectedVersion);
+    includes('src/CloudPDF/CloudPDFClient.cs', 'class CloudPDFClient');
+    includes('src/CloudPDF/Core/Public/CloudPDFException.cs', 'class CloudPDFException');
+    includes('src/CloudPDF/Core/Public/CloudPDFApiException.cs', 'class CloudPDFApiException');
     break;
   }
   case 'go': {
     includes('go.mod', 'module github.com/embedpdf/cloudpdf-sdk-go/v3');
     includes('core/request_option.go', `X-Fern-SDK-Version", "v${expectedVersion}`);
+    includes('client/client.go', 'func NewClient(');
     break;
   }
   case 'java': {
     const build = read('build.gradle');
     assert(build.includes("group = 'com.cloudpdf'"), 'Gradle group is not com.cloudpdf');
-    assert(build.includes("artifactId = 'cloudpdf'"), 'Gradle artifact is not cloudpdf');
+    assert(build.includes("artifactId = 'sdk'"), 'Gradle artifact is not sdk');
     assert(
       build.includes(`version = '${expectedVersion}'`),
       `Gradle version is not ${expectedVersion}`,
     );
     assert(build.includes("name = 'APACHE-2.0'"), 'Maven license is not Apache-2.0');
-    includes('src/main/java/CloudpdfApiClient.java', 'package com.cloudpdf.api;');
-    includes('src/main/java/core/ClientOptions.java', expectedVersion);
+    includes('src/main/java/api/CloudPDFClient.java', 'package com.cloudpdf.api;');
+    includes('src/main/java/api/CloudPDFClient.java', 'class CloudPDFClient');
+    includes('src/main/java/api/core/CloudPDFException.java', 'class CloudPDFException');
+    includes('src/main/java/api/core/CloudPDFApiException.java', 'class CloudPDFApiException');
+    includes('src/main/java/api/core/ClientOptions.java', expectedVersion);
     break;
   }
   case 'ruby': {
     includes('cloudpdf.gemspec', 'spec.name = "cloudpdf"');
-    includes('lib/cloudpdf/version.rb', `VERSION = "${expectedVersion}"`);
+    includes('lib/CloudPDF/version.rb', `VERSION = "${expectedVersion}"`);
+    includes('lib/CloudPDF/client.rb', 'module CloudPDF');
+    includes('lib/CloudPDF/client.rb', 'class Client');
+    includes('README.md', 'require "cloudpdf"');
     includes('custom.gemspec.rb', 'spec.license = "Apache-2.0"');
+    assert(
+      !readdirSync(outputDirectory).includes('CloudPDF.gemspec'),
+      'uppercase Ruby gemspec still exists',
+    );
+    assert(
+      !readdirSync(`${outputDirectory}/lib`).includes('CloudPDF.rb'),
+      'uppercase Ruby entrypoint still exists',
+    );
     break;
   }
 }


### PR DESCRIPTION
Enforce consistent CloudPDF branding across generated SDKs. Adds sdk-branding.mjs and tests to normalize README titles, PHP exception names, and Ruby gem/require casing. Calls normalization from record-sdk-metadata and updates paths for the C# project. Updates generators.yml to emit CloudPDF names and package identities for multiple languages, expands fern/README with public package identities, and strengthens validate-sdk checks. Adjusts workflows to run all test files and to build the renamed C# project path.