### PR TITLE
Implement TypeScript SDK generation wrapper

### DIFF
--- a/.github/workflows/sdk-generate.yml
+++ b/.github/workflows/sdk-generate.yml
@@ -136,24 +136,29 @@ jobs:
         env:
           LANGUAGE: ${{ matrix.language }}
           SDK_VERSION: ${{ steps.version.outputs.sdk }}
+          CLOUDPDF_FERN_CLI: fern
         run: |
-          fern generate \
-            --group "$LANGUAGE" \
-            --local \
-            --version "$SDK_VERSION" \
-            --force \
-            --no-prompt \
-            --generate-tests \
-            --log-level info
+          if [[ "$LANGUAGE" == "typescript" ]]; then
+            node fern/scripts/generate-typescript-sdk.mjs
+          else
+            fern generate \
+              --group "$LANGUAGE" \
+              --local \
+              --version "$SDK_VERSION" \
+              --force \
+              --no-prompt \
+              --generate-tests \
+              --log-level info
+          fi
 
       - name: Record generation metadata
-        if: steps.select.outputs.enabled == 'true'
+        if: steps.select.outputs.enabled == 'true' && matrix.language != 'typescript'
         env:
           LANGUAGE: ${{ matrix.language }}
         run: node fern/scripts/record-sdk-metadata.mjs "$LANGUAGE"
 
       - name: Validate generated SDK
-        if: steps.select.outputs.enabled == 'true'
+        if: steps.select.outputs.enabled == 'true' && matrix.language != 'typescript'
         env:
           LANGUAGE: ${{ matrix.language }}
         run: node fern/scripts/validate-sdk.mjs "$LANGUAGE"

--- a/cloudpdf/contract/package.json
+++ b/cloudpdf/contract/package.json
@@ -23,7 +23,7 @@
     "build": "tsup",
     "clean": "rimraf dist",
     "dev": "tsup --watch",
-    "emit:openapi": "tsup && node scripts/emit-openapi.mjs",
+    "emit:openapi": "tsup && node scripts/emit-openapi.mjs && prettier --write openapi.json",
     "test": "vitest run",
     "lint": "eslint src --color",
     "lint:fix": "eslint src --color --fix"

--- a/cloudpdf/sdk/.fern/metadata.json
+++ b/cloudpdf/sdk/.fern/metadata.json
@@ -25,6 +25,6 @@
     },
     "originGitCommit": null,
     "originGitCommitIsDirty": null,
-    "requestedVersion": "3.0.0-next.1",
-    "sdkVersion": "3.0.0-next.1"
+    "requestedVersion": "3.0.0-next.2",
+    "sdkVersion": "3.0.0-next.2"
 }

