### PR TITLE
Add guarded SDK release workflows for registry publishing

### DIFF
--- a/fern/README.md
+++ b/fern/README.md
@@ -57,6 +57,8 @@ release workflow calls the same generation workflow with repository sync
 enabled only after the multi-architecture server manifest exists and passes
 inspection. Each generated repository PR includes an `SDK CI` workflow and can
 optionally use GitHub native auto-merge after repository requirements pass.
+TypeScript, Python, .NET, and Ruby also receive the guarded release workflow
+described below.
 
 Repository sync uses a GitHub App rather than a personal access token. Install
 one app on the seven repositories with **Contents: read/write**, **Pull
@@ -75,6 +77,50 @@ required `Build and validate` status check.
 The sync is idempotent per canonical version. A failed post-release sync can be
 retried with the **SDK Generate** workflow dispatch after the corresponding
 `ghcr.io/embedpdf/cloudpdf-server:<version>` image exists.
+When a version branch already exists, the sync replaces it only if its remote
+SHA still matches the value observed before generation; a concurrent update is
+rejected instead of overwritten.
+
+## Registry publishing
+
+The first publishing wave is repository-owned for TypeScript, Python, .NET,
+and Ruby. Their `.github/workflows/sdk-release.yml` workflows build the actual
+package, verify `cloudpdf-generation.json` against the ecosystem manifest,
+protect an immutable `v<ecosystem-version>` tag, publish with GitHub OIDC, and
+create a matching GitHub release. Canonical prereleases become GitHub
+prereleases; npm additionally publishes them under the `next` dist-tag.
+
+Publishing is disabled by default. Before the first release, create a GitHub
+environment named `release` in each SDK repository and configure the registry
+to trust this exact environment and workflow:
+
+| Registry | Project | Repository | Additional setup |
+| -------- | ------- | ---------- | ---------------- |
+| npm | `@cloudpdf/sdk` | `cloudpdf-sdk-typescript` | Trusted publisher for `sdk-release.yml`; allow `npm publish` |
+| PyPI | `cloudpdf` | `cloudpdf-sdk-python` | Existing or pending trusted publisher for `sdk-release.yml` |
+| NuGet | `CloudPDF` | `cloudpdf-sdk-dotnet` | Trusted publishing policy for `sdk-release.yml`; repository variable `NUGET_USER` set to the NuGet profile name |
+| RubyGems | `cloudpdf` | `cloudpdf-sdk-ruby` | Existing or pending trusted publisher for `sdk-release.yml` |
+
+Use required reviewers on the `release` environments during rollout. Leave
+`SDK_AUTO_PUBLISH_ENABLED` unset and manually dispatch **SDK Release** once in
+each repository. After all four packages install successfully, remove the
+manual approval if desired and set the repository variable
+`SDK_AUTO_PUBLISH_ENABLED=true`; subsequent generated-source merges then
+publish automatically.
+
+The tag is created before registry authentication so a missing trusted
+publisher cannot publish untracked bytes. Fix the registry configuration and
+rerun the same commit: the workflow accepts the existing tag, skips an already
+published registry version, and fills in a missing GitHub release. A tag may be
+reused after workflow-only changes, but any different package source requires a
+new SDK version.
+
+npm trusted publishing normally requires the package to exist already. If the
+reserved `@cloudpdf/sdk` name has no published bootstrap version, perform its
+first publish with a short-lived granular token, then configure the trusted
+publisher and remove the token. PyPI and RubyGems support pending publishers
+for the first release; NuGet's existing `CloudPDF` package can use a trusted
+publishing policy directly.
 
 ## Version policy
 
@@ -136,5 +182,5 @@ and language generator version.
 
 The repository sync replaces generated source on its version branch while
 keeping each destination repository's `.github` directory repository-owned.
-This lets future registry publishing workflows live with their ecosystem
-credentials without being overwritten by SDK regeneration.
+The checked-in overlays install and update the repository CI and release
+workflows without putting registry credentials in the generation workflow.

--- a/fern/repository-overlays/csharp/.github/workflows/sdk-ci.yml
+++ b/fern/repository-overlays/csharp/.github/workflows/sdk-ci.yml
@@ -18,3 +18,4 @@ jobs:
         with:
           dotnet-version: '9.0.x'
       - run: dotnet build src/CloudPDF/CloudPDF.csproj -c Release -f net8.0
