### PR TITLE
php: create release; accept v-prefixed versions

### DIFF
--- a/fern/repository-overlays/php/.github/workflows/sdk-release.yml
+++ b/fern/repository-overlays/php/.github/workflows/sdk-release.yml
@@ -91,6 +91,19 @@ jobs:
           fi
           echo "commit=$tagged_commit" >> "$GITHUB_OUTPUT"
 
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+        run: |
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            exit 0
+          fi
+          args=(--verify-tag --generate-notes --title "CloudPDF PHP SDK $RELEASE_TAG")
+          if [ "$PRERELEASE" = 'true' ]; then args+=(--prerelease); fi
+          gh release create "$RELEASE_TAG" "${args[@]}"
+
       - name: Wait for Packagist publication
         env:
           VERSION: ${{ steps.version.outputs.version }}
@@ -105,7 +118,8 @@ jobs:
           const fs = require('node:fs');
           const metadata = JSON.parse(fs.readFileSync(process.env.METADATA_FILE, 'utf8'));
           const releases = metadata.packages?.['cloudpdf/sdk'] ?? [];
-          const release = releases.find((candidate) => candidate.version === process.env.VERSION);
+          const acceptableVersions = new Set([process.env.VERSION, `v${process.env.VERSION}`]);
+          const release = releases.find((candidate) => acceptableVersions.has(candidate.version));
           if (!release) process.exit(2);
           if (release.source?.reference !== process.env.TAGGED_COMMIT) {
             throw new Error(`Packagist ${process.env.VERSION} points to ${release.source?.reference}, expected ${process.env.TAGGED_COMMIT}`);
@@ -126,16 +140,3 @@ jobs:
           done
           echo "::error::Packagist did not index cloudpdf/sdk $VERSION. Register the repository and enable its GitHub hook, then rerun."
           exit 1
-
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ steps.version.outputs.tag }}
-          PRERELEASE: ${{ steps.version.outputs.prerelease }}
-        run: |
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
-            exit 0
-          fi
-          args=(--verify-tag --generate-notes --title "CloudPDF PHP SDK $RELEASE_TAG")
-          if [ "$PRERELEASE" = 'true' ]; then args+=(--prerelease); fi
-          gh release create "$RELEASE_TAG" "${args[@]}"

--- a/fern/scripts/sdk-repositories.test.mjs
+++ b/fern/scripts/sdk-repositories.test.mjs
@@ -75,6 +75,7 @@ test('release workflows use each registry publishing mechanism', () => {
     assert.match(workflow(language), /id-token: write/);
   }
   assert.match(workflow('php'), /repo\.packagist\.org/);
+  assert.match(workflow('php'), /acceptableVersions/);
   assert.match(workflow('go'), /proxy\.golang\.org/);
   assert.match(workflow('java'), /central\.sonatype\.com\/api\/v1\/publisher\/upload/);
   assert.match(workflow('java'), /MAVEN_GPG_PRIVATE_KEY/);


### PR DESCRIPTION
Add a GitHub release step to the PHP SDK workflow (removed a duplicate block). Update the Packagist publication check to accept both plain and v-prefixed versions when matching indexed releases. Also update the test to assert the new acceptableVersions handling. This ensures releases are created once and Packagist indexing works for tags like v1.2.3 as well as 1.2.3.