--- a/cloudpdf/sdk/.fernignore
+++ b/cloudpdf/sdk/.fernignore
@@ -4,3 +4,8 @@ src/CloudPDFClient.ts
 src/uploads/**
 tests/uploads.test.ts
 README.md
+
+# Changesets is the sole owner of the published package changelog. The pinned
+# generator currently writes it despite this rule, so the TypeScript generation
+# wrapper also snapshots and restores the file around Fern.
+CHANGELOG.md

--- a/cloudpdf/sdk/cloudpdf-generation.json
+++ b/cloudpdf/sdk/cloudpdf-generation.json
@@ -1,11 +1,11 @@
 {
   "language": "typescript",
-  "canonicalVersion": "3.0.0-next.1",
-  "sdkVersion": "3.0.0-next.1",
+  "canonicalVersion": "3.0.0-next.2",
+  "sdkVersion": "3.0.0-next.2",
   "source": {
     "repository": "embedpdf/embed-pdf-viewer",
     "openapi": "cloudpdf/contract/openapi.json",
-    "openapiSha256": "65f9768ac3d27301ed0fa7cd3b27e613e463945966ab42f1cec94ae216d979c1",
+    "openapiSha256": "afef16ae2ee6de353cf141d766e4815df5cee075c906b34c728c1176bc10ddb1",
     "gitCommit": null,
     "gitCommitIsDirty": null
   },

--- a/cloudpdf/sdk/src/BaseClient.ts
+++ b/cloudpdf/sdk/src/BaseClient.ts
@@ -64,8 +64,8 @@ export function normalizeClientOptions<T extends BaseClientOptions = BaseClientO
         {
             "X-Fern-Language": "JavaScript",
             "X-Fern-SDK-Name": "@cloudpdf/sdk",
-            "X-Fern-SDK-Version": "3.0.0-next.1",
-            "User-Agent": "@cloudpdf/sdk/3.0.0-next.1",
+            "X-Fern-SDK-Version": "3.0.0-next.2",
+            "User-Agent": "@cloudpdf/sdk/3.0.0-next.2",
             "X-Fern-Runtime": core.RUNTIME.type,
             "X-Fern-Runtime-Version": core.RUNTIME.version,
         },

--- a/cloudpdf/sdk/src/version.ts
+++ b/cloudpdf/sdk/src/version.ts
@@ -1,1 +1,1 @@
-export const SDK_VERSION = "3.0.0-next.1";
+export const SDK_VERSION = "3.0.0-next.2";

--- a/fern/README.md
+++ b/fern/README.md
@@ -213,6 +213,21 @@ Each artifact includes `cloudpdf-generation.json` with the canonical and mapped
 SDK versions, the exact OpenAPI SHA-256, source commit state, Fern CLI version,
 and language generator version.
 
+The TypeScript SDK is a committed workspace package, so a Changesets version PR
+regenerates it after resolving the new canonical version. Run that same path
+locally with:
+
+```bash
+pnpm run cloudpdf:sdk:generate
+```
+
+The command pins Fern CLI 5.91.0, generates `cloudpdf/sdk`, records normalized
+metadata, and validates every version-bearing file. Changesets is the sole owner
+of `CHANGELOG.md`; the wrapper snapshots and restores it because Fern currently
+writes a release heading even when the file is in `.fernignore`. `ci:publish`
+repeats the TypeScript validation before npm publishing, independently of the
+SDK freshness workflow.
+
 The repository sync replaces generated source on its version branch while
 keeping each destination repository's `.github` directory repository-owned.
 The checked-in overlays install and update the repository CI and release

--- a/fern/scripts/generate-typescript-sdk.mjs
+++ b/fern/scripts/generate-typescript-sdk.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+import { restoreFile, snapshotFile } from './generated-file-ownership.mjs';
+import { mapSdkVersion, readCanonicalVersion } from './sdk-version.mjs';
+
+export const FERN_CLI_VERSION = '5.91.0';
+
+const repositoryDirectory = fileURLToPath(new URL('../../', import.meta.url));
+const sdkVersion = mapSdkVersion(readCanonicalVersion(), 'typescript');
+const configuredFern = process.env.CLOUDPDF_FERN_CLI;
+const fernCommand = configuredFern || 'npx';
+const fernPrefix = configuredFern ? [] : ['--yes', `fern-api@${FERN_CLI_VERSION}`];
+const changelogPath = `${repositoryDirectory}cloudpdf/sdk/CHANGELOG.md`;
+const changesetsChangelog = snapshotFile(changelogPath);
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: repositoryDirectory,
+    env: process.env,
+    stdio: 'inherit',
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const outcome = result.signal ? `signal ${result.signal}` : `exit code ${result.status}`;
+    throw new Error(`${command} ${args.join(' ')} failed with ${outcome}`);
+  }
+}
+
+// Fern currently synthesizes a release heading even when CHANGELOG.md is in
+// .fernignore. Changesets owns this file, so restore its exact pre-generation
+// state before recording or validating the generated SDK.
+try {
+  run(fernCommand, [
+    ...fernPrefix,
+    'generate',
+    '--group',
+    'typescript',
+    '--local',
+    '--version',
+    sdkVersion,
+    '--force',
+    '--no-prompt',
+    '--generate-tests',
+    '--log-level',
+    'info',
+  ]);
+} finally {
+  restoreFile(changelogPath, changesetsChangelog);
+}
+
+run(process.execPath, ['fern/scripts/record-sdk-metadata.mjs', 'typescript']);
+run(process.execPath, ['fern/scripts/validate-sdk.mjs', 'typescript']);

--- a/fern/scripts/generated-file-ownership.mjs
+++ b/fern/scripts/generated-file-ownership.mjs
@@ -1,0 +1,13 @@
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+
+export function snapshotFile(path) {
+  return existsSync(path) ? readFileSync(path, 'utf8') : null;
+}
+
+export function restoreFile(path, snapshot) {
+  if (snapshot === null) {
+    if (existsSync(path)) unlinkSync(path);
+    return;
+  }
+  writeFileSync(path, snapshot);
+}

--- a/fern/scripts/release-versioning.test.mjs
+++ b/fern/scripts/release-versioning.test.mjs
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { restoreFile, snapshotFile } from './generated-file-ownership.mjs';
+import { repositoryDirectory } from './sdk-version.mjs';
+
+const read = (path) => readFileSync(join(repositoryDirectory, path), 'utf8');
+const rootManifest = JSON.parse(read('package.json'));
+const contractManifest = JSON.parse(read('cloudpdf/contract/package.json'));
+
+test('Changesets materializes the committed TypeScript SDK before refreshing docs', () => {
+  const version = rootManifest.scripts['ci:version'];
+  const orderedSteps = [
+    'changeset version',
+    'pnpm --filter @cloudpdf/contract emit:openapi',
+    'pnpm run cloudpdf:sdk:generate',
+    'pnpm --filter @cloudpdf/website api:metadata',
+    'pnpm --filter @cloudpdf/website api:pages',
+  ];
+
+  let previous = -1;
+  for (const step of orderedSteps) {
+    const index = version.indexOf(step);
+    assert.ok(index > previous, `${step} is missing or out of order in ci:version`);
+    previous = index;
+  }
+  assert.doesNotMatch(version, /prettier/);
+  assert.match(contractManifest.scripts['emit:openapi'], /prettier --write openapi\.json/);
+});
+
+test('the release command blocks stale committed TypeScript SDKs', () => {
+  const publish = rootManifest.scripts['ci:publish'];
+  const validate = publish.indexOf('node fern/scripts/validate-sdk.mjs typescript');
+  const publishPackages = publish.indexOf('pnpm publish -r');
+  assert.ok(validate !== -1 && validate < publishPackages);
+});
+
+test('the generated SDK leaves its Changesets changelog untouched', () => {
+  const ignored = read('cloudpdf/sdk/.fernignore')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+  assert.ok(ignored.includes('CHANGELOG.md'));
+
+  const directory = mkdtempSync(join(tmpdir(), 'cloudpdf-changelog-ownership-'));
+  try {
+    const existing = join(directory, 'existing.md');
+    writeFileSync(existing, 'Changesets\n');
+    const existingSnapshot = snapshotFile(existing);
+    writeFileSync(existing, 'Fern\n');
+    restoreFile(existing, existingSnapshot);
+    assert.equal(readFileSync(existing, 'utf8'), 'Changesets\n');
+
+    const absent = join(directory, 'absent.md');
+    const absentSnapshot = snapshotFile(absent);
+    writeFileSync(absent, 'Fern\n');
+    restoreFile(absent, absentSnapshot);
+    assert.throws(() => readFileSync(absent, 'utf8'), /ENOENT/);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test('versioning and SDK freshness use one pinned TypeScript generator path', () => {
+  assert.equal(
+    rootManifest.scripts['cloudpdf:sdk:generate'],
+    'node fern/scripts/generate-typescript-sdk.mjs',
+  );
+
+  const generator = read('fern/scripts/generate-typescript-sdk.mjs');
+  assert.match(generator, /FERN_CLI_VERSION = '5\.91\.0'/);
+  assert.match(generator, /readCanonicalVersion\(\)/);
+  assert.match(generator, /'--group',\s*'typescript'/);
+  assert.match(generator, /changesetsChangelog/);
+  assert.match(generator, /finally/);
+  assert.match(generator, /restoreFile\(changelogPath, changesetsChangelog\)/);
+  assert.match(generator, /record-sdk-metadata\.mjs', 'typescript'/);
+  assert.match(generator, /validate-sdk\.mjs', 'typescript'/);
+
+  const workflow = read('.github/workflows/sdk-generate.yml');
+  assert.match(workflow, /npm install -g fern-api@5\.91\.0/);
+  assert.match(workflow, /CLOUDPDF_FERN_CLI: fern/);
+  assert.match(workflow, /node fern\/scripts\/generate-typescript-sdk\.mjs/);
+});

--- a/fern/scripts/release-versioning.test.mjs
+++ b/fern/scripts/release-versioning.test.mjs
@@ -85,3 +85,19 @@ test('versioning and SDK freshness use one pinned TypeScript generator path', ()
   assert.match(workflow, /CLOUDPDF_FERN_CLI: fern/);
   assert.match(workflow, /node fern\/scripts\/generate-typescript-sdk\.mjs/);
 });
+
+test('Fern sdkVersion validation is scoped to the TypeScript generator', () => {
+  const validator = read('fern/scripts/validate-sdk.mjs');
+  const switchIndex = validator.indexOf('switch (language)');
+  const typescriptIndex = validator.indexOf("case 'typescript':", switchIndex);
+  const pythonIndex = validator.indexOf("case 'python':", typescriptIndex);
+
+  assert.notEqual(switchIndex, -1);
+  assert.notEqual(typescriptIndex, -1);
+  assert.notEqual(pythonIndex, -1);
+  assert.doesNotMatch(validator.slice(0, switchIndex), /fernMetadata\.sdkVersion/);
+  assert.match(
+    validator.slice(typescriptIndex, pythonIndex),
+    /fernMetadata\.sdkVersion === expectedVersion/,
+  );
+});

--- a/fern/scripts/validate-sdk.mjs
+++ b/fern/scripts/validate-sdk.mjs
@@ -51,10 +51,6 @@ assert(
   fernMetadata.requestedVersion === expectedVersion,
   `.fern/metadata.json requestedVersion is ${fernMetadata.requestedVersion}, expected ${expectedVersion}`,
 );
-assert(
-  fernMetadata.sdkVersion === expectedVersion,
-  `.fern/metadata.json sdkVersion is ${fernMetadata.sdkVersion}, expected ${expectedVersion}`,
-);
 includes('LICENSE', 'Apache License');
 includes('README.md', `# CloudPDF ${languageNames[language]} SDK`);
 assertCanonicalCloudPdfCasing(outputDirectory);
@@ -64,6 +60,13 @@ switch (language) {
     const manifest = readJson('package.json');
     assert(manifest.name === '@cloudpdf/sdk', `package.json name is ${manifest.name}`);
     assert(manifest.version === expectedVersion, `package.json version is ${manifest.version}`);
+    // requestedVersion is stable across Fern generators. sdkVersion is not:
+    // some generators omit it, while Go prefixes it with "v". The TypeScript
+    // SDK is published from this workspace, so validate its value exactly here.
+    assert(
+      fernMetadata.sdkVersion === expectedVersion,
+      `.fern/metadata.json sdkVersion is ${fernMetadata.sdkVersion}, expected ${expectedVersion}`,
+    );
     assert(manifest.license === 'Apache-2.0', `package.json license is ${manifest.license}`);
     assert(
       manifest.publishConfig?.access === 'public',

--- a/fern/scripts/validate-sdk.mjs
+++ b/fern/scripts/validate-sdk.mjs
@@ -51,6 +51,10 @@ assert(
   fernMetadata.requestedVersion === expectedVersion,
   `.fern/metadata.json requestedVersion is ${fernMetadata.requestedVersion}, expected ${expectedVersion}`,
 );
+assert(
+  fernMetadata.sdkVersion === expectedVersion,
+  `.fern/metadata.json sdkVersion is ${fernMetadata.sdkVersion}, expected ${expectedVersion}`,
+);
 includes('LICENSE', 'Apache License');
 includes('README.md', `# CloudPDF ${languageNames[language]} SDK`);
 assertCanonicalCloudPdfCasing(outputDirectory);
@@ -78,6 +82,8 @@ switch (language) {
       'committed TypeScript Fern metadata contains nondeterministic Git state',
     );
     includes('src/version.ts', expectedVersion);
+    includes('src/BaseClient.ts', `"X-Fern-SDK-Version": "${expectedVersion}"`);
+    includes('src/BaseClient.ts', `"User-Agent": "@cloudpdf/sdk/${expectedVersion}"`);
     includes('src/Client.ts', 'export class CloudPDFClient');
     includes('src/CloudPDFClient.ts', 'public readonly uploads: Uploads');
     includes('src/uploads/Uploads.ts', 'class Uploads');

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "bootstrap:package": "node scripts/bootstrap-package.mjs",
     "verify:engine-runtime-packages": "pnpm --filter @embedpdf/engine-runtime run verify:packages",
     "changeset": "changeset",
-    "ci:version": "changeset version && pnpm --filter @cloudpdf/contract emit:openapi && pnpm exec prettier --write cloudpdf/contract/openapi.json && pnpm --filter @cloudpdf/website api:metadata && pnpm --filter @cloudpdf/website api:pages",
-    "ci:publish": "node scripts/assert-publish-phase.mjs && pnpm publish -r --access public --tag next --publish-branch main --report-summary"
+    "cloudpdf:sdk:generate": "node fern/scripts/generate-typescript-sdk.mjs",
+    "ci:version": "changeset version && pnpm --filter @cloudpdf/contract emit:openapi && pnpm run cloudpdf:sdk:generate && pnpm --filter @cloudpdf/website api:metadata && pnpm --filter @cloudpdf/website api:pages",
+    "ci:publish": "node scripts/assert-publish-phase.mjs && node fern/scripts/validate-sdk.mjs typescript && pnpm publish -r --access public --tag next --publish-branch main --report-summary"
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.6",


### PR DESCRIPTION
Create a dedicated TypeScript SDK generation script that manages Changesets ownership of CHANGELOG.md. The wrapper snapshots and restores the changelog during Fern generation since the pinned Fern CLI version writes a release heading despite .fernignore rules.

Integrate the new script into CI workflow and package.json, add comprehensive validation and release versioning tests, and bump SDK version to 3.0.0-next.2. Adds proper formatting to emitted OpenAPI spec and enhances SDK validation checks.