### PR TITLE
Add Go/Java/PHP release workflows and metadata

### DIFF
--- a/fern/README.md
+++ b/fern/README.md
@@ -57,8 +57,8 @@ release workflow calls the same generation workflow with repository sync
 enabled only after the multi-architecture server manifest exists and passes
 inspection. Each generated repository PR includes an `SDK CI` workflow and can
 optionally use GitHub native auto-merge after repository requirements pass.
-TypeScript, Python, .NET, and Ruby also receive the guarded release workflow
-described below.
+All seven SDK repositories also receive the guarded release workflow described
+below.
 
 Repository sync uses a GitHub App rather than a personal access token. Install
 one app on the seven repositories with **Contents: read/write**, **Pull
@@ -83,12 +83,18 @@ rejected instead of overwritten.
 
 ## Registry publishing
 
-The first publishing wave is repository-owned for TypeScript, Python, .NET,
-and Ruby. Their `.github/workflows/sdk-release.yml` workflows build the actual
-package, verify `cloudpdf-generation.json` against the ecosystem manifest,
-protect an immutable `v<ecosystem-version>` tag, publish with GitHub OIDC, and
+Publishing is repository-owned for all seven SDKs. Their
+`.github/workflows/sdk-release.yml` workflows build the actual package, verify
+`cloudpdf-generation.json` against the ecosystem manifest, protect an
+immutable `v<ecosystem-version>` tag, verify the public package index, and
 create a matching GitHub release. Canonical prereleases become GitHub
 prereleases; npm additionally publishes them under the `next` dist-tag.
+
+TypeScript, Python, .NET, and Ruby exchange GitHub OIDC identities for
+short-lived registry credentials. Composer and Go releases are the Git tags
+themselves: Packagist and the Go module proxy index those immutable tags. Java
+builds PGP-signed JAR, source, Javadoc, and POM artifacts and uploads their
+checksummed bundle through the Maven Central Portal API.
 
 Publishing is disabled by default. Before the first release, create a GitHub
 environment named `release` in each SDK repository and configure the registry
@@ -96,24 +102,43 @@ to trust this exact environment and workflow:
 
 | Registry | Project | Repository | Additional setup |
 | -------- | ------- | ---------- | ---------------- |
-| npm | `@cloudpdf/sdk` | `cloudpdf-sdk-typescript` | Trusted publisher for `sdk-release.yml`; allow `npm publish` |
-| PyPI | `cloudpdf` | `cloudpdf-sdk-python` | Existing or pending trusted publisher for `sdk-release.yml` |
-| NuGet | `CloudPDF` | `cloudpdf-sdk-dotnet` | Trusted publishing policy for `sdk-release.yml`; repository variable `NUGET_USER` set to the NuGet profile name |
-| RubyGems | `cloudpdf` | `cloudpdf-sdk-ruby` | Existing or pending trusted publisher for `sdk-release.yml` |
+| npm | `@cloudpdf/sdk` | `cloudpdf-sdk-typescript` | Trusted publisher for `sdk-release.yml`; environment `release`; allow `npm publish` |
+| PyPI | `cloudpdf` | `cloudpdf-sdk-python` | Existing or pending trusted publisher for `sdk-release.yml`; environment `release` |
+| Packagist | `cloudpdf/sdk` | `cloudpdf-sdk-php` | Submit the GitHub repository once and enable Packagist's GitHub auto-update hook |
+| NuGet | `CloudPDF` | `cloudpdf-sdk-dotnet` | Trusted publishing policy for `sdk-release.yml`; environment `release`; repository variable `NUGET_USER` set to the NuGet profile name |
+| Go proxy | `github.com/embedpdf/cloudpdf-sdk-go/v3` | `cloudpdf-sdk-go` | None; the workflow pushes the SemVer tag and prompts `proxy.golang.org` to index it |
+| Maven Central | `com.cloudpdf:sdk` | `cloudpdf-sdk-java` | Verified `com.cloudpdf` namespace, Portal user token, and PGP signing key as described below |
+| RubyGems | `cloudpdf` | `cloudpdf-sdk-ruby` | Existing or pending trusted publisher for `sdk-release.yml`; environment `release` |
 
