### PR TITLE
Add 14-day refund window and simplify policy

### DIFF
--- a/cloudpdf/website/src/app/refund-policy/page.tsx
+++ b/cloudpdf/website/src/app/refund-policy/page.tsx
@@ -1,12 +1,9 @@
 import type { Metadata } from 'next';
 
 import {
-  LegalCallout,
   LegalLink,
-  LegalList,
   LegalPage,
   LegalParagraph,
-  LegalSubheading,
   type LegalSection,
 } from '@/components/site/legal-page';
 
@@ -16,156 +13,63 @@ export const metadata: Metadata = {
     'Cancellation and refund terms for CloudPDF managed-service and self-hosted subscriptions.',
 };
 
-const COMPANY = 'CloudPDF LTD';
 const CONTACT_EMAIL = 'hello@cloudpdf.com';
-const LAST_UPDATED = '11 August 2026';
+const LAST_UPDATED = '12 August 2026';
 
 const sections: readonly LegalSection[] = [
   {
-    id: 'scope',
-    title: 'Scope and relationship with Paddle',
+    id: 'refund-window',
+    title: '14-day refund window',
     content: (
       <>
         <LegalParagraph>
-          This Refund Policy applies to paid CloudPDF managed-service subscriptions and CloudPDF
-          self-hosted commercial subscriptions purchased through Paddle. Open-source software, free
-          trials, and unpaid evaluation licenses have no purchase price to refund.
+          CloudPDF offers a 14-calendar-day refund window for CloudPDF managed-service and
+          self-hosted subscriptions purchased through Paddle.
         </LegalParagraph>
         <LegalParagraph>
-          Paddle is the authorized reseller and Merchant of Record for these purchases. Paddle
-          processes payments, cancellations, and approved refunds, while {COMPANY} remains the
-          supplier, licensor, and service provider. This policy should be read with our{' '}
-          <LegalLink href="/terms">Terms of Service</LegalLink>, the{' '}
-          <LegalLink href="https://www.paddle.com/legal/buyer-terms">Paddle Buyer Terms</LegalLink>,
-          and Paddle’s{' '}
-          <LegalLink href="https://www.paddle.com/legal/refund-policy">Refund Policy</LegalLink>.
-        </LegalParagraph>
-        <LegalCallout>
-          A signed agreement, accepted custom offer, order form, or checkout summary is an “Order”.
-          Product-specific commercial terms in an Order control if they conflict with this policy,
-          while Paddle’s terms govern the payment transaction and mandatory law always applies.
-        </LegalCallout>
-      </>
-    ),
-  },
-  {
-    id: 'managed-service',
-    title: 'CloudPDF managed-service subscriptions',
-    content: (
-      <>
-        <LegalSubheading>Free trial</LegalSubheading>
-        <LegalParagraph>
-          When a 14-day free trial is offered, you may cancel before the trial ends to avoid the
-          first subscription charge. The exact trial end date and the subscription that follows are
-          shown at signup or checkout. If you do not cancel in time, the paid subscription begins
-          and Paddle charges the payment method on file.
-        </LegalParagraph>
-
-        <LegalSubheading>Cancellation</LegalSubheading>
-        <LegalParagraph>
-          You may cancel renewal through the available billing flow, Paddle, or by contacting us.
-          Cancellation normally takes effect at the end of the current paid billing period. You
-          retain access through that period, and no further renewal is charged. Canceling a
-          subscription does not by itself refund a charge already made.
-        </LegalParagraph>
-
-        <LegalSubheading>Paid subscription charges</LegalSubheading>
-        <LegalParagraph>
-          Monthly and annual subscription charges are generally non-refundable once the paid term
-          begins, and we do not automatically provide prorated refunds or credits for unused time.
-          An annual subscription is an annual commitment even if pricing is also displayed as a
-          monthly equivalent. The exceptions in the refund eligibility section below still apply.
+          You may request a full refund within 14 calendar days of the date of your initial purchase
+          or any renewal transaction. You do not need to provide a reason.
         </LegalParagraph>
       </>
     ),
   },
   {
-    id: 'self-hosted',
-    title: 'CloudPDF self-hosted subscriptions',
+    id: 'request-refund',
+    title: 'How to request a refund',
     content: (
       <>
         <LegalParagraph>
-          Self-hosted commercial subscriptions are normally annual and sales-assisted. The
-          applicable Order specifies the license term, authorized deployments, fees, support,
-          renewal, and any setup, onboarding, implementation, or other services.
+          Submit your refund request no later than 14 calendar days after the transaction date shown
+          on your Paddle receipt. You can use the “View receipt” or “Manage subscription” link in
+          your Paddle transaction email, visit{' '}
+          <LegalLink href="https://paddle.net">Paddle Buyer Support</LegalLink>, or email us at{' '}
+          <LegalLink href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</LegalLink>.
         </LegalParagraph>
-        <LegalList>
-          <li>
-            An unpaid evaluation license has no purchase price to refund and expires according to
-            its stated evaluation period.
-          </li>
-          <li>
-            You may cancel future renewal using the method stated in the Order or by contacting us.
-            Unless the Order says otherwise, the license and included support remain active through
-            the paid term and end when that term expires.
-          </li>
-          <li>
-            Recurring self-hosted subscription fees are generally non-refundable after the license
-            term begins, with no automatic prorated refund for an unused part of the term.
-          </li>
-          <li>
-            Setup, onboarding, implementation, and other one-time service fees are generally
-            non-refundable after the applicable work has begun or been delivered.
-          </li>
-        </LegalList>
         <LegalParagraph>
-          These rules are subject to the refund eligibility section below, any different remedy in
-          your Order, and rights that cannot lawfully be excluded.
+          Include the email address used for the purchase and the Paddle transaction or subscription
+          number if available. Do not send payment-card details by email.
+        </LegalParagraph>
+        <LegalParagraph>
+          Paddle processes refunds to the original payment method. Bank and card processing times
+          may affect when the refunded funds appear in your account.
         </LegalParagraph>
       </>
     ),
   },
   {
-    id: 'eligibility',
-    title: 'When a refund may be available',
-    content: (
-      <>
-        <LegalParagraph>You may request a full or partial refund where:</LegalParagraph>
-        <LegalList>
-          <li>a charge was duplicated or processed for an incorrect amount;</li>
-          <li>
-            a paid Service materially fails to conform to its documentation and we cannot correct
-            the problem within a reasonable time after receiving enough information to investigate;
-          </li>
-          <li>
-            your Order expressly provides a refund, service credit, or termination remedy in the
-            relevant circumstances;
-          </li>
-          <li>mandatory consumer, cancellation, or statutory warranty law requires one; or</li>
-          <li>Paddle approves a refund under its then-current refund policy.</li>
-        </LegalList>
-        <LegalParagraph>
-          For a technical or licensing problem, please give us a reasonable opportunity to
-          investigate and correct it first. A failure to cancel before a trial conversion or
-          renewal, a change of mind, unused subscription time, an unsupported environment, or a
-          problem in a customer-controlled integration does not by itself guarantee a refund.
-        </LegalParagraph>
-        <LegalParagraph>
-          Paddle may consider discretionary requests submitted within the period stated in its{' '}
-          <LegalLink href="https://www.paddle.com/legal/refund-policy">Refund Policy</LegalLink>.
-          Submitting a request does not guarantee approval.
-        </LegalParagraph>
-      </>
-    ),
-  },
-  {
-    id: 'requests',
-    title: 'How to cancel or request a refund',
+    id: 'cancellation',
+    title: 'Subscription cancellation',
     content: (
       <>
         <LegalParagraph>
-          To cancel a subscription or request a refund, use the subscription-management link in your
-          Paddle receipt or billing email, contact Paddle through{' '}
-          <LegalLink href="https://paddle.net">paddle.net</LegalLink>, or email us at{' '}
-          <LegalLink href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</LegalLink>. Include the email
-          address used for the purchase, the Paddle transaction or subscription number if available,
-          and the reason for your request. Do not send payment-card details by email.
+          You may cancel a subscription at any time to prevent future renewal. Unless a refund is
+          issued, cancellation normally takes effect at the end of the current paid billing period
+          and access continues until that date.
         </LegalParagraph>
         <LegalParagraph>
-          Cancellation and a refund request are separate actions. If you want both, say so clearly.
-          Refund requests may be reviewed by CloudPDF and/or Paddle under the applicable policy.
-          Paddle processes any approved refund to the original payment method. Bank and card
-          processing times may delay when the funds appear.
+          Cancellation and a refund request are separate actions. If you are within the 14-day
+          refund window and want a refund as well as cancellation, submit a refund request using one
+          of the methods above.
         </LegalParagraph>
       </>
     ),
@@ -174,37 +78,36 @@ const sections: readonly LegalSection[] = [
     id: 'after-refund',
     title: 'What happens after a refund',
     content: (
-      <>
-        <LegalParagraph>
-          If a full refund is issued, access, paid entitlements, and commercial licenses associated
-          with the refunded purchase may end immediately. For a refunded self-hosted subscription,
-          you must stop using the commercial software and license materials when the refund or
-          termination takes effect. If a partial refund or service credit is approved, we or Paddle
-          will explain its effect on the subscription and access.
-        </LegalParagraph>
-        <LegalParagraph>
-          A cancellation without a refund normally leaves access active until the end of the paid
-          billing period. We may deny or reverse a refund obtained through fraud, material
-          misrepresentation, or abuse, subject to Paddle’s processes and applicable law.
-        </LegalParagraph>
-      </>
+      <LegalParagraph>
+        When a transaction is fully refunded, the corresponding CloudPDF subscription, service
+        access, and commercial license end. For a refunded self-hosted subscription, you must stop
+        using the commercial software and associated license materials.
+      </LegalParagraph>
     ),
   },
   {
-    id: 'mandatory-rights',
-    title: 'Mandatory rights and policy changes',
+    id: 'paddle',
+    title: 'Paddle and mandatory rights',
     content: (
       <>
         <LegalParagraph>
-          Nothing in this Refund Policy limits cancellation, refund, or warranty rights that cannot
-          lawfully be limited. Those rights vary by location and may apply despite the general rules
-          above.
+          Our order process is conducted by our online reseller Paddle.com. Paddle.com is the
+          Merchant of Record for all our orders. Paddle provides all customer service inquiries and
+          handles returns.
         </LegalParagraph>
         <LegalParagraph>
-          We may update this policy as our products, billing arrangements, or legal requirements
-          change. The version presented with or applicable to your purchase governs to the extent
-          permitted by law. Questions may be sent to{' '}
-          <LegalLink href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</LegalLink>.
+          Transactions outside the 14-day refund window are non-refundable except where required by
+          applicable law or Paddle’s{' '}
+          <LegalLink href="https://www.paddle.com/legal/refund-policy">Refund Policy</LegalLink>.
+          Nothing in this policy limits mandatory consumer, cancellation, refund, or warranty
+          rights.
+        </LegalParagraph>
+        <LegalParagraph>
+          This policy should be read with our <LegalLink href="/terms">Terms of Service</LegalLink>,
+          the{' '}
+          <LegalLink href="https://www.paddle.com/legal/buyer-terms">Paddle Buyer Terms</LegalLink>,
+          and Paddle’s{' '}
+          <LegalLink href="https://www.paddle.com/legal/refund-policy">Refund Policy</LegalLink>.
         </LegalParagraph>
       </>
     ),
@@ -216,7 +119,7 @@ export default function RefundPolicyPage() {
     <LegalPage
       eyebrow="Legal"
       title="Refund Policy"
-      description="Cancellation and refund terms for CloudPDF managed-service and self-hosted subscriptions."
+      description="A clear 14-day refund policy for CloudPDF managed-service and self-hosted subscriptions."
       lastUpdated={LAST_UPDATED}
       sections={sections}
     />

--- a/cloudpdf/website/src/app/terms/page.tsx
+++ b/cloudpdf/website/src/app/terms/page.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
 
 const COMPANY = 'CloudPDF LTD';
 const CONTACT_EMAIL = 'hello@cloudpdf.com';
-const LAST_UPDATED = '4 August 2026';
+const LAST_UPDATED = '12 August 2026';
 
 const sections: readonly LegalSection[] = [
   {
@@ -41,8 +41,9 @@ const sections: readonly LegalSection[] = [
         <LegalCallout>
           A signed commercial agreement, order form, accepted custom offer, checkout summary, or
           other ordering document is an “Order”. If an Order conflicts with these Terms, the Order
-          controls for that purchase. Open-source code and separately licensed software remain
-          governed by their applicable license files.
+          controls for that purchase, but it does not reduce the 14-day refund right for a
+          transaction processed through Paddle. Open-source code and separately licensed software
+          remain governed by their applicable license files.
         </LegalCallout>
       </>
     ),
@@ -200,14 +201,14 @@ const sections: readonly LegalSection[] = [
           </li>
           <li>
             You may cancel future renewal through the available billing flow or by contacting us.
-            Cancellation normally takes effect at the end of the paid term and does not
-            retroactively refund that term.
+            Cancellation normally takes effect at the end of the paid term and prevents future
+            renewal. Cancellation and requesting a refund are separate actions.
           </li>
           <li>
-            Refund eligibility and requests are described in our{' '}
-            <LegalLink href="/refund-policy">Refund Policy</LegalLink>, alongside the checkout,
-            Paddle’s terms, and mandatory law. Nothing in these Terms limits rights that cannot
-            lawfully be limited.
+            You may request a full refund within 14 calendar days of an initial purchase or renewal
+            transaction, as described in our{' '}
+            <LegalLink href="/refund-policy">Refund Policy</LegalLink>. Nothing in these Terms
+            limits rights that cannot lawfully be limited.
           </li>
         </LegalList>
         <LegalParagraph>


### PR DESCRIPTION
Implement a clear 14-calendar-day refund window across site legal pages. Simplify cloudpdf/website/src/app/refund-policy/page.tsx by removing verbose managed-service/self-hosted sections, adding concise refund-request instructions (Paddle/email), clarifying post-refund effects, and updating links. Update lastUpdated to 12 August 2026 and adjust page description. Update cloudpdf/website/src/app/terms/page.tsx to reference the 14-day refund right and update its lastUpdated date. Remove an unused COMPANY constant from the refund page.