### PR TITLE
Streaming materialize + single-read commit verify

### DIFF
--- a/.changeset/cloudpdf-server-materialize-verify.md
+++ b/.changeset/cloudpdf-server-materialize-verify.md
@@ -1,0 +1,11 @@
+---
+'@cloudpdf/server': minor
+---
+
+Fixes presigned-upload materialization and makes commit-time sha verification single-read and constant-memory.
+
+- Fixes the range materializer crashing with `EBADF` whenever an object carried no SHA metadata — the shape of every presigned browser upload. The failure was silent: commits still reached `ready` while the security probe recorded `unknown` and thumbnail warming recorded `failed`. The hash fallback now closes the write-only handle and streams the finished partial from disk, guards against short positional writes, and rejects a metadata/expected-sha disagreement before paying for the download.
+- Replaces the S3 and FS `getSha256` fallbacks that buffered whole objects in RAM with streaming hashes — constant memory regardless of document size.
+- Commit now verifies uploaded bytes with a single object-store read when a base-file cache is wired (`DocumentLifecycleOptions.fileCache`): the upload is materialized into the cache, hashed on the way down, and reused by the security probe instead of being downloaded a second time. `LocalFileHandle.sourceKey` reports which object key materialized a content-addressed entry, so a cross-key cache hit still triggers a direct verification of the committing document's own object.
+- Adds a typed `ShaMismatchError` (exported) thrown by all `materializeLocal` implementations, letting callers distinguish declared-hash mismatches from retryable transport failures.
+- Surfaces previously swallowed failures: `DocumentSecurityProbeOptions.onError`, `DerivedRenderServiceOptions.onWarmError`, and base-file-cache `materialize-error` events are now wired to the server log.

--- a/cloudpdf/server/src/app/buildApp.ts
+++ b/cloudpdf/server/src/app/buildApp.ts
@@ -35,9 +35,19 @@ import { TenantUsageRepo } from '../db/repos/tenant_usage.repo';
 import { TenantsRepo } from '../db/repos/tenants.repo';
 import { WeakAnnotationSessionsRepo } from '../db/repos/weak_annotation_sessions.repo';
 import type { Database as Schema } from '../db/schema';
+import type { ConnectedUsageReporter } from '../licensing/ConnectedUsageReporter';
+import type { LicenseGate } from '../licensing/LicenseRuntime';
+import { isLicenseGateTrusted } from '../licensing/trusted-license-gates';
+import { UsageMeters } from '../licensing/UsageMeters';
 import { InProcessRealtimeBus, type RealtimeBus } from '../realtime/RealtimeBus';
 import { SharpImageEncoder } from '../render/SharpImageEncoder';
 import { registerAccessRoutes } from '../routes/access';
+import { registerAdminDocumentsRoutes } from '../routes/admin/documents';
+import { registerAdminSharesRoutes } from '../routes/admin/shares';
+import { registerAdminTenantsRoutes } from '../routes/admin/tenants';
+import { registerAdminTokensRoutes } from '../routes/admin/tokens';
+import { registerAnnotationRoutes } from '../routes/annotations';
+import { registerAttachmentRoutes } from '../routes/attachments';
 import { registerDocsRoutes } from '../routes/docs';
 import { CloudRevisionBridge } from '../services/CloudRevisionBridge';
 import { DerivedRenderService } from '../services/DerivedRenderService';
@@ -47,24 +57,14 @@ import { EventLogService } from '../services/EventLogService';
 import { LayerService } from '../services/LayerService';
 import { LayerStateService } from '../services/LayerStateService';
 import { WeakAnnotationSessionService } from '../services/WeakAnnotationSessionService';
-import { registerAnnotationRoutes } from '../routes/annotations';
-import { registerAttachmentRoutes } from '../routes/attachments';
 import { registerFormRoutes } from '../routes/forms';
 import { registerMetadataRoutes } from '../routes/metadata';
 import { registerPageRoutes } from '../routes/pages';
 import { registerRedactionRoutes } from '../routes/redactions';
 import { registerSearchRoutes } from '../routes/search';
-import { registerAdminDocumentsRoutes } from '../routes/admin/documents';
-import { registerAdminSharesRoutes } from '../routes/admin/shares';
-import { registerAdminTenantsRoutes } from '../routes/admin/tenants';
-import { registerAdminTokensRoutes } from '../routes/admin/tokens';
 import { registerShareSessionRoutes } from '../routes/share-sessions';
 import type { KmsKeyring } from '../security';
 import { registerEventsRoutes } from '../routes/events';
-import type { LicenseGate } from '../licensing/LicenseRuntime';
-import { UsageMeters } from '../licensing/UsageMeters';
-import type { ConnectedUsageReporter } from '../licensing/ConnectedUsageReporter';
-import { isLicenseGateTrusted } from '../licensing/trusted-license-gates';
 import { WorkerThreadPool, type FallbackFontDescriptor } from '../runtime/WorkerThreadPool';
 import {
   DocumentLifecycleService,
@@ -548,6 +548,14 @@ async function buildAppUnchecked(opts: BuildAppOptions): Promise<AppBundle> {
         root: opts.cacheRoot,
         maxBytes: opts.cacheMaxBytes ?? 4 * 1024 * 1024 * 1024,
         store: opts.objectStore,
+        // Failed materialises were once completely silent (callers
+        // like the security probe swallow them by design) — always
+        // give them a log line.
+        onEvent: (e) => {
+          if (e.kind === 'materialize-error') {
+            app.log.warn({ sha: e.sha, error: e.error }, 'base file cache: materialize failed');
+          }
+        },
       });
       // One-shot boot sweep: a crash during a prior materialise can
       // leave `.partial.*` files behind. Better to clean them up