-Use required reviewers on the `release` environments during rollout. Leave
-`SDK_AUTO_PUBLISH_ENABLED` unset and manually dispatch **SDK Release** once in
-each repository. After all four packages install successfully, remove the
-manual approval if desired and set the repository variable
+Required reviewers on `release` are optional. They provide an independent
+authorization boundary, but a self-approval before the job starts does not
+validate build output. Leave `SDK_AUTO_PUBLISH_ENABLED` unset and manually
+dispatch **SDK Release** once in each repository. After all seven packages
+install successfully, set the repository variable
 `SDK_AUTO_PUBLISH_ENABLED=true`; subsequent generated-source merges then
 publish automatically.
 
-The tag is created before registry authentication so a missing trusted
-publisher cannot publish untracked bytes. Fix the registry configuration and
-rerun the same commit: the workflow accepts the existing tag, skips an already
-published registry version, and fills in a missing GitHub release. A tag may be
-reused after workflow-only changes, but any different package source requires a
-new SDK version.
+For Java, generate a Maven Central Portal user token and configure these
+`release` environment secrets in `cloudpdf-sdk-java`:
+
+- `MAVEN_CENTRAL_USERNAME`
+- `MAVEN_CENTRAL_PASSWORD`
+- `MAVEN_GPG_PRIVATE_KEY`
+- `MAVEN_GPG_PASSPHRASE`
+
+The first two values are the generated Portal token credentials, not the
+interactive Central account password. Export the private signing key as ASCII
+armor and publish its public key to a Maven Central-supported keyserver before
+the first release. The workflow keeps the private key in memory, builds a local
+Maven repository, requires every artifact to have a signature, and submits an
+automatic Central deployment. Maven Central performs the authoritative
+signature validation.
+
+The tag is created before registry authentication or external publication. Fix
+the registry configuration and rerun the same commit: the workflow accepts the
+existing tag, skips an already published registry version, and fills in a
+missing GitHub release. A tag may be reused after workflow-only changes, but
+any different package source requires a new SDK version.
 
 npm trusted publishing normally requires the package to exist already. If the
 reserved `@cloudpdf/sdk` name has no published bootstrap version, perform its

--- a/fern/repository-overlays/go/.github/workflows/sdk-ci.yml
+++ b/fern/repository-overlays/go/.github/workflows/sdk-ci.yml
@@ -18,4 +18,6 @@ jobs:
         with:
           go-version: '1.21.x'
           cache-dependency-path: go.sum
+      - run: go mod tidy
+      - run: git diff --exit-code -- go.mod go.sum
       - run: go test -run '^$' ./...

