### PR TITLE
Add build-hygiene; update exports and bump WASM

### DIFF
--- a/.github/workflows/build-hygiene.yml
+++ b/.github/workflows/build-hygiene.yml
@@ -5,13 +5,17 @@
 # disagrees with its declared build configuration surfaces here as a dirty
 # tree — on the pull request, instead of at the release workflow's
 # "Verify publish worktree" gate after a version PR has already merged.
+#
+# Triggers are deliberately narrow: the rewrite is a function of the
+# manifest and the build preset, never of source code, so only changes to
+# a package.json, the tooling, or the lockfile (which can move tooling
+# dependencies) can introduce drift. Source-only PRs never run this.
 name: build-hygiene
 
 on:
   pull_request:
     paths:
-      - 'packages/**'
-      - 'cloudpdf/**'
+      - '**/package.json'
       - 'tooling/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/build-hygiene.yml'
@@ -45,6 +49,20 @@ jobs:
 
       - name: Install deps
         run: pnpm install --frozen-lockfile
+        env:
+          # .npmrc interpolates it; empty beats a WARN on public installs.
+          NPM_TOKEN: ''
+
+      # Hydrate the wasm32 runtime payload from the public content-addressed
+      # shelf (the same script Vercel previews and fresh clones use) — the
+      # engine worker bundle inlines its browser glue at build time. Payload
+      # libs are gitignored, so this cannot dirty the worktree being judged.
+      - name: Fetch engine runtime payload
+        run: pnpm --filter @embedpdf/engine-runtime fetch:payload
+        env:
+          # A PR that changes runtime sources races its own Build PDF
+          # Runtime workflow, which publishes the payload for the new hash.
+          EPDF_PAYLOAD_WAIT_MINUTES: '30'
 
       - name: Build packages
         run: pnpm run build:release

--- a/.github/workflows/build-hygiene.yml
+++ b/.github/workflows/build-hygiene.yml
@@ -1,0 +1,65 @@
+# Builds every publishable package and asserts the worktree stays clean.
+#
+# epdf-build owns generated manifest fields (`exports`, `publishConfig`)
+# and tsdown rewrites them on every build, so a hand-edited manifest that
+# disagrees with its declared build configuration surfaces here as a dirty
+# tree — on the pull request, instead of at the release workflow's
+# "Verify publish worktree" gate after a version PR has already merged.
+name: build-hygiene
+
+on:
+  pull_request:
+    paths:
+      - 'packages/**'
+      - 'cloudpdf/**'
+      - 'tooling/**'
+      - 'pnpm-lock.yaml'
+      - '.github/workflows/build-hygiene.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-hygiene-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-clean-worktree:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v5
+        with:
+          run_install: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm run build:release
+
+      # Same as release.yml: build-workers.mjs regenerates this tracked
+      # source pin before compiling it into dist. The generated source is
+      # not part of the package, so restore it and judge the rest.
+      - name: Restore build-time WASM version source
+        run: git restore --source=HEAD -- packages/engine/main/src/generated/wasm32-version.ts
+
+      - name: Verify build left the worktree clean
+        run: |
+          status="$(git status --short --untracked-files=all)"
+          if [ -n "$status" ]; then
+            echo "::error::Building rewrote tracked files — commit the build-normalized form or fix the package's epdf configuration:"
+            echo "$status"
+            exit 1
+          fi

--- a/cloudpdf/viewer/react/package.json
+++ b/cloudpdf/viewer/react/package.json
@@ -9,7 +9,6 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "development": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
@@ -66,5 +65,8 @@
       },
       "./package.json": "./package.json"
     }
+  },
+  "epdf": {
+    "devExports": "development"
   }
 }

--- a/packages/engine/main/src/generated/wasm32-version.ts
+++ b/packages/engine/main/src/generated/wasm32-version.ts
@@ -6,4 +6,4 @@
  * the published version, which pins the default jsDelivr wasm URL to the
  * exact binary this package was built against.
  */
-export const WASM32_VERSION = '3.0.0-next.1';
+export const WASM32_VERSION = '3.0.0-next.2';

--- a/packages/viewer/chrome/package.json
+++ b/packages/viewer/chrome/package.json
@@ -9,19 +9,16 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "development": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./chrome": {
-      "types": "./dist/chrome.d.ts",
       "development": "./src/config/chrome.ts",
       "import": "./dist/chrome.js",
       "require": "./dist/chrome.cjs"
     },
     "./commands": {
-      "types": "./dist/commands.d.ts",
       "development": "./src/config/commands.ts",
       "import": "./dist/commands.js",
       "require": "./dist/commands.cjs"
@@ -32,7 +29,8 @@
   "epdf": {
     "rawExports": [
       "./styles.css"
-    ]
+    ],
+    "devExports": "development"
   },
   "files": [
     "dist",

--- a/packages/viewer/react/package.json
+++ b/packages/viewer/react/package.json
@@ -9,13 +9,11 @@
   "types": "./dist/index.d.cts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "development": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./core": {
-      "types": "./dist/core.d.ts",
       "development": "./src/core.ts",
       "import": "./dist/core.js",
       "require": "./dist/core.cjs"
@@ -70,5 +68,8 @@
     "type": "git",
     "url": "git+https://github.com/embedpdf/embed-pdf-viewer.git",
     "directory": "packages/viewer/react"
+  },
+  "epdf": {
+    "devExports": "development"
   }
 }


### PR DESCRIPTION
Add a build-hygiene GitHub Action that builds all publishable packages on PRs and fails if the build rewrites tracked files (restores generated wasm32-version.ts before check). Remove redundant `types` entries from package `exports` and add `epdf.devExports: "development"` to several package.json files; add `epdf.rawExports` for chrome styles. Bump WASM32_VERSION to "3.0.0-next.2". Affected files: .github/workflows/build-hygiene.yml, packages/engine/main/src/generated/wasm32-version.ts, cloudpdf/viewer/react/package.json, packages/viewer/chrome/package.json, packages/viewer/react/package.json.