+      - run: dotnet pack src/CloudPDF/CloudPDF.csproj -c Release -o /tmp/cloudpdf-nuget

--- a/fern/repository-overlays/csharp/.github/workflows/sdk-release.yml
+++ b/fern/repository-overlays/csharp/.github/workflows/sdk-release.yml
@@ -1,0 +1,143 @@
+name: SDK Release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '.github/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Publish CloudPDF
+    if: github.event_name == 'workflow_dispatch' || vars.SDK_AUTO_PUBLISH_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Verify generated release version
+        id: version
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import xml.etree.ElementTree as ET
+
+          project = ET.parse('src/CloudPDF/CloudPDF.csproj').getroot()
+          package_id = project.findtext('./PropertyGroup/PackageId')
+          version = project.findtext('./PropertyGroup/Version')
+          with open('cloudpdf-generation.json', encoding='utf-8') as file:
+              generation = json.load(file)
+          if generation['language'] != 'csharp':
+              raise RuntimeError('generation language is not csharp')
+          if package_id != 'CloudPDF':
+              raise RuntimeError(f'unexpected NuGet package {package_id}')
+          if version != generation['sdkVersion']:
+              raise RuntimeError(f'package version {version} does not match generated version {generation["sdkVersion"]}')
+          prerelease = '-' in generation['canonicalVersion']
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as output:
+              output.write(f'version={version}\n')
+              output.write(f'tag=v{version}\n')
+              output.write(f'prerelease={str(prerelease).lower()}\n')
+          PY
+
+      - name: Pack NuGet package
+        run: dotnet pack src/CloudPDF/CloudPDF.csproj -c Release -o dist
+
+      - name: Protect immutable release tag
+        id: release-tag
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git fetch --force --tags origin
+          if git rev-parse --quiet --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
+            if [ "$tagged_commit" != "$GITHUB_SHA" ]; then
+              if git diff --quiet "$RELEASE_TAG" "$GITHUB_SHA" -- . ':(exclude).github/**'; then
+                echo "::notice::Reusing $RELEASE_TAG after a workflow-only change."
+              else
+                echo "::error::Release tag $RELEASE_TAG already points to different package source at $tagged_commit; bump the SDK version."
+                exit 1
+              fi
+            fi
+            echo "existed=true" >> "$GITHUB_OUTPUT"
+          else
+            git config user.name cloudpdf-sdk-bot
+            git config user.email hello@cloudpdf.com
+            git tag -a "$RELEASE_TAG" -m "CloudPDF .NET SDK $RELEASE_TAG"
+            git push origin "refs/tags/$RELEASE_TAG"
+            echo "existed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check NuGet publication state
+        id: registry
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG_EXISTED: ${{ steps.release-tag.outputs.existed }}
+        run: |
+          normalized_version="$(printf '%s' "$VERSION" | tr '[:upper:]' '[:lower:]')"
+          package_url="https://api.nuget.org/v3-flatcontainer/cloudpdf/$normalized_version/cloudpdf.$normalized_version.nupkg"
+          http_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' "$package_url")"
+          case "$http_status" in
+            200)
+              if [ "$TAG_EXISTED" != 'true' ]; then
+                echo "::error::CloudPDF $VERSION already exists on NuGet but its release tag did not exist."
+                exit 1
+              fi
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::NuGet returned HTTP $http_status while checking CloudPDF $VERSION."
+              exit 1
+              ;;
+          esac
+
+      - name: Exchange GitHub identity for a NuGet API key
+        if: steps.registry.outputs.publish == 'true'
+        id: nuget-login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ vars.NUGET_USER }}
+
+      - name: Publish to NuGet
+        if: steps.registry.outputs.publish == 'true'
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+        run: dotnet nuget push "dist/CloudPDF.${{ steps.version.outputs.version }}.nupkg" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            exit 0
+          fi
+          args=(--verify-tag --generate-notes --title "CloudPDF .NET SDK $RELEASE_TAG")
+          if [ "$PRERELEASE" = 'true' ]; then args+=(--prerelease); fi
+          gh release create "$RELEASE_TAG" "${args[@]}"