--- a/fern/repository-overlays/go/.github/workflows/sdk-release.yml
+++ b/fern/repository-overlays/go/.github/workflows/sdk-release.yml
@@ -1,0 +1,115 @@
+name: SDK Release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '.github/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release Go module
+    if: github.event_name == 'workflow_dispatch' || vars.SDK_AUTO_PUBLISH_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.x'
+          cache-dependency-path: go.sum
+
+      - name: Verify generated release version
+        id: version
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const generation = JSON.parse(fs.readFileSync('cloudpdf-generation.json', 'utf8'));
+          const goMod = fs.readFileSync('go.mod', 'utf8');
+          if (generation.language !== 'go') throw new Error('generation language is not go');
+          if (!goMod.startsWith('module github.com/embedpdf/cloudpdf-sdk-go/v3\n')) {
+            throw new Error('unexpected Go module path');
+          }
+          const prerelease = generation.canonicalVersion.includes('-');
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${generation.sdkVersion}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `tag=v${generation.sdkVersion}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `prerelease=${prerelease}\n`);
+          NODE
+
+      - name: Validate Go module
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+          go test -run '^$' ./...
+
+      - name: Protect immutable release tag
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git fetch --force --tags origin
+          if git rev-parse --quiet --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
+            if [ "$tagged_commit" != "$GITHUB_SHA" ]; then
+              if git diff --quiet "$RELEASE_TAG" "$GITHUB_SHA" -- . ':(exclude).github/**'; then
+                echo "::notice::Reusing $RELEASE_TAG after a workflow-only change."
+              else
+                echo "::error::Release tag $RELEASE_TAG already points to different module source at $tagged_commit; bump the SDK version."
+                exit 1
+              fi
+            fi
+          else
+            git config user.name cloudpdf-sdk-bot
+            git config user.email hello@cloudpdf.com
+            git tag -a "$RELEASE_TAG" -m "CloudPDF Go SDK $RELEASE_TAG"
+            git push origin "refs/tags/$RELEASE_TAG"
+          fi
+
+      - name: Publish through the Go module proxy
+        env:
+          MODULE_PATH: github.com/embedpdf/cloudpdf-sdk-go/v3
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          proxy_error="$(mktemp)"
+          for attempt in $(seq 1 60); do
+            if GOPROXY=https://proxy.golang.org go list -m -json "$MODULE_PATH@$RELEASE_TAG" >module.json 2>"$proxy_error"; then
+              node <<'NODE'
+          const fs = require('node:fs');
+          const module = JSON.parse(fs.readFileSync('module.json', 'utf8'));
+          if (module.Path !== process.env.MODULE_PATH || module.Version !== process.env.RELEASE_TAG) {
+            throw new Error(`Go proxy returned ${module.Path}@${module.Version}`);
+          }
+          NODE
+              exit 0
+            fi
+            echo "Go proxy has not indexed $MODULE_PATH@$RELEASE_TAG yet (attempt $attempt/60)."
+            sleep 10
+          done
+          cat "$proxy_error"
+          echo "::error::Go proxy did not index $MODULE_PATH@$RELEASE_TAG."
+          exit 1
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            exit 0
+          fi
+          args=(--verify-tag --generate-notes --title "CloudPDF Go SDK $RELEASE_TAG")
+          if [ "$PRERELEASE" = 'true' ]; then args+=(--prerelease); fi
+          gh release create "$RELEASE_TAG" "${args[@]}"

--- a/fern/repository-overlays/java/.github/workflows/sdk-ci.yml
+++ b/fern/repository-overlays/java/.github/workflows/sdk-ci.yml
@@ -19,4 +19,4 @@ jobs:
           distribution: temurin
           java-version: '17'
           cache: gradle
-      - run: ./gradlew test --no-daemon
+      - run: ./gradlew test generatePomFileForMavenPublication jar sourcesJar javadocJar --no-daemon

--- a/fern/repository-overlays/java/.github/workflows/sdk-release.yml
+++ b/fern/repository-overlays/java/.github/workflows/sdk-release.yml
@@ -1,0 +1,241 @@
+name: SDK Release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '.github/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Publish com.cloudpdf:sdk
+    if: github.event_name == 'workflow_dispatch' || vars.SDK_AUTO_PUBLISH_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Verify generated release version
+        id: version
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const generation = JSON.parse(fs.readFileSync('cloudpdf-generation.json', 'utf8'));
+          const build = fs.readFileSync('build.gradle', 'utf8');
+          if (generation.language !== 'java') throw new Error('generation language is not java');
+          const group = build.match(/^group = '([^']+)'$/m)?.[1];
+          const projectVersion = build.match(/^version = '([^']+)'$/m)?.[1];
+          const artifact = build.match(/^\s*artifactId = '([^']+)'$/m)?.[1];
+          if (group !== 'com.cloudpdf' || artifact !== 'sdk') {
+            throw new Error(`unexpected Maven coordinates ${group}:${artifact}`);
+          }
+          if (projectVersion !== generation.sdkVersion) {
+            throw new Error(`project version ${projectVersion} does not match generated version ${generation.sdkVersion}`);
+          }
+          const prerelease = generation.canonicalVersion.includes('-');
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${projectVersion}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `tag=v${projectVersion}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `prerelease=${prerelease}\n`);
+          NODE
+
+      - name: Build signed Maven Central bundle
+        env:
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          VERSION: ${{ steps.version.outputs.version }}
+          CENTRAL_BUNDLE: ${{ runner.temp }}/cloudpdf-central-bundle.zip
+        run: |
+          ./gradlew clean test publishMavenPublicationToCentralStagingRepository --no-daemon
+          release_directory="build/central-staging/com/cloudpdf/sdk/$VERSION"
+          required_artifacts=(
+            "sdk-$VERSION.pom"
+            "sdk-$VERSION.jar"
+            "sdk-$VERSION-sources.jar"
+            "sdk-$VERSION-javadoc.jar"
+          )
+          for artifact in "${required_artifacts[@]}"; do
+            if [ ! -f "$release_directory/$artifact" ]; then
+              echo "::error::Maven Central bundle is missing $artifact."
+              exit 1
+            fi
+            if [ ! -f "$release_directory/$artifact.asc" ]; then
+              echo "::error::Maven artifact $artifact is not signed."
+              exit 1
+            fi
+          done
+
+          python3 <<'PY'
+          import os
+          import xml.etree.ElementTree as ET
+
+          version = os.environ['VERSION']
+          pom = ET.parse(f'build/central-staging/com/cloudpdf/sdk/{version}/sdk-{version}.pom').getroot()
+          namespace = {'m': 'http://maven.apache.org/POM/4.0.0'}
+          expected = {
+              'm:groupId': 'com.cloudpdf',
+              'm:artifactId': 'sdk',
+              'm:version': version,
+              'm:name': 'CloudPDF',
+              'm:url': 'https://www.cloudpdf.com',
+              'm:scm/m:url': 'https://github.com/embedpdf/cloudpdf-sdk-java',
+          }
+          for path, value in expected.items():
+              actual = pom.findtext(path, namespaces=namespace)
+              if actual != value:
+                  raise RuntimeError(f'POM {path} is {actual!r}, expected {value!r}')
+          PY
+
+          bundle_root="$RUNNER_TEMP/cloudpdf-central-bundle"
+          bundle_release="$bundle_root/com/cloudpdf/sdk/$VERSION"
+          mkdir -p "$bundle_release"
+          for artifact in "${required_artifacts[@]}"; do
+            cp "$release_directory/$artifact" "$bundle_release/$artifact"
+            cp "$release_directory/$artifact.asc" "$bundle_release/$artifact.asc"
+            md5sum "$release_directory/$artifact" | awk '{ print $1 }' > "$bundle_release/$artifact.md5"
+            sha1sum "$release_directory/$artifact" | awk '{ print $1 }' > "$bundle_release/$artifact.sha1"
+          done
+
+          cd "$bundle_root"
+          zip -q -r "$CENTRAL_BUNDLE" com
+
+      - name: Protect immutable release tag
+        id: release-tag
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git fetch --force --tags origin
+          if git rev-parse --quiet --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
+            if [ "$tagged_commit" != "$GITHUB_SHA" ]; then
+              if git diff --quiet "$RELEASE_TAG" "$GITHUB_SHA" -- . ':(exclude).github/**'; then
+                echo "::notice::Reusing $RELEASE_TAG after a workflow-only change."
+              else
+                echo "::error::Release tag $RELEASE_TAG already points to different package source at $tagged_commit; bump the SDK version."
+                exit 1
+              fi
+            fi
+            echo "existed=true" >> "$GITHUB_OUTPUT"
+          else
+            git config user.name cloudpdf-sdk-bot
+            git config user.email hello@cloudpdf.com
+            git tag -a "$RELEASE_TAG" -m "CloudPDF Java SDK $RELEASE_TAG"
+            git push origin "refs/tags/$RELEASE_TAG"
+            echo "existed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check Maven Central publication state
+        id: registry
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG_EXISTED: ${{ steps.release-tag.outputs.existed }}
+        run: |
+          package_url="https://repo1.maven.org/maven2/com/cloudpdf/sdk/$VERSION/sdk-$VERSION.pom"
+          http_status="$(curl --silent --show-error --output /dev/null --write-out '%{http_code}' "$package_url")"
+          case "$http_status" in
+            200)
+              if [ "$TAG_EXISTED" != 'true' ]; then
+                echo "::error::com.cloudpdf:sdk:$VERSION exists on Maven Central but its release tag did not exist."
+                exit 1
+              fi
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              ;;
+            404)
+              echo "publish=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Maven Central returned HTTP $http_status while checking com.cloudpdf:sdk:$VERSION."
+              exit 1
+              ;;
+          esac
+
+      - name: Upload to Maven Central
+        if: steps.registry.outputs.publish == 'true'
+        id: central
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          CENTRAL_BUNDLE: ${{ runner.temp }}/cloudpdf-central-bundle.zip
+        run: |
+          central_auth="$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64 --wrap=0)"
+          echo "::add-mask::$central_auth"
+          deployment_id="$(curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $central_auth" \
+            --form "bundle=@$CENTRAL_BUNDLE;type=application/octet-stream" \
+            'https://central.sonatype.com/api/v1/publisher/upload?publishingType=AUTOMATIC')"
+          if ! printf '%s' "$deployment_id" | grep -Eq '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'; then
+            echo "::error::Maven Central returned an invalid deployment ID."
+            exit 1
+          fi
+          echo "deployment_id=$deployment_id" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for Maven Central publication
+        if: steps.registry.outputs.publish == 'true'
+        env:
+          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          DEPLOYMENT_ID: ${{ steps.central.outputs.deployment_id }}
+        run: |
+          central_auth="$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64 --wrap=0)"
+          echo "::add-mask::$central_auth"
+          status_file="$(mktemp)"
+          for attempt in $(seq 1 120); do
+            curl --fail-with-body --silent --show-error \
+              --request POST \
+              --header "Authorization: Bearer $central_auth" \
+              --output "$status_file" \
+              "https://central.sonatype.com/api/v1/publisher/status?id=$DEPLOYMENT_ID"
+            deployment_state="$(jq --raw-output '.deploymentState' "$status_file")"
+            case "$deployment_state" in
+              PUBLISHED)
+                exit 0
+                ;;
+              FAILED)
+                cat "$status_file"
+                echo "::error::Maven Central rejected deployment $DEPLOYMENT_ID."
+                exit 1
+                ;;
+              PENDING|VALIDATING|VALIDATED|PUBLISHING)
+                echo "Maven Central deployment is $deployment_state (attempt $attempt/120)."
+                ;;
+              *)
+                cat "$status_file"
+                echo "::error::Maven Central returned unexpected deployment state $deployment_state."
+                exit 1
+                ;;
+            esac
+            sleep 10
+          done
+          echo "::error::Maven Central deployment $DEPLOYMENT_ID did not finish within 20 minutes."
+          exit 1
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            exit 0
+          fi
+          args=(--verify-tag --generate-notes --title "CloudPDF Java SDK $RELEASE_TAG")
+          if [ "$PRERELEASE" = 'true' ]; then args+=(--prerelease); fi
+          gh release create "$RELEASE_TAG" "${args[@]}"