@@ -574,6 +582,8 @@ async function buildAppUnchecked(opts: BuildAppOptions): Promise<AppBundle> {
         pool,
         encoder: new SharpImageEncoder(),
         documents: new DocumentsRepo(opts.db),
+        onWarmError: (err, ctx) =>
+          app.log.warn({ err, ...ctx }, 'thumbnail warm failed; thumbnailState=failed'),
       });
     }
 
@@ -583,7 +593,13 @@ async function buildAppUnchecked(opts: BuildAppOptions): Promise<AppBundle> {
       storage: opts.objectStore,
       autoProvisionTenant: opts.autoProvisionTenant ?? false,
       uploadProxyPolicy: opts.uploadProxyPolicy ?? 'fallback-only',
-      securityProbe: new DocumentSecurityProbe({ cache: baseFileCache, pool }),
+      securityProbe: new DocumentSecurityProbe({
+        cache: baseFileCache,
+        pool,
+        onError: (err, ctx) =>
+          app.log.warn({ err, ...ctx }, 'security probe failed; recording unknown security state'),
+      }),
+      ...(baseFileCache ? { fileCache: baseFileCache } : {}),
       ...(derivedRenders ? { derivedRenders } : {}),
       ...(usageMeters ? { usageMeters } : {}),
       tenantUsage: new TenantUsageRepo(opts.db),

--- a/cloudpdf/server/src/index.ts
+++ b/cloudpdf/server/src/index.ts
@@ -184,6 +184,7 @@ export type {
   BaseFileCacheEvent,
   LocalFileHandle,
 } from './storage/BaseFileCache';
+export { ShaMismatchError } from './storage/ObjectStore';
 export type { MaterializeOpts, MaterializeResult } from './storage/ObjectStore';
 export { DocumentService } from './services/DocumentService';
 export type {

--- a/cloudpdf/server/src/services/DerivedRenderService.ts
+++ b/cloudpdf/server/src/services/DerivedRenderService.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'node:buffer';
+
 import {
   EngineError,
   EngineErrorCode,
@@ -56,6 +57,13 @@ export interface DerivedRenderServiceOptions {
   pool?: WorkerThreadPool;
   encoder?: SharpImageEncoder;
   documents?: DocumentsRepo;
+  /**
+   * Called when a thumbnail warm fails, right before the document's
+   * thumbnail state is recorded as `failed`. Warming is deliberately
+   * fire-and-forget, but the cause must not be invisible — wire this
+   * to the app logger.
+   */
+  onWarmError?: (err: unknown, ctx: { docId: string; tenantId: string }) => void;
 }
 
 export interface LatticeClassification {
@@ -102,6 +110,7 @@ export class DerivedRenderService {
   private readonly pool?: WorkerThreadPool;
   private readonly encoder?: SharpImageEncoder;
   private readonly documents?: DocumentsRepo;
+  private readonly onWarmError?: (err: unknown, ctx: { docId: string; tenantId: string }) => void;
   private readonly inFlight = new Map<string, Promise<DerivedRenderResult>>();
 
   constructor(opts: DerivedRenderServiceOptions) {
@@ -114,6 +123,7 @@ export class DerivedRenderService {
     this.pool = opts.pool;
     this.encoder = opts.encoder;
     this.documents = opts.documents;
+    this.onWarmError = opts.onWarmError;
   }
 
   /** The advertised deployment policy — rides `/v1/access`, never manifests. */
@@ -365,7 +375,8 @@ export class DerivedRenderService {
       } finally {
         handle.release();
       }
-    } catch {
+    } catch (err) {
+      this.onWarmError?.(err, { docId: input.docId, tenantId: input.tenantId });
       await this.documents
         ?.setThumbnail(input.docId, input.tenantId, 'failed')
         .catch(() => undefined);

--- a/cloudpdf/server/src/services/DocumentLifecycleService.ts
+++ b/cloudpdf/server/src/services/DocumentLifecycleService.ts
@@ -11,8 +11,14 @@ import type { ShareGrantsRepo } from '../db/repos/share_grants.repo';
 import type { TenantUsageRepo } from '../db/repos/tenant_usage.repo';
 import { TenantsRepo } from '../db/repos/tenants.repo';
 import type { UsageMeters } from '../licensing/UsageMeters';
+import type { BaseFileCache, LocalFileHandle } from '../storage/BaseFileCache';
 import { StorageKeys } from '../storage/keys';
-import type { ObjectBody, ObjectStoreWithInfo, PresignedUpload } from '../storage/ObjectStore';
+import {
+  ShaMismatchError,
+  type ObjectBody,
+  type ObjectStoreWithInfo,
+  type PresignedUpload,
+} from '../storage/ObjectStore';
 
 export type DedupMode = 'always-create' | 'reuse-existing';
 export type UploadPreference = 'auto' | 'presigned' | 'proxy';
@@ -91,6 +97,14 @@ export interface DocumentLifecycleOptions {
    */
   autoProvisionTenant?: boolean;
   securityProbe?: DocumentSecurityProbe;
+  /**
+   * Base-file cache shared with the security probe and render plane.
+   * When present, commit verifies the uploaded bytes by materialising
+   * them into this cache — ONE object-store read serves both the
+   * sha verification and the probe that follows. Absent (admin-only
+   * deploys), commit falls back to a streaming remote hash.
+   */
+  fileCache?: Pick<BaseFileCache, 'acquire'>;
   /** When present, commit warms the document's thumbnail (fire-and-forget). */
   derivedRenders?: DerivedRenderService;
   usageMeters?: UsageMeters;
@@ -113,9 +127,12 @@ export interface DocumentLifecycleOptions {
  *                  if the customer supplied a stale idempotency key
  *                  pointing at a different content sha.
  *   - `commit`   - returns `null`/throws `Conflict` if the row is no
- *                  longer pending. Verifies sha by reading
- *                  `objectStore.getSha256(key)`; mismatch -> marks
- *                  failed + throws `InvalidArg('sha_mismatch')`.
+ *                  longer pending. Verifies sha by materialising the
+ *                  upload into the base-file cache (one object-store
+ *                  read, reused by the security probe); falls back to
+ *                  a streaming `objectStore.getSha256(key)` when no
+ *                  cache is wired. Mismatch -> marks failed + throws
+ *                  `InvalidArg('sha_mismatch')`.
  *   - `delete`   - two-phase: flip to `deleting`, drop storage prefix,
  *                  remove DB row. A crash between phases leaves
  *                  `deleting` rows for the sweeper to retry.
@@ -126,6 +143,7 @@ export class DocumentLifecycleService {
   private readonly storage: ObjectStoreWithInfo;
   private readonly autoProvisionTenant: boolean;
   private readonly securityProbe: DocumentSecurityProbe;
+  private readonly fileCache?: Pick<BaseFileCache, 'acquire'>;
   private readonly derivedRenders?: DerivedRenderService;
   private readonly usageMeters?: UsageMeters;
   private readonly tenantUsage?: TenantUsageRepo;
@@ -138,6 +156,7 @@ export class DocumentLifecycleService {
     this.storage = opts.storage;
     this.autoProvisionTenant = opts.autoProvisionTenant ?? false;
     this.securityProbe = opts.securityProbe ?? new DocumentSecurityProbe();
+    this.fileCache = opts.fileCache;
     this.derivedRenders = opts.derivedRenders;
     this.usageMeters = opts.usageMeters;
     this.tenantUsage = opts.tenantUsage;
@@ -317,9 +336,7 @@ export class DocumentLifecycleService {
       throw conflict(`document ${doc.id} is not pending (state=${doc.state})`);
     }
     if (doc.expectedSha256 !== null && doc.expectedSha256 !== input.sha256) {
-      throw conflict(
-        `commit SHA does not match the SHA pinned at init for document ${doc.id}`,
-      );
+      throw conflict(`commit SHA does not match the SHA pinned at init for document ${doc.id}`);
     }
 
     const key = this.buildUploadKey(doc.id, doc.tenantId);
@@ -336,62 +353,99 @@ export class DocumentLifecycleService {
         `size_mismatch: init declared ${doc.expectedSizeBytes} bytes but storage contains ${stat.size}`,
       );
     }
-    const observedSha = await this.storage.getSha256(key);
-    if (!observedSha) {
-      await this.documents.markFailed(doc.id, doc.tenantId, 'sha_unavailable');
-      throw new Error('object store could not produce SHA-256 for the uploaded bytes');
-    }
-    const expectedSha = doc.expectedSha256 ?? input.sha256;
-    if (observedSha !== expectedSha) {
+    const declaredSha = doc.expectedSha256 ?? input.sha256;
+    if (!/^[0-9a-f]{64}$/.test(declaredSha)) {
       await this.documents.markFailed(doc.id, doc.tenantId, 'sha_mismatch');
-      // Also remove the bad bytes so a retry isn't reading stale data.
       await this.storage.delete(key);
-      throw badRequest(
-        `sha_mismatch: init declared ${expectedSha} but server observed ${observedSha}`,
-      );
+      throw badRequest('sha_mismatch: declared sha256 must be 64 lowercase hex chars');
     }
 
-    const probe = await this.securityProbe.probe({
-      key,
-      expectedSha: observedSha,
-    });
+    // Verify the uploaded bytes with a SINGLE object-store read.
+    // `fileCache.acquire` materialises the object into the base-file
+    // cache and hashes it on the way down (ShaMismatchError when the
+    // bytes don't hash to `declaredSha`); the security probe below then
+    // reuses that warm entry instead of downloading a second time.
+    let baseHandle: LocalFileHandle | null = null;
+    try {
+      if (this.fileCache) {
+        try {
+          baseHandle = await this.fileCache.acquire({ sha: declaredSha, key });
+        } catch (err) {
+          if (err instanceof ShaMismatchError) {
+            await this.documents.markFailed(doc.id, doc.tenantId, 'sha_mismatch');
+            // Also remove the bad bytes so a retry isn't reading stale data.
+            await this.storage.delete(key);
+            throw badRequest(
+              `sha_mismatch: init declared ${err.expected} but server observed ${err.actual}`,
+            );
+          }
+          throw err;
+        }
+      }
+      if (!baseHandle || baseHandle.sourceKey !== key) {
+        // No cache wired, OR the content-addressed cache already held
+        // these bytes materialised from a DIFFERENT object's key — a
+        // hit proves nothing about what is stored at OUR key, so hash
+        // the remote object directly (streaming, constant memory).
+        const observedSha = await this.storage.getSha256(key);
+        if (!observedSha) {
+          await this.documents.markFailed(doc.id, doc.tenantId, 'sha_unavailable');
+          throw new Error('object store could not produce SHA-256 for the uploaded bytes');
+        }
+        if (observedSha !== declaredSha) {
+          await this.documents.markFailed(doc.id, doc.tenantId, 'sha_mismatch');
+          // Also remove the bad bytes so a retry isn't reading stale data.
+          await this.storage.delete(key);
+          throw badRequest(
+            `sha_mismatch: init declared ${declaredSha} but server observed ${observedSha}`,
+          );
+        }
+      }
 
-    // Meter only a newly committed document. The ready/idempotent return at
-    // the top of this method never reaches this path.
-    await this.usageMeters?.assertUploadAllowed();
-    await this.usageMeters?.assertStorageAllowed(stat.size);
+      const probe = await this.securityProbe.probe({
+        key,
+        expectedSha: declaredSha,
+      });
 
-    const updated = await this.documents.commit({
-      id: doc.id,
-      tenantId: doc.tenantId,
-      baseSha: observedSha,
-      storageSizeBytes: stat.size,
-      security: probe.security,
-    });
-    if (!updated) {
-      throw conflict(`document ${doc.id} state changed during commit`);
+      // Meter only a newly committed document. The ready/idempotent return at
+      // the top of this method never reaches this path.
+      await this.usageMeters?.assertUploadAllowed();
+      await this.usageMeters?.assertStorageAllowed(stat.size);
+
+      const updated = await this.documents.commit({
+        id: doc.id,
+        tenantId: doc.tenantId,
+        baseSha: declaredSha,
+        storageSizeBytes: stat.size,
+        security: probe.security,
+      });
+      if (!updated) {
+        throw conflict(`document ${doc.id} state changed during commit`);
+      }
+      const recorded = await this.usageMeters?.recordUpload(updated.id, updated.createdAt);
+      if (recorded?.counted) await this.tenantUsage?.recordUpload(updated.tenantId);
+
+      // Thumbnail lifecycle: user-password documents get NO
+      // derived artifact — a thumbnail is content disclosure, and the lock
+      // tile IS the correct render. Everything else warms fire-and-forget:
+      // the read-through path is the correctness path, warming is latency.
+      if (probe.security.encryptionRequiresPassword === true) {
+        await this.documents.setThumbnail(doc.id, doc.tenantId, 'locked');
+      } else if (this.derivedRenders) {
+        void this.derivedRenders
+          .warmDocumentThumbnail({
+            tenantId: doc.tenantId,
+            docId: doc.id,
+            baseSha: declaredSha,
+            baseKey: key,
+          })
+          .catch(() => undefined); // warm records `failed` itself
+      }
+
+      return { doc: updated };
+    } finally {
+      baseHandle?.release();
     }
-    const recorded = await this.usageMeters?.recordUpload(updated.id, updated.createdAt);
-    if (recorded?.counted) await this.tenantUsage?.recordUpload(updated.tenantId);
-
-    // Thumbnail lifecycle: user-password documents get NO
-    // derived artifact — a thumbnail is content disclosure, and the lock
-    // tile IS the correct render. Everything else warms fire-and-forget:
-    // the read-through path is the correctness path, warming is latency.
-    if (probe.security.encryptionRequiresPassword === true) {
-      await this.documents.setThumbnail(doc.id, doc.tenantId, 'locked');
-    } else if (this.derivedRenders) {
-      void this.derivedRenders
-        .warmDocumentThumbnail({
-          tenantId: doc.tenantId,
-          docId: doc.id,
-          baseSha: observedSha,
-          baseKey: key,
-        })
-        .catch(() => undefined); // warm records `failed` itself
-    }
-
-    return { doc: updated };
   }
 
   private assertSameUploadIntent(existing: DocumentRow, input: InitInput): void {

--- a/cloudpdf/server/src/services/DocumentSecurityProbe.ts
+++ b/cloudpdf/server/src/services/DocumentSecurityProbe.ts
@@ -1,7 +1,8 @@
 import { EngineError, EngineErrorCode, wirePack } from '@embedpdf/engine-core/runtime';
+
 import type { DocumentSecurityInfo } from '../db/repos/documents.repo';
-import type { BaseFileCache, LocalFileHandle } from '../storage/BaseFileCache';
 import type { WorkerThreadPool } from '../runtime/WorkerThreadPool';
+import type { BaseFileCache, LocalFileHandle } from '../storage/BaseFileCache';
 
 export interface DocumentSecurityProbeInput {
   key: string;
@@ -17,6 +18,14 @@ export interface DocumentSecurityProbeResult {
 export interface DocumentSecurityProbeOptions {
   cache?: BaseFileCache;
   pool?: WorkerThreadPool;
+  /**
+   * Called when a probe attempt fails before the security state is
+   * recorded as `unknown`. The probe is deliberately best-effort — it
+   * never fails a commit — but the cause must not be invisible: a
+   * broken materialise path once hid behind this catch for every
+   * presigned upload. Wire this to the app logger.
+   */
+  onError?: (err: unknown, ctx: { key: string; sha: string }) => void;
 }
 
 /**
@@ -58,7 +67,8 @@ export class DocumentSecurityProbe {
         );
       }
       return { security: result.security };
-    } catch {
+    } catch (err) {
+      this.opts.onError?.(err, { key: input.key, sha: input.expectedSha });
       return { security: unknownSecurity() };
     } finally {
       handle?.release();

--- a/cloudpdf/server/src/storage/BaseFileCache.ts
+++ b/cloudpdf/server/src/storage/BaseFileCache.ts
@@ -2,6 +2,7 @@ import { createReadStream } from 'node:fs';
 import { mkdir, readdir, stat, unlink } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
+
 import type { ObjectStoreWithInfo } from './ObjectStore';
 
 /**
@@ -56,6 +57,15 @@ export interface LocalFileHandle {
   readonly size: number;
   readonly sha256: string;
   /**
+   * Object-store key the entry was ORIGINALLY materialised from. The
+   * cache is content-addressed, so a hit may have been fetched under a
+   * different key than the one this `acquire()` passed — same bytes,
+   * different object. Callers that need "the object at MY key was
+   * read and verified" (commit does) must check this and re-verify
+   * their own key when it differs.
+   */
+  readonly sourceKey: string;
+  /**
    * Decrement the refcount. After the last `release()` the file is
    * eligible for LRU eviction; before then it's pinned to disk.
    *
@@ -69,6 +79,8 @@ export interface LocalFileHandle {
 interface CacheEntry {
   sha: string;
   path: string;
+  /** Object-store key of the materialise that produced this entry. */
+  key: string;
   size: number;
   refcount: number;
   /** Order tracker — incremented on every access, used for LRU. */
@@ -180,6 +192,7 @@ export class BaseFileCache {
     entry = {
       sha,
       path,
+      key: opts.key,
       size: 0,
       refcount: 1,
       lastUsed: ++this.accessTick,
@@ -246,6 +259,7 @@ export class BaseFileCache {
       path: entry.path,
       size: entry.size,
       sha256: entry.sha,
+      sourceKey: entry.key,
       release: onRelease,
     };
   }

--- a/cloudpdf/server/src/storage/ObjectStore.ts
+++ b/cloudpdf/server/src/storage/ObjectStore.ts
@@ -158,7 +158,8 @@ export interface ObjectStore {
    * Returns the size and SHA-256 of the materialised bytes. If the
    * adapter stores the SHA in object metadata (S3) we trust that and
    * skip a redundant rehash; otherwise we hash during materialise.
-   * `expectedSha` is verified at the end; mismatch throws.
+   * `expectedSha` is verified at the end; mismatch throws
+   * `ShaMismatchError`.
    */
   materializeLocal(
     key: string,
@@ -220,3 +221,24 @@ export interface ObjectStoreInfo {
  * downstream code; remove after callers migrate.
  */
 export type ObjectStoreWithInfo = ObjectStore;
+
+/**
+ * Thrown by `materializeLocal` when the materialised bytes (or the
+ * backend-recorded SHA they were compared against) don't match
+ * `MaterializeOpts.expectedSha`. A typed class so callers can
+ * distinguish "the object genuinely doesn't hash to what was
+ * declared" (commit maps it to a 400 `sha_mismatch`) from transport
+ * failures, which stay retryable.
+ */
+export class ShaMismatchError extends Error {
+  constructor(
+    context: string,
+    /** SHA-256 hex the caller expected. */
+    readonly expected: string,
+    /** SHA-256 hex actually observed. */
+    readonly actual: string,
+  ) {
+    super(`${context}: sha mismatch (expected ${expected}, got ${actual})`);
+    this.name = 'ShaMismatchError';
+  }
+}

--- a/cloudpdf/server/src/storage/adapters/FsObjectStore.ts
+++ b/cloudpdf/server/src/storage/adapters/FsObjectStore.ts
@@ -16,15 +16,16 @@ import { dirname, join, resolve, sep } from 'node:path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
-import type {
-  MaterializeOpts,
-  MaterializeResult,
-  ObjectBody,
-  ObjectStat,
-  ObjectStore,
-  PresignedDownload,
-  PresignedUpload,
-  PresignUploadOpts,
+import {
+  ShaMismatchError,
+  type MaterializeOpts,
+  type MaterializeResult,
+  type ObjectBody,
+  type ObjectStat,
+  type ObjectStore,
+  type PresignedDownload,
+  type PresignedUpload,
+  type PresignUploadOpts,
 } from '../ObjectStore';
 
 // ObjectStore keys are URL-safe, slash-delimited names produced by
@@ -139,8 +140,13 @@ export class FsObjectStore implements ObjectStore {
   async getSha256(key: string): Promise<string | null> {
     const abs = this.absolute(key);
     try {
-      const buf = await readFile(abs);
-      return createHash('sha256').update(buf).digest('hex');
+      // Stream rather than readFile: base PDFs can be hundreds of MB
+      // and this must never hold a whole object in RAM.
+      const hash = createHash('sha256');
+      for await (const chunk of createReadStream(abs)) {
+        hash.update(chunk as Buffer);
+      }
+      return hash.digest('hex');
     } catch (err) {
       if (isENOENT(err)) return null;
       throw err;
@@ -205,10 +211,7 @@ export class FsObjectStore implements ObjectStore {
       const sha = hash.digest('hex');
       if (sha !== opts.expectedSha) {
         await safeUnlink(partial);
-        throw new Error(
-          `FsObjectStore.materializeLocal: sha mismatch for ${key} ` +
-            `(expected ${opts.expectedSha}, got ${sha})`,
-        );
+        throw new ShaMismatchError(`FsObjectStore.materializeLocal ${key}`, opts.expectedSha, sha);
       }
       await rename(partial, destPath);
       return { path: destPath, size, sha256: sha };

--- a/cloudpdf/server/src/storage/adapters/S3ObjectStore.ts
+++ b/cloudpdf/server/src/storage/adapters/S3ObjectStore.ts
@@ -20,7 +20,9 @@
  */
 
 import { Readable } from 'node:stream';
+
 import type { ObjectIdentifier } from '@aws-sdk/client-s3';
+
 import type {
   MaterializeOpts,
   MaterializeResult,
@@ -34,6 +36,7 @@ import type {
 import {
   drainReadable,
   computeSha256Hex,
+  streamingSha256,
   materializeViaRanges,
   SHA256_METADATA_KEY,
 } from './_internal';
@@ -170,11 +173,14 @@ export class S3ObjectStore implements ObjectStore {
       // S3 lowercases user-metadata keys on read.
       const fromMeta = meta[SHA256_METADATA_KEY];
       if (fromMeta) return fromMeta;
-      // Fall back to streaming the body. Only used when an object was
-      // PUT outside our SDK (presigned PUT by a misbehaving client).
-      const bytes = await this.get(key);
-      if (!bytes) return null;
-      return computeSha256Hex(bytes);
+      // No metadata means the object was PUT outside our SDK — the
+      // normal shape of every presigned browser upload (SigV4 refuses
+      // unsigned x-amz-meta-* headers, so those uploads can't carry a
+      // recorded SHA). Hash the body as it streams; never buffer the
+      // whole object (base PDFs can be hundreds of MB).
+      const got = await client.send(new cmd.GetObjectCommand({ Bucket: this.bucket, Key: key }));
+      if (!got.Body) return null;
+      return await streamingSha256(got.Body as Readable);
     } catch (err) {
       if (isS3NotFound(err)) return null;
       throw err;

--- a/cloudpdf/server/src/storage/adapters/_internal.ts
+++ b/cloudpdf/server/src/storage/adapters/_internal.ts
@@ -19,10 +19,12 @@
  */
 
 import { createHash, randomBytes } from 'node:crypto';
+import { createReadStream } from 'node:fs';
 import { open, mkdir, rename, unlink } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { Readable } from 'node:stream';
-import type { MaterializeOpts, MaterializeResult } from '../ObjectStore';
+
+import { ShaMismatchError, type MaterializeOpts, type MaterializeResult } from '../ObjectStore';
 
 /**
  * Custom-metadata key under which every remote adapter stashes the
@@ -123,6 +125,14 @@ export async function materializeViaRanges(
   const { size } = source;
   const concurrency = Math.max(1, opts.concurrency ?? 8);
   const chunk = Math.max(1, opts.chunkSizeBytes ?? 16 * 1024 * 1024);
+
+  // A backend-recorded SHA that already disagrees with the caller's
+  // expectation can never produce a valid file — fail before paying
+  // for the download.
+  if (source.knownSha256 && source.knownSha256 !== opts.expectedSha) {
+    throw new ShaMismatchError(`${label}.materializeLocal`, opts.expectedSha, source.knownSha256);
+  }
+
   await mkdir(dirname(destPath), { recursive: true });
   const partial = `${destPath}.partial.${randomBytes(6).toString('hex')}`;
 
@@ -138,6 +148,7 @@ export async function materializeViaRanges(
   }
 
   const fh = await open(partial, 'w');
+  let fhOpen = true;
   try {
     let nextRange = 0;
     const worker = async (): Promise<void> => {
@@ -151,7 +162,22 @@ export async function materializeViaRanges(
         let offset = r.start;
         for await (const piece of stream) {
           const buf = piece instanceof Buffer ? piece : Buffer.from(piece as Uint8Array);
-          await fh.write(buf, 0, buf.byteLength, offset);
+          // Positional writes may land short of the full buffer; a
+          // silently dropped tail would only surface as PDFium reading
+          // garbage, so loop until every byte is on disk.
+          let done = 0;
+          while (done < buf.byteLength) {
+            const { bytesWritten } = await fh.write(
+              buf,
+              done,
+              buf.byteLength - done,
+              offset + done,
+            );
+            if (bytesWritten <= 0) {
+              throw new Error(`${label}.materializeLocal: short write at offset ${offset + done}`);
+            }
+            done += bytesWritten;
+          }
           offset += buf.byteLength;
         }
       }
@@ -161,26 +187,30 @@ export async function materializeViaRanges(
     );
     await Promise.all(workers);
 
+    // The handle was opened write-only and the ranges landed out of
+    // order, so the hash can't be computed inline or through `fh`.
+    // Close first, then (when the backend recorded no SHA on PUT —
+    // every presigned browser upload) stream-hash the finished partial
+    // from disk before promoting it.
+    fhOpen = false;
+    await fh.close();
+
     let materialisedSha = source.knownSha256;
     if (!materialisedSha) {
-      materialisedSha = await streamingSha256(fh.createReadStream({ start: 0 }));
+      materialisedSha = await streamingSha256(createReadStream(partial));
     }
     if (materialisedSha !== opts.expectedSha) {
-      await fh.close();
-      await safeUnlink(partial);
-      throw new Error(
-        `${label}.materializeLocal: sha mismatch ` +
-          `(expected ${opts.expectedSha}, got ${materialisedSha})`,
-      );
+      throw new ShaMismatchError(`${label}.materializeLocal`, opts.expectedSha, materialisedSha);
     }
-    await fh.close();
     await rename(partial, destPath);
     return { path: destPath, size, sha256: materialisedSha };
   } catch (err) {
-    try {
-      await fh.close();
-    } catch {
-      // already closed / never opened — ignore
+    if (fhOpen) {
+      try {
+        await fh.close();
+      } catch {
+        // the write failure is the interesting error — ignore
+      }
     }
     await safeUnlink(partial);
     throw err;

--- a/cloudpdf/server/test/document-lifecycle-commit.test.ts
+++ b/cloudpdf/server/test/document-lifecycle-commit.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Commit-time sha verification. The interesting property under test:
+ * commit needs exactly ONE object-store read of the uploaded bytes.
+ *
+ * With a base-file cache wired, `fileCache.acquire` downloads the
+ * object into the cache and verifies its hash on the way down; the
+ * security probe then reuses that warm entry. The old shape hashed the
+ * remote object (buffering it whole in RAM) and THEN materialised it a
+ * second time for the probe — two full downloads per presigned upload.
+ *
+ * The cache is content-addressed across documents, so a hit that was
+ * materialised from a DIFFERENT object's key proves nothing about OUR
+ * key — commit must detect that via `handle.sourceKey` and fall back
+ * to hashing the remote object directly.
+ */
+import { createHash } from 'node:crypto';
+import { describe, expect, test, vi } from 'vitest';
+
+import type { DocumentsRepo, DocumentRow } from '../src/db/repos/documents.repo';
+import type { TenantsRepo } from '../src/db/repos/tenants.repo';
+import { DocumentLifecycleService } from '../src/services/DocumentLifecycleService';
+import type { LocalFileHandle } from '../src/storage/BaseFileCache';
+import { ShaMismatchError, type ObjectStoreWithInfo } from '../src/storage/ObjectStore';
+
+const CONTENT = Buffer.from('%PDF-1.7 fake body for commit sha tests');
+const SHA = createHash('sha256').update(CONTENT).digest('hex');
+const SIZE = CONTENT.byteLength;
+
+function pendingDoc(overrides: Partial<DocumentRow> = {}): DocumentRow {
+  return {
+    id: 'doc-1',
+    tenantId: 'tnt-1',
+    state: 'pending',
+    baseSha: null,
+    storageSizeBytes: null,
+    expectedSha256: SHA,
+    expectedSizeBytes: SIZE,
+    uploadKind: 'presigned',
+    uploadExpiresAt: null,
+    security: {
+      encryptionState: 'unknown',
+      encryptionRequiresPassword: null,
+      securityHandlerRevision: null,
+      pdfPermissionsBits: null,
+      pdfPermissionsAllAllowed: null,
+      pdfOpenedAs: null,
+      securityProbedAt: null,
+    },
+    docVersion: 1,
+    metadata: null,
+    idempotencyKey: null,
+    failureReason: null,
+    thumbnailState: 'pending',
+    thumbnailKey: null,
+    createdAt: 1,
+    updatedAt: 1,
+    createdBy: 'test',
+    ...overrides,
+  };
+}
+
+function fixture(
+  opts: {
+    doc?: DocumentRow;
+    /** Omit the fileCache entirely (legacy admin-only deploys). */
+    withCache?: boolean;
+    /** Make acquire() reject with this error. */
+    acquireError?: Error;
+    /** Pretend the cache hit came from a different object's key. */
+    hitFromKey?: string;
+    /** What storage.getSha256 reports for the remote object. */
+    remoteSha?: string | null;
+  } = {},
+) {
+  const doc = opts.doc ?? pendingDoc();
+  const markFailed = vi.fn(async () => undefined);
+  const setThumbnail = vi.fn(async () => undefined);
+  const commit = vi.fn(async (input: { baseSha: string }): Promise<DocumentRow> => {
+    return { ...doc, state: 'ready', baseSha: input.baseSha };
+  });
+  const documents = {
+    requireOwned: vi.fn(async () => doc),
+    markFailed,
+    setThumbnail,
+    commit,
+  } as unknown as DocumentsRepo;
+
+  const getSha256 = vi.fn(async () => (opts.remoteSha === undefined ? SHA : opts.remoteSha));
+  const del = vi.fn(async () => true);
+  const storage = {
+    info: { kind: 's3', location: 's3://b' },
+    stat: vi.fn(async () => ({ size: SIZE, etag: 'e' })),
+    getSha256,
+    delete: del,
+  } as unknown as ObjectStoreWithInfo;
+
+  const release = vi.fn();
+  const acquire = vi.fn(async (input: { sha: string; key: string }): Promise<LocalFileHandle> => {
+    if (opts.acquireError) throw opts.acquireError;
+    return {
+      path: '/cache/base',
+      size: SIZE,
+      sha256: input.sha,
+      sourceKey: opts.hitFromKey ?? input.key,
+      release,
+    };
+  });
+
+  const lifecycle = new DocumentLifecycleService({
+    documents,
+    tenants: {} as TenantsRepo,
+    storage,
+    ...(opts.withCache === false ? {} : { fileCache: { acquire } }),
+  });
+  return { lifecycle, doc, markFailed, commit, getSha256, del, acquire, release };
+}
+
+const INPUT = { docId: 'doc-1', tenantId: 'tnt-1', sha256: SHA };
+
+describe('DocumentLifecycleService commit sha verification', () => {
+  test('verifies via one cache materialisation; never re-reads the remote object', async () => {
+    const fx = fixture();
+    const r = await fx.lifecycle.commit(INPUT);
+    expect(r.doc.state).toBe('ready');
+    expect(r.doc.baseSha).toBe(SHA);
+    expect(fx.acquire).toHaveBeenCalledTimes(1);
+    expect(fx.acquire).toHaveBeenCalledWith(expect.objectContaining({ sha: SHA }));
+    expect(fx.getSha256).not.toHaveBeenCalled();
+    expect(fx.release).toHaveBeenCalledTimes(1);
+  });
+
+  test('ShaMismatchError from the cache marks the doc failed and deletes the bytes', async () => {
+    const observed = 'b'.repeat(64);
+    const fx = fixture({ acquireError: new ShaMismatchError('test', SHA, observed) });
+    await expect(fx.lifecycle.commit(INPUT)).rejects.toMatchObject({ status: 400 });
+    expect(fx.markFailed).toHaveBeenCalledWith('doc-1', 'tnt-1', 'sha_mismatch');
+    expect(fx.del).toHaveBeenCalledTimes(1);
+    expect(fx.commit).not.toHaveBeenCalled();
+  });
+
+  test('a transient materialise failure propagates without failing the doc (retryable)', async () => {
+    const fx = fixture({ acquireError: new Error('socket hang up') });
+    await expect(fx.lifecycle.commit(INPUT)).rejects.toThrow(/socket hang up/);
+    expect(fx.markFailed).not.toHaveBeenCalled();
+    expect(fx.del).not.toHaveBeenCalled();
+  });
+
+  test('a cache hit materialised from a DIFFERENT key still verifies our object', async () => {
+    const fx = fixture({ hitFromKey: 'other-tenant/docs/zz/zzz/base.pdf' });
+    const r = await fx.lifecycle.commit(INPUT);
+    expect(r.doc.state).toBe('ready');
+    // Content came from someone else's materialisation — our key's
+    // bytes were never read, so commit must hash them directly.
+    expect(fx.getSha256).toHaveBeenCalledTimes(1);
+    expect(fx.release).toHaveBeenCalledTimes(1);
+  });
+
+  test('cross-key hit whose remote bytes do not match fails the commit', async () => {
+    const fx = fixture({ hitFromKey: 'other/key.pdf', remoteSha: 'c'.repeat(64) });
+    await expect(fx.lifecycle.commit(INPUT)).rejects.toMatchObject({ status: 400 });
+    expect(fx.markFailed).toHaveBeenCalledWith('doc-1', 'tnt-1', 'sha_mismatch');
+    expect(fx.del).toHaveBeenCalledTimes(1);
+    expect(fx.release).toHaveBeenCalledTimes(1);
+  });
+
+  test('without a cache, falls back to the streaming remote hash', async () => {
+    const fx = fixture({ withCache: false });
+    const r = await fx.lifecycle.commit(INPUT);
+    expect(r.doc.state).toBe('ready');
+    expect(fx.getSha256).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects a malformed declared sha before touching storage bytes', async () => {
+    const fx = fixture({ doc: pendingDoc({ expectedSha256: null }) });
+    await expect(
+      fx.lifecycle.commit({ ...INPUT, sha256: 'NOT-A-SHA' }),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(fx.markFailed).toHaveBeenCalledWith('doc-1', 'tnt-1', 'sha_mismatch');
+    expect(fx.acquire).not.toHaveBeenCalled();
+    expect(fx.getSha256).not.toHaveBeenCalled();
+  });
+});

--- a/cloudpdf/server/test/storage-s3.test.ts
+++ b/cloudpdf/server/test/storage-s3.test.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { Readable } from 'node:stream';
-import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { sdkStreamMixin } from '@smithy/util-stream';
@@ -16,6 +16,7 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3';
 import { S3ObjectStore } from '../src/storage/adapters/S3ObjectStore';
+import { ShaMismatchError } from '../src/storage/ObjectStore';
 import { StorageKeys } from '../src/storage/keys';
 
 const s3Mock = mockClient(S3Client);
@@ -221,6 +222,80 @@ describe('S3ObjectStore', () => {
         store.materializeLocal('k', dest, { expectedSha: sha256Hex(bytes) }),
       ).rejects.toThrow(/sha mismatch/);
       await expect(stat(dest)).rejects.toMatchObject({ code: 'ENOENT' });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('materializeLocal hashes the download when no SHA metadata exists (presigned uploads)', async () => {
+    const store = newStore();
+    const total = 5 * 1024;
+    const bytes = randomBytes(total);
+    const chunk = 1024;
+    const sha = sha256Hex(bytes);
+
+    // A presigned browser PUT cannot carry signed x-amz-meta-* headers,
+    // so HEAD reports no metadata and the fallback must hash the
+    // finished partial. Regression: this branch used to re-read the
+    // write-only descriptor and die with EBADF on every such upload.
+    s3Mock.on(HeadObjectCommand).resolves({
+      ContentLength: total,
+      ETag: '"abc"',
+      Metadata: {},
+    });
+    s3Mock.on(GetObjectCommand).callsFake((input: { Range?: string }) => {
+      const m = /^bytes=(\d+)-(\d+)$/.exec(input.Range ?? '');
+      if (!m) throw new Error(`unexpected range: ${input.Range}`);
+      const start = parseInt(m[1]!, 10);
+      const end = parseInt(m[2]!, 10);
+      const slice = bytes.slice(start, end + 1);
+      return { Body: sdkStreamMixin(Readable.from([Buffer.from(slice)])) };
+    });
+
+    const dir = await mkdtemp(join(tmpdir(), 's3-mat-'));
+    try {
+      const dest = join(dir, 'out.pdf');
+      const r = await store.materializeLocal('k', dest, {
+        expectedSha: sha,
+        chunkSizeBytes: chunk,
+        concurrency: 4,
+      });
+      expect(r.size).toBe(total);
+      expect(r.sha256).toBe(sha);
+      expect(await readFile(dest)).toEqual(Buffer.from(bytes));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('materializeLocal without metadata rejects bytes that hash differently', async () => {
+    const store = newStore();
+    const total = 2048;
+    const bytes = randomBytes(total);
+
+    s3Mock.on(HeadObjectCommand).resolves({
+      ContentLength: total,
+      ETag: '"x"',
+      Metadata: {},
+    });
+    s3Mock.on(GetObjectCommand).resolves({
+      Body: sdkStreamMixin(Readable.from([Buffer.from(bytes)])),
+    });
+
+    const dir = await mkdtemp(join(tmpdir(), 's3-mat-'));
+    try {
+      const dest = join(dir, 'bad.pdf');
+      const err = await store
+        .materializeLocal('k', dest, { expectedSha: 'a'.repeat(64) })
+        .then(
+          () => null,
+          (e: unknown) => e,
+        );
+      expect(err).toBeInstanceOf(ShaMismatchError);
+      expect((err as ShaMismatchError).actual).toBe(sha256Hex(bytes));
+      // Neither the destination nor any .partial.* may survive.
+      await expect(stat(dest)).rejects.toMatchObject({ code: 'ENOENT' });
+      expect(await readdir(dir)).toEqual([]);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Fix presigned-upload materialization and make commit-time SHA verification single-read and constant-memory.

- Fixes range materializer EBADF on objects with no SHA (common with presigned browser uploads): close write-only handle, stream finished partial from disk, guard against short positional writes, and reject backend-recorded/expected-SHA disagreement early.
- Replace S3/FS getSha256 fallbacks that buffered whole objects with streaming hashes (constant memory).
- Commit now verifies uploaded bytes with a single object-store read when a base-file cache is wired: materialise into cache, hash on the way down, and reuse by the security probe; cross-key cache hits still trigger direct verification.
- Add exported ShaMismatchError typed class thrown by materializeLocal implementations so callers can distinguish declared-hash mismatches from transport failures.
- Surface previously swallowed failures: wire base-file-cache materialize-error, DerivedRenderService.onWarmError, and DocumentSecurityProbe.onError to server logging.
- Add tests for commit sha verification and S3 materialization behavior.