--- a/fern/repository-overlays/python/.github/workflows/sdk-ci.yml
+++ b/fern/repository-overlays/python/.github/workflows/sdk-ci.yml
@@ -18,4 +18,4 @@ jobs:
         with:
           python-version: '3.12'
       - run: python -m pip install --disable-pip-version-check build
-      - run: python -m build --wheel
+      - run: python -m build

--- a/fern/repository-overlays/python/.github/workflows/sdk-release.yml
+++ b/fern/repository-overlays/python/.github/workflows/sdk-release.yml
@@ -1,0 +1,132 @@
+name: SDK Release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '.github/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Publish cloudpdf
+    if: github.event_name == 'workflow_dispatch' || vars.SDK_AUTO_PUBLISH_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Verify generated release version
+        id: version
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import tomllib
+
+          with open('pyproject.toml', 'rb') as file:
+              manifest = tomllib.load(file)
+          with open('cloudpdf-generation.json', encoding='utf-8') as file:
+              generation = json.load(file)
+          name = manifest['tool']['poetry']['name']
+          version = manifest['tool']['poetry']['version']
+          if generation['language'] != 'python':
+              raise RuntimeError('generation language is not python')
+          if name != 'cloudpdf':
+              raise RuntimeError(f'unexpected PyPI project {name}')
+          if version != generation['sdkVersion']:
+              raise RuntimeError(f'package version {version} does not match generated version {generation["sdkVersion"]}')
+          prerelease = '-' in generation['canonicalVersion']
+          with open(os.environ['GITHUB_OUTPUT'], 'a', encoding='utf-8') as output:
+              output.write(f'version={version}\n')
+              output.write(f'tag=v{version}\n')
+              output.write(f'prerelease={str(prerelease).lower()}\n')
+          PY
+
+      - name: Build and inspect distributions
+        run: |
+          python -m pip install --disable-pip-version-check build
+          python -m build --outdir dist
+          python -m zipfile --list dist/*.whl >/dev/null
+
+      - name: Protect immutable release tag
+        id: release-tag
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git fetch --force --tags origin
+          if git rev-parse --quiet --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
+            if [ "$tagged_commit" != "$GITHUB_SHA" ]; then
+              if git diff --quiet "$RELEASE_TAG" "$GITHUB_SHA" -- . ':(exclude).github/**'; then
+                echo "::notice::Reusing $RELEASE_TAG after a workflow-only change."
+              else
+                echo "::error::Release tag $RELEASE_TAG already points to different package source at $tagged_commit; bump the SDK version."
+                exit 1
+              fi
+            fi
+            echo "existed=true" >> "$GITHUB_OUTPUT"
+          else
+            git config user.name cloudpdf-sdk-bot
+            git config user.email hello@cloudpdf.com
+            git tag -a "$RELEASE_TAG" -m "CloudPDF Python SDK $RELEASE_TAG"
+            git push origin "refs/tags/$RELEASE_TAG"
+            echo "existed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check PyPI publication state
+        id: registry
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG_EXISTED: ${{ steps.release-tag.outputs.existed }}
+        run: |
+          http_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' "https://pypi.org/pypi/cloudpdf/$VERSION/json")"
+          case "$http_status" in
+            200)
+              if [ "$TAG_EXISTED" != 'true' ]; then
+                echo "::error::cloudpdf==$VERSION already exists on PyPI but its release tag did not exist."
+                exit 1
+              fi
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::PyPI returned HTTP $http_status while checking cloudpdf==$VERSION."
+              exit 1
+              ;;
+          esac
+
+      - name: Publish to PyPI
+        if: steps.registry.outputs.publish == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            exit 0
+          fi
+          args=(--verify-tag --generate-notes --title "CloudPDF Python SDK $RELEASE_TAG")
+          if [ "$PRERELEASE" = 'true' ]; then args+=(--prerelease); fi
+          gh release create "$RELEASE_TAG" "${args[@]}"

--- a/fern/repository-overlays/ruby/.github/workflows/sdk-release.yml
+++ b/fern/repository-overlays/ruby/.github/workflows/sdk-release.yml
@@ -1,0 +1,130 @@
+name: SDK Release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '.github/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Publish cloudpdf
+    if: github.event_name == 'workflow_dispatch' || vars.SDK_AUTO_PUBLISH_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+
+      - name: Verify generated release version
+        id: version
+        run: |
+          ruby <<'RUBY'
+          require "json"
+          require_relative "lib/CloudPDF/version"
+
+          generation = JSON.parse(File.read("cloudpdf-generation.json"))
+          raise "generation language is not ruby" unless generation.fetch("language") == "ruby"
+          version = CloudPDF::VERSION
+          unless version == generation.fetch("sdkVersion")
+            raise "package version #{version} does not match generated version #{generation.fetch('sdkVersion')}"
+          end
+          prerelease = generation.fetch("canonicalVersion").include?("-")
+          File.open(ENV.fetch("GITHUB_OUTPUT"), "a") do |output|
+            output.puts "version=#{version}"
+            output.puts "tag=v#{version}"
+            output.puts "prerelease=#{prerelease}"
+          end
+          RUBY
+
+      - name: Build and verify packaged require graph
+        run: |
+          mkdir -p dist
+          gem build cloudpdf.gemspec --output "dist/cloudpdf-${{ steps.version.outputs.version }}.gem"
+          ruby_gem_home="$(mktemp -d)"
+          gem install "dist/cloudpdf-${{ steps.version.outputs.version }}.gem" --local --no-document --install-dir "$ruby_gem_home"
+          GEM_HOME="$ruby_gem_home" GEM_PATH="$ruby_gem_home" ruby -e 'require "cloudpdf"; abort "CloudPDF::Client was not packaged" unless defined?(CloudPDF::Client)'
+
+      - name: Protect immutable release tag
+        id: release-tag
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git fetch --force --tags origin
+          if git rev-parse --quiet --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
+            if [ "$tagged_commit" != "$GITHUB_SHA" ]; then
+              if git diff --quiet "$RELEASE_TAG" "$GITHUB_SHA" -- . ':(exclude).github/**'; then
+                echo "::notice::Reusing $RELEASE_TAG after a workflow-only change."
+              else
+                echo "::error::Release tag $RELEASE_TAG already points to different package source at $tagged_commit; bump the SDK version."
+                exit 1
+              fi
+            fi
+            echo "existed=true" >> "$GITHUB_OUTPUT"
+          else
+            git config user.name cloudpdf-sdk-bot
+            git config user.email hello@cloudpdf.com
+            git tag -a "$RELEASE_TAG" -m "CloudPDF Ruby SDK $RELEASE_TAG"
+            git push origin "refs/tags/$RELEASE_TAG"
+            echo "existed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check RubyGems publication state
+        id: registry
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG_EXISTED: ${{ steps.release-tag.outputs.existed }}
+        run: |
+          versions_file="$(mktemp)"
+          http_status="$(curl --silent --show-error --output "$versions_file" --write-out '%{http_code}' https://rubygems.org/api/v1/versions/cloudpdf.json)"
+          if [ "$http_status" != '200' ]; then
+            echo "::error::RubyGems returned HTTP $http_status while checking cloudpdf $VERSION."
+            exit 1
+          fi
+          if ruby -rjson -e 'version = ENV.fetch("VERSION"); exit(JSON.parse(File.read(ARGV.fetch(0))).any? { |item| item["number"] == version } ? 0 : 1)' "$versions_file"; then
+            if [ "$TAG_EXISTED" != 'true' ]; then
+              echo "::error::cloudpdf $VERSION already exists on RubyGems but its release tag did not exist."
+              exit 1
+            fi
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure RubyGems trusted publishing
+        if: steps.registry.outputs.publish == 'true'
+        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a
+
+      - name: Publish to RubyGems
+        if: steps.registry.outputs.publish == 'true'
+        run: gem push "dist/cloudpdf-${{ steps.version.outputs.version }}.gem"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            exit 0
+          fi
+          args=(--verify-tag --generate-notes --title "CloudPDF Ruby SDK $RELEASE_TAG")
+          if [ "$PRERELEASE" = 'true' ]; then args+=(--prerelease); fi
+          gh release create "$RELEASE_TAG" "${args[@]}"

--- a/fern/repository-overlays/typescript/.github/workflows/sdk-ci.yml
+++ b/fern/repository-overlays/typescript/.github/workflows/sdk-ci.yml
@@ -20,3 +20,4 @@ jobs:
       - run: corepack enable
       - run: pnpm install --lockfile=false --ignore-scripts
       - run: pnpm build
+      - run: npm pack --dry-run

--- a/fern/repository-overlays/typescript/.github/workflows/sdk-release.yml
+++ b/fern/repository-overlays/typescript/.github/workflows/sdk-release.yml
@@ -1,0 +1,125 @@
+name: SDK Release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '.github/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Publish @cloudpdf/sdk
+    if: github.event_name == 'workflow_dispatch' || vars.SDK_AUTO_PUBLISH_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Verify generated release version
+        id: version
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const manifest = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+          const generation = JSON.parse(fs.readFileSync('cloudpdf-generation.json', 'utf8'));
+          if (generation.language !== 'typescript') throw new Error('generation language is not typescript');
+          if (manifest.name !== '@cloudpdf/sdk') throw new Error(`unexpected npm package ${manifest.name}`);
+          if (manifest.version !== generation.sdkVersion) {
+            throw new Error(`package version ${manifest.version} does not match generated version ${generation.sdkVersion}`);
+          }
+          const prerelease = generation.canonicalVersion.includes('-');
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${manifest.version}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `tag=v${manifest.version}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `dist_tag=${prerelease ? 'next' : 'latest'}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `prerelease=${prerelease}\n`);
+          NODE
+
+      - name: Install, build, and pack
+        run: |
+          pnpm install --lockfile=false --ignore-scripts
+          pnpm build
+          npm pack --dry-run
+
+      - name: Protect immutable release tag
+        id: release-tag
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git fetch --force --tags origin
+          if git rev-parse --quiet --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
+            if [ "$tagged_commit" != "$GITHUB_SHA" ]; then
+              if git diff --quiet "$RELEASE_TAG" "$GITHUB_SHA" -- . ':(exclude).github/**'; then
+                echo "::notice::Reusing $RELEASE_TAG after a workflow-only change."
+              else
+                echo "::error::Release tag $RELEASE_TAG already points to different package source at $tagged_commit; bump the SDK version."
+                exit 1
+              fi
+            fi
+            echo "existed=true" >> "$GITHUB_OUTPUT"
+          else
+            git config user.name cloudpdf-sdk-bot
+            git config user.email hello@cloudpdf.com
+            git tag -a "$RELEASE_TAG" -m "CloudPDF TypeScript SDK $RELEASE_TAG"
+            git push origin "refs/tags/$RELEASE_TAG"
+            echo "existed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check npm publication state
+        id: registry
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG_EXISTED: ${{ steps.release-tag.outputs.existed }}
+        run: |
+          npm_view_output="$(mktemp)"
+          if npm view "@cloudpdf/sdk@$VERSION" version --json >"$npm_view_output" 2>&1; then
+            if [ "$TAG_EXISTED" != 'true' ]; then
+              echo "::error::@cloudpdf/sdk@$VERSION already exists on npm but its release tag did not exist."
+              exit 1
+            fi
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          elif grep -Eiq 'E404|not found' "$npm_view_output"; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            cat "$npm_view_output"
+            echo "::error::Could not determine whether @cloudpdf/sdk@$VERSION exists on npm."
+            exit 1
+          fi
+
+      - name: Publish to npm
+        if: steps.registry.outputs.publish == 'true'
+        env:
+          DIST_TAG: ${{ steps.version.outputs.dist_tag }}
+        run: npm publish --access public --tag "$DIST_TAG"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            exit 0
+          fi
+          args=(--verify-tag --generate-notes --title "CloudPDF TypeScript SDK $RELEASE_TAG")
+          if [ "$PRERELEASE" = 'true' ]; then args+=(--prerelease); fi
+          gh release create "$RELEASE_TAG" "${args[@]}"

--- a/fern/scripts/record-sdk-metadata.mjs
+++ b/fern/scripts/record-sdk-metadata.mjs
@@ -48,6 +48,24 @@ writeFileSync(
 copyFileSync(`${repositoryDirectory}cloudpdf/contract/LICENSE`, `${outputDirectory}/LICENSE`);
 normalizeSdkBranding(outputDirectory, language);
 
+// Registry-facing metadata that Fern does not currently expose through every
+// generator configuration. Keep these deterministic and validate them below so
+// a generator upgrade cannot silently publish incomplete package metadata.
+if (language === 'typescript') {
+  const manifestPath = `${outputDirectory}/package.json`;
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  manifest.publishConfig = { access: 'public' };
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 4)}\n`);
+}
+
+if (language === 'python') {
+  const projectPath = `${outputDirectory}/pyproject.toml`;
+  const project = readFileSync(projectPath, 'utf8')
+    .replace('description = ""', 'description = "The official Python SDK for the CloudPDF API."')
+    .replace('authors = []', 'authors = ["CloudPDF <hello@cloudpdf.com>"]');
+  writeFileSync(projectPath, project);
+}
+
 // The Ruby generator intentionally leaves registry metadata in its generated
 // custom.gemspec.rb hook. Fill that hook deterministically until each SDK has
 // its own repository-owned customization layer.
@@ -61,6 +79,13 @@ def add_custom_gemspec_data(spec)
   spec.email = ["hello@cloudpdf.com"]
   spec.homepage = "https://www.cloudpdf.com"
   spec.license = "Apache-2.0"
+  spec.summary = "The official Ruby SDK for the CloudPDF API."
+  spec.description = "A typed Ruby client for deployment, tenant, and document operations in the CloudPDF API."
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = "https://github.com/embedpdf/cloudpdf-sdk-ruby"
+  spec.files = spec.files.reject do |file|
+    file.start_with?(".github/") || file == "cloudpdf-generation.json"
+  end
 end
 `,
   );
@@ -74,6 +99,16 @@ if (language === 'csharp') {
   const projectPath = `${outputDirectory}/src/CloudPDF/CloudPDF.csproj`;
   const numericBinaryVersion = `${canonicalVersion.split('-')[0]}.0`;
   const project = readFileSync(projectPath, 'utf8')
+    .replace(
+      '<PackageId>CloudPDF</PackageId>',
+      `<PackageId>CloudPDF</PackageId>
+    <Authors>CloudPDF</Authors>
+    <Description>The official .NET SDK for the CloudPDF API.</Description>
+    <PackageProjectUrl>https://www.cloudpdf.com</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/embedpdf/cloudpdf-sdk-dotnet</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageTags>cloudpdf;pdf;api;sdk</PackageTags>`,
+    )
     .replace(
       '<AssemblyVersion>$(Version)</AssemblyVersion>',
       `<AssemblyVersion>${numericBinaryVersion}</AssemblyVersion>`,

--- a/fern/scripts/sdk-repositories.test.mjs
+++ b/fern/scripts/sdk-repositories.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import test from 'node:test';
 
@@ -33,6 +33,28 @@ test('every generated language has one distinct public SDK repository', () => {
 test('the C# generator publishes source to the consumer-facing .NET repository', () => {
   assert.equal(sdkRepository('csharp').slug, 'embedpdf/cloudpdf-sdk-dotnet');
   assert.equal(sdkRepository('csharp').displayName, '.NET');
+});
+
+test('trusted-publishing SDKs receive guarded repository release workflows', () => {
+  for (const language of ['typescript', 'python', 'csharp', 'ruby']) {
+    const workflowPath = join(
+      repositoryDirectory,
+      'fern',
+      'repository-overlays',
+      language,
+      '.github',
+      'workflows',
+      'sdk-release.yml',
+    );
+    assert.ok(existsSync(workflowPath), `${language} is missing its release workflow`);
+    const workflow = readFileSync(workflowPath, 'utf8');
+    assert.match(workflow, /SDK_AUTO_PUBLISH_ENABLED/);
+    assert.match(workflow, /environment: release/);
+    assert.match(workflow, /id-token: write/);
+    assert.match(workflow, /cloudpdf-generation\.json/);
+    assert.match(workflow, /Protect immutable release tag/);
+    assert.match(workflow, /Create GitHub release/);
+  }
 });
 
 test('unknown languages and fields fail explicitly', () => {

--- a/fern/scripts/sync-sdk-repository.mjs
+++ b/fern/scripts/sync-sdk-repository.mjs
@@ -125,10 +125,15 @@ try {
   ]);
 
   const branch = `automation/cloudpdf-sdk-v${canonicalVersion.replaceAll(/[^0-9A-Za-z._-]/g, '-')}`;
-  run('git', ['fetch', 'origin', `refs/heads/${branch}:refs/remotes/origin/${branch}`], {
+  const remoteBranchRef = `refs/heads/${branch}`;
+  const remoteBranch = run('git', ['ls-remote', '--heads', 'origin', remoteBranchRef], {
     cwd: checkoutDirectory,
-    allowFailure: true,
+    capture: true,
   });
+  const remoteBranchSha = remoteBranch ? remoteBranch.split(/\s+/)[0] : '';
+  if (remoteBranchSha && !/^[0-9a-f]+$/.test(remoteBranchSha)) {
+    throw new Error(`${repository.slug}: invalid remote branch SHA ${remoteBranchSha}`);
+  }
   run('git', ['checkout', '-B', branch, 'origin/main'], { cwd: checkoutDirectory });
   run('git', ['config', 'user.name', 'cloudpdf-sdk-bot'], { cwd: checkoutDirectory });
   run('git', ['config', 'user.email', 'hello@cloudpdf.com'], { cwd: checkoutDirectory });
@@ -163,9 +168,20 @@ try {
       ],
       { cwd: checkoutDirectory },
     );
-    run('git', ['push', 'origin', `HEAD:refs/heads/${branch}`, '--force-with-lease'], {
-      cwd: checkoutDirectory,
-    });
+    // The clone is intentionally shallow and tracks only main, so generic
+    // --force-with-lease cannot infer the expected value for a previously used
+    // automation branch. Pin the lease to the exact SHA observed above. An
+    // empty expected SHA means the branch must still be absent.
+    run(
+      'git',
+      [
+        'push',
+        'origin',
+        `HEAD:${remoteBranchRef}`,
+        `--force-with-lease=${remoteBranchRef}:${remoteBranchSha}`,
+      ],
+      { cwd: checkoutDirectory },
+    );
 
     let pullRequestUrl = run(
       'gh',
@@ -197,7 +213,7 @@ try {
 - OpenAPI SHA-256: \`${generation.source.openapiSha256}\`
 - Source commit: \`${process.env.GITHUB_SHA ?? generation.source.gitCommit ?? 'unknown'}\`
 
-This PR contains generated source only. Package registry publishing is intentionally disabled.
+This PR updates generated source and repository-owned automation. Registry publication remains gated by the SDK repository's release workflow and environment.
 `,
       );
       pullRequestUrl = run(

--- a/fern/scripts/sync-sdk-repository.test.mjs
+++ b/fern/scripts/sync-sdk-repository.test.mjs
@@ -32,7 +32,7 @@ function run(command, args, options = {}) {
   return result.stdout.trim();
 }
 
-test('sync replaces generated source, preserves repository workflows, and opens a PR branch', () => {
+test('sync creates and safely updates a reused PR branch while preserving repository workflows', () => {
   const fixture = mkdtempSync(join(tmpdir(), 'cloudpdf-sdk-sync-test-'));
   try {
     const remote = join(fixture, 'remote.git');
@@ -104,16 +104,34 @@ esac
       },
     });
 
+    // Auto-merge may leave its head ref behind. Regenerating the same canonical
+    // version must safely replace that existing ref using an explicit lease.
+    writeFileSync(join(generated, 'README.md'), 'generated again\n');
+    run(process.execPath, [script, 'typescript'], {
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH}`,
+        GH_LOG: ghLog,
+        GH_TOKEN: 'fixture-token',
+        SDK_GITHUB_TOKEN: 'fixture-token',
+        SDK_GENERATED_DIRECTORY: generated,
+        SDK_REPOSITORY_REMOTE_URL: remote,
+        SDK_AUTO_MERGE: 'true',
+      },
+    });
+
     const branch = `automation/cloudpdf-sdk-v${canonicalVersion}`;
     run('git', ['clone', '--branch', branch, remote, inspection]);
-    assert.equal(readFileSync(join(inspection, 'README.md'), 'utf8'), 'generated\n');
+    assert.equal(readFileSync(join(inspection, 'README.md'), 'utf8'), 'generated again\n');
     assert.equal(
       readFileSync(join(inspection, '.github', 'workflows', 'existing.yml'), 'utf8'),
       'name: Existing\n',
     );
     assert.ok(existsSync(join(inspection, '.github', 'workflows', 'sdk-ci.yml')));
     assert.equal(existsSync(join(inspection, 'node_modules')), false);
-    assert.match(readFileSync(ghLog, 'utf8'), /pr merge .* --auto --squash --delete-branch/);
+    const ghInvocations = readFileSync(ghLog, 'utf8');
+    assert.match(ghInvocations, /pr merge .* --auto --squash --delete-branch/);
+    assert.equal(ghInvocations.match(/^pr create /gm)?.length, 2);
   } finally {
     rmSync(fixture, { recursive: true, force: true });
   }

--- a/fern/scripts/validate-sdk.mjs
+++ b/fern/scripts/validate-sdk.mjs
@@ -58,6 +58,10 @@ switch (language) {
     assert(manifest.name === '@cloudpdf/sdk', `package.json name is ${manifest.name}`);
     assert(manifest.version === expectedVersion, `package.json version is ${manifest.version}`);
     assert(manifest.license === 'Apache-2.0', `package.json license is ${manifest.license}`);
+    assert(
+      manifest.publishConfig?.access === 'public',
+      'package.json publishConfig.access is not public',
+    );
     includes('src/version.ts', expectedVersion);
     includes('src/Client.ts', 'export class CloudPDFClient');
     includes('src/errors/CloudPDFError.ts', 'export class CloudPDFError');
@@ -79,6 +83,14 @@ switch (language) {
     assert(
       pyproject.includes('license = "Apache-2.0"'),
       'pyproject.toml license is not Apache-2.0',
+    );
+    assert(
+      pyproject.includes('description = "The official Python SDK for the CloudPDF API."'),
+      'pyproject.toml description is not publication-ready',
+    );
+    assert(
+      pyproject.includes('authors = ["CloudPDF <hello@cloudpdf.com>"]'),
+      'pyproject.toml authors are not publication-ready',
     );
     includes('src/cloudpdf/core/client_wrapper.py', expectedVersion);
     includes('src/cloudpdf/client.py', 'class CloudPDFClient:');
@@ -120,6 +132,15 @@ switch (language) {
       project.includes('<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>'),
       'NuGet license is not Apache-2.0',
     );
+    includes('src/CloudPDF/CloudPDF.csproj', '<Authors>CloudPDF</Authors>');
+    includes(
+      'src/CloudPDF/CloudPDF.csproj',
+      '<Description>The official .NET SDK for the CloudPDF API.</Description>',
+    );
+    includes(
+      'src/CloudPDF/CloudPDF.csproj',
+      '<RepositoryUrl>https://github.com/embedpdf/cloudpdf-sdk-dotnet</RepositoryUrl>',
+    );
     includes('src/CloudPDF/Core/Public/Version.cs', expectedVersion);
     includes('src/CloudPDF/CloudPDFClient.cs', 'class CloudPDFClient');
     includes('src/CloudPDF/Core/Public/CloudPDFException.cs', 'class CloudPDFException');
@@ -155,6 +176,12 @@ switch (language) {
     includes('lib/CloudPDF/client.rb', 'class Client');
     includes('README.md', 'require "cloudpdf"');
     includes('custom.gemspec.rb', 'spec.license = "Apache-2.0"');
+    includes('custom.gemspec.rb', 'spec.summary = "The official Ruby SDK for the CloudPDF API."');
+    includes(
+      'custom.gemspec.rb',
+      'spec.metadata["source_code_uri"] = "https://github.com/embedpdf/cloudpdf-sdk-ruby"',
+    );
+    includes('custom.gemspec.rb', 'file.start_with?(".github/")');
     assert(
       !readdirSync(outputDirectory).includes('CloudPDF.gemspec'),
       'uppercase Ruby gemspec still exists',


### PR DESCRIPTION
Introduce repository-owned release workflows for TypeScript, Python, .NET, and Ruby SDKs that build packages, verify metadata against cloudpdf-generation.json, create immutable release tags, and publish to npm, PyPI, NuGet, and RubyGems with GitHub OIDC trusted publishing.

Enhancements include:
- New sdk-release.yml workflows gated by repository environment and auto-publish variable
- Safe concurrent updates using explicit git lease values to prevent overwrites
- Registry metadata enrichment (authors, descriptions, repository URLs, tags)
- Validation of package versions and ecosystem manifests before publishing
- Documentation of registry setup and trusted publisher configuration
- Prerelease and GitHub release handling
- Tests verifying workflow structure and metadata completeness