--- a/fern/repository-overlays/php/.github/workflows/sdk-release.yml
+++ b/fern/repository-overlays/php/.github/workflows/sdk-release.yml
@@ -1,0 +1,141 @@
+name: SDK Release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '.github/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sdk-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Release cloudpdf/sdk
+    if: github.event_name == 'workflow_dispatch' || vars.SDK_AUTO_PUBLISH_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer
+
+      - name: Verify generated release version
+        id: version
+        run: |
+          php <<'PHP'
+          <?php
+          $manifest = json_decode(file_get_contents('composer.json'), true, flags: JSON_THROW_ON_ERROR);
+          $generation = json_decode(file_get_contents('cloudpdf-generation.json'), true, flags: JSON_THROW_ON_ERROR);
+          if ($generation['language'] !== 'php') {
+              throw new RuntimeException('generation language is not php');
+          }
+          if ($manifest['name'] !== 'cloudpdf/sdk') {
+              throw new RuntimeException("unexpected Composer package {$manifest['name']}");
+          }
+          if (array_key_exists('version', $manifest)) {
+              throw new RuntimeException('composer.json version must be derived from the release tag');
+          }
+          $client = file_get_contents('src/CloudPDFClient.php');
+          if (!str_contains($client, $generation['sdkVersion'])) {
+              throw new RuntimeException('generated client version does not match generation metadata');
+          }
+          $prerelease = str_contains($generation['canonicalVersion'], '-');
+          $output = fopen(getenv('GITHUB_OUTPUT'), 'a');
+          fwrite($output, "version={$generation['sdkVersion']}\n");
+          fwrite($output, "tag=v{$generation['sdkVersion']}\n");
+          fwrite($output, 'prerelease=' . ($prerelease ? 'true' : 'false') . "\n");
+          PHP
+
+      - name: Validate package and autoloading
+        run: |
+          find src -type f -name '*.php' -print0 | xargs -0 -P 4 -n1 php -l >/dev/null
+          composer validate --no-check-publish --no-interaction
+          composer dump-autoload --no-dev --no-interaction --optimize --strict-psr --quiet
+          php -r "require 'vendor/autoload.php'; if (!class_exists(CloudPDF\\CloudPDFClient::class)) { throw new RuntimeException('CloudPDF client autoload verification failed'); }"
+
+      - name: Protect immutable release tag
+        id: release-tag
+        env:
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git fetch --force --tags origin
+          if git rev-parse --quiet --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+            tagged_commit="$(git rev-list -n 1 "$RELEASE_TAG")"
+            if [ "$tagged_commit" != "$GITHUB_SHA" ]; then
+              if git diff --quiet "$RELEASE_TAG" "$GITHUB_SHA" -- . ':(exclude).github/**'; then
+                echo "::notice::Reusing $RELEASE_TAG after a workflow-only change."
+              else
+                echo "::error::Release tag $RELEASE_TAG already points to different package source at $tagged_commit; bump the SDK version."
+                exit 1
+              fi
+            fi
+          else
+            git config user.name cloudpdf-sdk-bot
+            git config user.email hello@cloudpdf.com
+            git tag -a "$RELEASE_TAG" -m "CloudPDF PHP SDK $RELEASE_TAG"
+            git push origin "refs/tags/$RELEASE_TAG"
+            tagged_commit="$GITHUB_SHA"
+          fi
+          echo "commit=$tagged_commit" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for Packagist publication
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAGGED_COMMIT: ${{ steps.release-tag.outputs.commit }}
+          METADATA_FILE: ${{ runner.temp }}/cloudpdf-packagist-metadata.json
+        run: |
+          metadata_file="$METADATA_FILE"
+          for attempt in $(seq 1 60); do
+            http_status="$(curl --silent --show-error --location --output "$metadata_file" --write-out '%{http_code}' https://repo.packagist.org/p2/cloudpdf/sdk.json)"
+            if [ "$http_status" = '200' ]; then
+              if node <<'NODE'
+          const fs = require('node:fs');
+          const metadata = JSON.parse(fs.readFileSync(process.env.METADATA_FILE, 'utf8'));
+          const releases = metadata.packages?.['cloudpdf/sdk'] ?? [];
+          const release = releases.find((candidate) => candidate.version === process.env.VERSION);
+          if (!release) process.exit(2);
+          if (release.source?.reference !== process.env.TAGGED_COMMIT) {
+            throw new Error(`Packagist ${process.env.VERSION} points to ${release.source?.reference}, expected ${process.env.TAGGED_COMMIT}`);
+          }
+          NODE
+              then
+                exit 0
+              else
+                node_status="$?"
+                if [ "$node_status" -ne 2 ]; then exit "$node_status"; fi
+              fi
+            elif [ "$http_status" != '404' ]; then
+              echo "::error::Packagist returned HTTP $http_status while checking cloudpdf/sdk $VERSION."
+              exit 1
+            fi
+            echo "Packagist has not indexed cloudpdf/sdk $VERSION yet (attempt $attempt/60)."
+            sleep 10
+          done
+          echo "::error::Packagist did not index cloudpdf/sdk $VERSION. Register the repository and enable its GitHub hook, then rerun."
+          exit 1
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            exit 0
+          fi
+          args=(--verify-tag --generate-notes --title "CloudPDF PHP SDK $RELEASE_TAG")
+          if [ "$PRERELEASE" = 'true' ]; then args+=(--prerelease); fi
+          gh release create "$RELEASE_TAG" "${args[@]}"

--- a/fern/scripts/record-sdk-metadata.mjs
+++ b/fern/scripts/record-sdk-metadata.mjs
@@ -58,6 +58,26 @@ if (language === 'typescript') {
   writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 4)}\n`);
 }
 
+if (language === 'php') {
+  const manifestPath = `${outputDirectory}/composer.json`;
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  // Packagist derives versions from immutable VCS tags and Composer warns when
+  // a published library hard-codes its version in composer.json.
+  delete manifest.version;
+  manifest.authors = [
+    {
+      name: 'CloudPDF',
+      email: 'hello@cloudpdf.com',
+      homepage: 'https://www.cloudpdf.com',
+    },
+  ];
+  manifest.support = {
+    issues: 'https://github.com/embedpdf/cloudpdf-sdk-php/issues',
+    source: 'https://github.com/embedpdf/cloudpdf-sdk-php',
+  };
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
 if (language === 'python') {
   const projectPath = `${outputDirectory}/pyproject.toml`;
   const project = readFileSync(projectPath, 'utf8')
@@ -117,5 +137,90 @@ if (language === 'csharp') {
       '<FileVersion>$(Version)</FileVersion>',
       `<FileVersion>${numericBinaryVersion}</FileVersion>`,
     );
+  writeFileSync(projectPath, project);
+}
+
+// Maven Central requires source and Javadoc artifacts, complete POM metadata,
+// and a PGP signature for every published artifact. Fern generates the first
+// two but currently leaves placeholder SCM URLs and an OSSRH-era remote
+// repository. Stage a signed local Maven repository instead; the repository
+// release workflow bundles and uploads it through the Central Portal API.
+if (language === 'java') {
+  const projectPath = `${outputDirectory}/build.gradle`;
+  const project = readFileSync(projectPath, 'utf8')
+    .replace("    id 'maven-publish'\n", "    id 'maven-publish'\n    id 'signing'\n")
+    .replace(
+      `                licenses {
+                    license {
+                        name = 'APACHE-2.0'
+                    }
+                }`,
+      `                licenses {
+                    license {
+                        name = 'Apache License, Version 2.0'
+                        url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                        distribution = 'repo'
+                    }
+                }`,
+    )
+    .replace(
+      `                developers {
+                    developer {
+                        name = 'CloudPDF'
+                        email = 'hello@cloudpdf.com'
+                    }
+                }`,
+      `                developers {
+                    developer {
+                        id = 'cloudpdf'
+                        name = 'CloudPDF'
+                        email = 'hello@cloudpdf.com'
+                        organization = 'CloudPDF'
+                        organizationUrl = 'https://www.cloudpdf.com'
+                    }
+                }`,
+    )
+    .replace(
+      `                scm {
+                    connection = 'scm:git:git://github.com/YOUR-ORG/YOUR-REPO.git'
+                    developerConnection = 'scm:git:git://github.com/YOUR-ORG/YOUR-REPO.git'
+                    url = 'https://github.com/YOUR-ORG/YOUR-REPO'
+                }`,
+      `                scm {
+                    connection = 'scm:git:https://github.com/embedpdf/cloudpdf-sdk-java.git'
+                    developerConnection = 'scm:git:ssh://git@github.com/embedpdf/cloudpdf-sdk-java.git'
+                    url = 'https://github.com/embedpdf/cloudpdf-sdk-java'
+                }`,
+    )
+    .replace(
+      `    repositories {
+        maven {
+            url "$System.env.MAVEN_PUBLISH_REGISTRY_URL"
+            credentials {
+                username "$System.env.MAVEN_USERNAME"
+                password "$System.env.MAVEN_PASSWORD"
+            }
+        }
+    }`,
+      `    repositories {
+        maven {
+            name = 'centralStaging'
+            url = layout.buildDirectory.dir('central-staging')
+        }
+    }`,
+    )
+    .concat(`
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}
+
+signing {
+    useInMemoryPgpKeys(
+        System.getenv('MAVEN_GPG_PRIVATE_KEY'),
+        System.getenv('MAVEN_GPG_PASSPHRASE')
+    )
+    sign publishing.publications.maven
+}
+`);
   writeFileSync(projectPath, project);
 }

--- a/fern/scripts/sdk-repositories.test.mjs
+++ b/fern/scripts/sdk-repositories.test.mjs
@@ -35,8 +35,8 @@ test('the C# generator publishes source to the consumer-facing .NET repository',
   assert.equal(sdkRepository('csharp').displayName, '.NET');
 });
 
-test('trusted-publishing SDKs receive guarded repository release workflows', () => {
-  for (const language of ['typescript', 'python', 'csharp', 'ruby']) {
+test('every SDK receives a guarded repository release workflow', () => {
+  for (const language of LANGUAGES) {
     const workflowPath = join(
       repositoryDirectory,
       'fern',
@@ -50,11 +50,34 @@ test('trusted-publishing SDKs receive guarded repository release workflows', () 
     const workflow = readFileSync(workflowPath, 'utf8');
     assert.match(workflow, /SDK_AUTO_PUBLISH_ENABLED/);
     assert.match(workflow, /environment: release/);
-    assert.match(workflow, /id-token: write/);
     assert.match(workflow, /cloudpdf-generation\.json/);
     assert.match(workflow, /Protect immutable release tag/);
     assert.match(workflow, /Create GitHub release/);
   }
+});
+
+test('release workflows use each registry publishing mechanism', () => {
+  const workflow = (language) =>
+    readFileSync(
+      join(
+        repositoryDirectory,
+        'fern',
+        'repository-overlays',
+        language,
+        '.github',
+        'workflows',
+        'sdk-release.yml',
+      ),
+      'utf8',
+    );
+
+  for (const language of ['typescript', 'python', 'csharp', 'ruby']) {
+    assert.match(workflow(language), /id-token: write/);
+  }
+  assert.match(workflow('php'), /repo\.packagist\.org/);
+  assert.match(workflow('go'), /proxy\.golang\.org/);
+  assert.match(workflow('java'), /central\.sonatype\.com\/api\/v1\/publisher\/upload/);
+  assert.match(workflow('java'), /MAVEN_GPG_PRIVATE_KEY/);
 });
 
 test('unknown languages and fields fail explicitly', () => {

--- a/fern/scripts/validate-sdk.mjs
+++ b/fern/scripts/validate-sdk.mjs
@@ -100,8 +100,13 @@ switch (language) {
   case 'php': {
     const manifest = readJson('composer.json');
     assert(manifest.name === 'cloudpdf/sdk', `composer.json name is ${manifest.name}`);
-    assert(manifest.version === expectedVersion, `composer.json version is ${manifest.version}`);
+    assert(!('version' in manifest), 'composer.json version must be derived from the Packagist tag');
     assert(manifest.license === 'Apache-2.0', `composer.json license is ${manifest.license}`);
+    assert(manifest.authors?.[0]?.name === 'CloudPDF', 'Composer author is not CloudPDF');
+    assert(
+      manifest.support?.source === 'https://github.com/embedpdf/cloudpdf-sdk-php',
+      'Composer source URL is not the PHP SDK repository',
+    );
     includes('src/CloudPDFClient.php', expectedVersion);
     includes('src/CloudPDFClient.php', 'class CloudPDFClient');
     includes('src/Exceptions/CloudPDFException.php', 'class CloudPDFException');
@@ -161,7 +166,25 @@ switch (language) {
       build.includes(`version = '${expectedVersion}'`),
       `Gradle version is not ${expectedVersion}`,
     );
-    assert(build.includes("name = 'APACHE-2.0'"), 'Maven license is not Apache-2.0');
+    assert(build.includes("id 'signing'"), 'Gradle signing plugin is not enabled');
+    assert(
+      build.includes("name = 'Apache License, Version 2.0'"),
+      'Maven license name is not publication-ready',
+    );
+    assert(
+      build.includes("url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'"),
+      'Maven license URL is not publication-ready',
+    );
+    assert(
+      build.includes("url = 'https://github.com/embedpdf/cloudpdf-sdk-java'"),
+      'Maven SCM URL is not the Java SDK repository',
+    );
+    assert(build.includes("name = 'centralStaging'"), 'Central staging repository is missing');
+    assert(
+      build.includes("System.getenv('MAVEN_GPG_PRIVATE_KEY')"),
+      'in-memory Maven signing key is not configured',
+    );
+    assert(!build.includes('YOUR-ORG'), 'placeholder Maven SCM organization remains');
     includes('src/main/java/api/CloudPDFClient.java', 'package com.cloudpdf.api;');
     includes('src/main/java/api/CloudPDFClient.java', 'class CloudPDFClient');
     includes('src/main/java/api/core/CloudPDFException.java', 'class CloudPDFException');


### PR DESCRIPTION
Introduce guarded SDK release workflows for Go, Java, and PHP and expand README registry publishing details to cover all seven SDKs (npm, PyPI, Packagist, NuGet, Go proxy, Maven Central, RubyGems). CI tweaks: Go CI runs go mod tidy and checks go.mod/go.sum; Java CI builds jar, sources and javadoc. Recording scripts update composer.json for Packagist and enhance build.gradle for Maven Central signing/staging. Tests and validation updated to assert per-language release workflows and registry-specific checks, plus stronger PHP/Java validation.