### PR TITLE
Derive connected reporting credential from license key

### DIFF
--- a/.changeset/cloudpdf-server-derived-reporting-credential.md
+++ b/.changeset/cloudpdf-server-derived-reporting-credential.md
@@ -1,0 +1,11 @@
+---
+'@cloudpdf/server': minor
+---
+
+Derives the connected usage-reporting credential from the license key, so a connected deployment is configured with `CLOUDPDF_LICENSE_KEY` alone.
+
+- Computes the reporting credential as `cpr_v1_` + base64url(HMAC-SHA256) over a domain-separated message that binds the signed `cloudpdfLicenseId` license metadata, so the wire credential is one-way (it can never reveal the license key) and never authenticates another license record.
+- Retires `CLOUDPDF_LICENSE_REPORTING_TOKEN`. A deployment that still sets it boots normally; the variable is ignored and the server logs a warning asking for its removal.
+- Existing connected deployments upgrade by removing the retired variable. During the coordinated verifier cutover on the CloudPDF side a usage report may answer 401; reports retry every five minutes with cumulative counters, so no usage is lost and license validation is unaffected.
+- Air-gapped deployments are unchanged and continue to send no telemetry.
+- Pins fixed cross-runtime derivation test vectors shared with the CloudPDF control plane.

--- a/cloudpdf/server/src/bin/cloudpdf-server.ts
+++ b/cloudpdf/server/src/bin/cloudpdf-server.ts
@@ -100,8 +100,9 @@ import type { ObjectStore } from '../storage/ObjectStore';
  *   CLOUDPDF_WORKER_POOL_SIZE  int|max  (default: min(2, cpus))
  *   CLOUDPDF_FALLBACK_FONTS  JSON [{key,path,familyName?,...}]  (default: none)
  *   CLOUDPDF_LICENSE_MODE     connected|air-gapped
- *   CLOUDPDF_LICENSE_KEY      required for connected mode
- *   CLOUDPDF_LICENSE_REPORTING_TOKEN     required for connected usage reporting
+ *   CLOUDPDF_LICENSE_KEY      required for connected mode; usage reporting
+ *                             derives its credential from this key
+ *                             (CLOUDPDF_LICENSE_REPORTING_TOKEN is retired)
  *
  * Exit codes:
  *   0  success
@@ -251,10 +252,7 @@ function readUploadProxyPolicyEnv(): 'fallback-only' | 'allowed' | 'disabled' {
   const raw = process.env['CLOUDPDF_UPLOAD_PROXY_POLICY']?.trim().toLowerCase();
   if (!raw) return 'fallback-only';
   if (raw === 'fallback-only' || raw === 'allowed' || raw === 'disabled') return raw;
-  fail(
-    2,
-    `CLOUDPDF_UPLOAD_PROXY_POLICY must be fallback-only, allowed, or disabled (got ${raw})`,
-  );
+  fail(2, `CLOUDPDF_UPLOAD_PROXY_POLICY must be fallback-only, allowed, or disabled (got ${raw})`);
 }
 
 /** CLOUDPDF_ENABLE_REVOCATION=1 mounts tokens.revoke and enforces the jti denylist. */
@@ -758,9 +756,17 @@ async function cmdServe(): Promise<void> {
     initialLicense.mode === 'connected' &&
     initialLicense.telemetryProfile === 'aggregated-usage'
   ) {
+    if (process.env['CLOUDPDF_LICENSE_REPORTING_TOKEN']) {
+      console.warn(
+        '[cloudpdf-server] CLOUDPDF_LICENSE_REPORTING_TOKEN is retired and ignored: ' +
+          'the usage-reporting credential is derived from CLOUDPDF_LICENSE_KEY. ' +
+          'Remove the variable from this deployment.',
+      );
+    }
     try {
       const cloudPdfLicenseId = licenseRuntime.getConnectedReportingLicenseId();
-      if (!cloudPdfLicenseId) {
+      const reportingCredential = licenseRuntime.getConnectedReportingCredential();
+      if (!cloudPdfLicenseId || !reportingCredential) {
         throw new Error(
           'Connected license requires usage reporting but its signed metadata is missing cloudpdfLicenseId',
         );
@@ -769,8 +775,7 @@ async function cmdServe(): Promise<void> {
         cloudPdfLicenseId,
         db: dbCtx.db,
         meters: new UsageMeters(dbCtx.db, licenseRuntime),
-        reportingToken: process.env['CLOUDPDF_LICENSE_REPORTING_TOKEN'],
-        secretResolver: resolver,
+        reportingCredential,
       });
     } catch (error) {
       await licenseRuntime.close();

--- a/cloudpdf/server/src/licensing/ConnectedUsageReporter.ts
+++ b/cloudpdf/server/src/licensing/ConnectedUsageReporter.ts
@@ -13,9 +13,7 @@ import type { Kysely, Selectable } from 'kysely';
 
 import type { LicenseUsageSnapshot } from './UsageMeters';
 import { UsageMeters } from './UsageMeters';
-import { parseSecretRefUri } from '../config/secrets/parseSecretRefUri';
 import type { Database, LicenseReportingStateTable } from '../db/schema';
-import type { SecretResolver } from '../security/secrets/SecretResolver';
 
 const productionControlPlaneUrl = 'https://api.cloudpdf.com';
 
@@ -54,15 +52,14 @@ export class ConnectedUsageReporter {
     private readonly meters: UsageMeters,
     private readonly cloudPdfLicenseId: string,
     private readonly controlPlaneUrl: string,
-    private readonly reportingToken: string,
+    private readonly reportingCredential: string,
   ) {}
 
   static async create(input: {
     cloudPdfLicenseId: string;
     db: Kysely<Database>;
     meters: UsageMeters;
-    reportingToken?: string;
-    secretResolver?: SecretResolver;
+    reportingCredential: string;
   }): Promise<ConnectedUsageReporter> {
     return this.createWithControlPlane(input, productionControlPlaneUrl);
   }
@@ -73,8 +70,7 @@ export class ConnectedUsageReporter {
     controlPlaneUrl: string;
     db: Kysely<Database>;
     meters: UsageMeters;
-    reportingToken?: string;
-    secretResolver?: SecretResolver;
+    reportingCredential: string;
   }): Promise<ConnectedUsageReporter> {
     return this.createWithControlPlane(
       input,
@@ -87,16 +83,14 @@ export class ConnectedUsageReporter {
       cloudPdfLicenseId: string;
       db: Kysely<Database>;
       meters: UsageMeters;
-      reportingToken?: string;
-      secretResolver?: SecretResolver;
+      reportingCredential: string;
     },
     controlPlaneUrl: string,
   ): Promise<ConnectedUsageReporter> {
-    const reportingToken = await resolveSecret(
-      input.reportingToken,
-      input.secretResolver,
-      'CLOUDPDF_LICENSE_REPORTING_TOKEN',
-    );
+    const reportingCredential = input.reportingCredential.trim();
+    if (!reportingCredential) {
+      throw new Error('A connected reporting credential is required for usage reporting');
+    }
     const cloudPdfLicenseId = input.cloudPdfLicenseId.trim();
     if (!cloudPdfLicenseId) {
       throw new Error('A signed CloudPDF reporting license ID is required');
@@ -106,7 +100,7 @@ export class ConnectedUsageReporter {
       input.meters,
       cloudPdfLicenseId,
       controlPlaneUrl,
-      reportingToken,
+      reportingCredential,
     );
   }
 
@@ -129,7 +123,7 @@ export class ConnectedUsageReporter {
       await this.markAttempt();
       const response = await postWithRetry(
         `${this.controlPlaneUrl}/v1/licenses/${encodeURIComponent(pending.licenseId)}/usage`,
-        this.reportingToken,
+        this.reportingCredential,
         pending.payload,
       );
       if (!response.ok) {
@@ -308,7 +302,7 @@ export class ConnectedUsageReporter {
 
 async function postWithRetry(
   url: string,
-  token: string,
+  credential: string,
   payload: UsageReportPayload,
 ): Promise<Response> {
   let lastError: unknown;
@@ -317,7 +311,7 @@ async function postWithRetry(
       const response = await fetch(url, {
         body: JSON.stringify(payload),
         headers: {
-          authorization: `Bearer ${token}`,
+          authorization: `Bearer ${credential}`,
           'content-type': 'application/json',
         },
         method: 'POST',
@@ -332,22 +326,6 @@ async function postWithRetry(
     await new Promise((resolve) => setTimeout(resolve, 250 * 2 ** attempt));
   }
   throw lastError;
-}
-
-async function resolveSecret(
-  raw: string | undefined,
-  resolver: SecretResolver | undefined,
-  name: string,
-): Promise<string> {
-  const value = raw?.trim();
-  if (!value) throw new Error(`${name} is required for connected usage reporting`);
-  if (!value.startsWith('secret://')) return value;
-  if (!resolver) throw new Error(`A SecretResolver is required when ${name} is a secret:// URI`);
-  const resolved = await resolver.resolve({
-    reportingToken: { as: 'string', ref: parseSecretRefUri(value) },
-  });
-  if (!resolved.reportingToken.trim()) throw new Error(`${name} resolved to an empty secret`);
-  return resolved.reportingToken.trim();
 }
 
 function requireHttpsUrl(value: string | undefined, name: string): string {

--- a/cloudpdf/server/src/licensing/LicenseRuntime.ts
+++ b/cloudpdf/server/src/licensing/LicenseRuntime.ts
@@ -23,6 +23,7 @@ import type { KeygenResponseProof } from './keygen-response';
 import { LicenseStateRepository } from './LicenseStateRepository';
 import { verifyMachineCertificate, type VerifiedMachineCertificate } from './offline-certificate';
 import { resolveCloudPdfLicenseIdentity, type CloudPdfLicenseIdentity } from './product';
+import { deriveConnectedReportingCredential } from './reporting-credential';
 import { markLicenseGateTrusted } from './trusted-license-gates';
 import { parseSecretRefUri } from '../config/secrets/parseSecretRefUri';
 import type { Database } from '../db/schema';
@@ -150,6 +151,20 @@ export class LicenseRuntime implements LicenseGate {
   /** Internal server bootstrap value sourced only from verified license metadata. */
   getConnectedReportingLicenseId(): string | null {
     return this.connectedReportingLicenseId;
+  }
+
+  /**
+   * Internal server bootstrap value: the usage-reporting bearer credential,
+   * derived one-way from the configured license key and the signed
+   * cloudpdfLicenseId metadata. Null until a connected validation has
+   * surfaced the license ID; always null in air-gapped mode.
+   */
+  getConnectedReportingCredential(): string | null {
+    if (!this.key || !this.connectedReportingLicenseId) return null;
+    return deriveConnectedReportingCredential({
+      cloudpdfLicenseId: this.connectedReportingLicenseId,
+      licenseKey: this.key,
+    });
   }
 
   async close(): Promise<void> {

--- a/cloudpdf/server/src/licensing/reporting-credential.ts
+++ b/cloudpdf/server/src/licensing/reporting-credential.ts
@@ -1,0 +1,53 @@
+/**
+ * @license FCL-1.0-ALv2
+ *
+ * WARNING: This file is part of CloudPDF's license-key functionality. Removing
+ * or modifying this code to disable or circumvent license enforcement, enable
+ * protected functionality without a valid license key, or remove protected
+ * functionality is a breach of FCL-1.0-ALv2 while this release is governed by
+ * that license. See cloudpdf/server/LICENSE.
+ */
+import { createHmac } from 'node:crypto';
+
+/**
+ * Connected reporting credential, version 1.
+ *
+ * The usage-reporting bearer credential is derived from the license key
+ * instead of being a separately issued secret, so a connected deployment is
+ * configured with the license key alone. The derivation is one-way and
+ * domain-separated: possession of the wire credential proves nothing about
+ * the license key, and the value can never collide with the plain
+ * SHA-256 license-key fingerprints stored elsewhere.
+ *
+ *   cpr_v1_ + base64url( HMAC-SHA256(
+ *     key     = UTF-8(trim(licenseKey)),
+ *     message = UTF-8("cloudpdf/usage-reporting/v1\0" + trim(cloudpdfLicenseId)),
+ *   ) )
+ *
+ * The signed control-plane license ID is bound into the message so a
+ * credential can never be replayed against another license record. The
+ * control plane derives the same value at issuance and stores only its
+ * SHA-256 digest. Both sides pin identical fixed test vectors; changing
+ * either implementation without the other breaks usage reporting.
+ */
+const REPORTING_CREDENTIAL_DOMAIN = 'cloudpdf/usage-reporting/v1\0';
+
+export const REPORTING_CREDENTIAL_PREFIX = 'cpr_v1_';
+
+export function deriveConnectedReportingCredential(input: {
+  cloudpdfLicenseId: string;
+  licenseKey: string;
+}): string {
+  const licenseKey = input.licenseKey.trim();
+  const cloudpdfLicenseId = input.cloudpdfLicenseId.trim();
+  if (!licenseKey) {
+    throw new Error('A license key is required to derive the reporting credential');
+  }
+  if (!cloudpdfLicenseId) {
+    throw new Error('A CloudPDF license ID is required to derive the reporting credential');
+  }
+  const mac = createHmac('sha256', Buffer.from(licenseKey, 'utf8'))
+    .update(Buffer.from(REPORTING_CREDENTIAL_DOMAIN + cloudpdfLicenseId, 'utf8'))
+    .digest('base64url');
+  return `${REPORTING_CREDENTIAL_PREFIX}${mac}`;
+}

--- a/cloudpdf/server/test/licensing.test.ts
+++ b/cloudpdf/server/test/licensing.test.ts
@@ -12,6 +12,7 @@ import { UsageLimitError, UsageMeters } from '../src/licensing/UsageMeters';
 import type { LicenseGate } from '../src/licensing/LicenseRuntime';
 import { ConnectedUsageReporter } from '../src/licensing/ConnectedUsageReporter';
 import { LicenseStateRepository } from '../src/licensing/LicenseStateRepository';
+import { deriveConnectedReportingCredential } from '../src/licensing/reporting-credential';
 import { buildApp, buildAppForTesting } from '../src/app/buildApp';
 
 const accountId = 'account-test';
@@ -482,9 +483,17 @@ test('connected cache requires an encrypted, signed proof bound to the key and d
   });
   vi.stubGlobal('fetch', fetchMock);
 
+  // The reporting credential needs no configuration beyond the license key:
+  // it is derived from the key and the signed cloudpdfLicenseId metadata.
+  const expectedReportingCredential = deriveConnectedReportingCredential({
+    cloudpdfLicenseId: 'cloudpdf-license-record-id',
+    licenseKey: key,
+  });
+
   const first = await LicenseRuntime.create({ db, env, identity, startTimer: false });
   expect(first.getStatus()).toMatchObject({ access: 'full', code: 'VALID' });
   expect(first.getConnectedReportingLicenseId()).toBe('cloudpdf-license-record-id');
+  expect(first.getConnectedReportingCredential()).toBe(expectedReportingCredential);
   await first.close();
 
   const state = await new LicenseStateRepository(db).load();
@@ -493,6 +502,7 @@ test('connected cache requires an encrypted, signed proof bound to the key and d
   const cached = await LicenseRuntime.create({ db, env, identity, startTimer: false });
   expect(cached.getStatus()).toMatchObject({ access: 'full', code: 'VALID_CACHED' });
   expect(cached.getConnectedReportingLicenseId()).toBe('cloudpdf-license-record-id');
+  expect(cached.getConnectedReportingCredential()).toBe(expectedReportingCredential);
   expect(fetchMock).not.toHaveBeenCalled();
   await cached.close();
 
@@ -707,7 +717,7 @@ test('connected reporting retries the persisted sequence and payload after a fai
     controlPlaneUrl: 'https://accounts.example.test',
     db,
     meters,
-    reportingToken: 'reporting-secret',
+    reportingCredential: 'cpr_v1_test-reporting-credential',
   });
 
   try {
@@ -720,7 +730,7 @@ test('connected reporting retries the persisted sequence and payload after a fai
     responseStatus = 200;
     await expect(reporter.reportNow()).resolves.toBe(true);
     expect(requests[1]?.body).toEqual(requests[0]?.body);
-    expect(requests[1]?.authorization).toBe('Bearer reporting-secret');
+    expect(requests[1]?.authorization).toBe('Bearer cpr_v1_test-reporting-credential');
     expect(requests[1]?.url).toBe(
       `https://accounts.example.test/v1/licenses/${cloudPdfLicenseId}/usage`,
     );

--- a/cloudpdf/server/test/reporting-credential.test.ts
+++ b/cloudpdf/server/test/reporting-credential.test.ts
@@ -1,0 +1,65 @@
+import { createHash } from 'node:crypto';
+
+import { expect, test } from 'vitest';
+
+import {
+  deriveConnectedReportingCredential,
+  REPORTING_CREDENTIAL_PREFIX,
+} from '../src/licensing/reporting-credential';
+
+// Fixed cross-runtime vectors. The control plane pins the same values
+// (apps/control-plane/test/reporting-credential.test.ts in cloudpdf-platform);
+// a change that breaks one side breaks connected usage reporting.
+const VECTORS = [
+  {
+    cloudpdfLicenseId: '0b19ed08-59a4-4d3e-8f37-6c3a1c2f9d10',
+    credential: 'cpr_v1_dorzyB3nrGIMBT84M2ZRg7YlDJvVRtvhA57pegzhoI4',
+    licenseKey: 'DEMO-KEY-1234-5678',
+    verifierSha256: '45b092d876e835e678b7a4006e63657e8c52e15423c918b1275397c851dff089',
+  },
+  {
+    // Surrounding whitespace is trimmed before derivation.
+    cloudpdfLicenseId: '11111111-2222-3333-4444-555555555555',
+    credential: 'cpr_v1_t4Fw-LK1JSxofHQhThWEpF7q6bHiXvRXQ43AJi1ndps',
+    licenseKey: '  KEY-TRIM-TEST  ',
+    verifierSha256: 'ccbc2249e3f9b445fd86b9ff314426277168c078b4f3f8eea7077a480e3dec4b',
+  },
+  {
+    // Non-ASCII input pins the UTF-8 encoding of both HMAC inputs.
+    cloudpdfLicenseId: '99999999-8888-7777-6666-555555555555',
+    credential: 'cpr_v1_fgyCpNrlsZQpdplnbwcfWi5vGJdYfa-UBeSw3BNqXDY',
+    licenseKey: 'clé-δ',
+    verifierSha256: '7ecbfce933cc2250119c5b5446de7f4f29357f1ffe1f6428e0207a31a9f57af7',
+  },
+];
+
+test('derives the pinned reporting credentials', () => {
+  for (const vector of VECTORS) {
+    const credential = deriveConnectedReportingCredential(vector);
+    expect(credential).toBe(vector.credential);
+    expect(credential.startsWith(REPORTING_CREDENTIAL_PREFIX)).toBe(true);
+    expect(createHash('sha256').update(credential).digest('hex')).toBe(vector.verifierSha256);
+  }
+});
+
+test('binds the credential to the license record', () => {
+  const base = deriveConnectedReportingCredential({
+    cloudpdfLicenseId: 'license-a',
+    licenseKey: 'KEY-ONE',
+  });
+  expect(
+    deriveConnectedReportingCredential({ cloudpdfLicenseId: 'license-b', licenseKey: 'KEY-ONE' }),
+  ).not.toBe(base);
+  expect(
+    deriveConnectedReportingCredential({ cloudpdfLicenseId: 'license-a', licenseKey: 'KEY-TWO' }),
+  ).not.toBe(base);
+});
+
+test('rejects empty inputs', () => {
+  expect(() =>
+    deriveConnectedReportingCredential({ cloudpdfLicenseId: ' ', licenseKey: 'KEY' }),
+  ).toThrow(/license ID/);
+  expect(() =>
+    deriveConnectedReportingCredential({ cloudpdfLicenseId: 'id', licenseKey: '  ' }),
+  ).toThrow(/license key/);
+});


### PR DESCRIPTION
Retire the CLOUDPDF_LICENSE_REPORTING_TOKEN and derive the usage-reporting bearer credential one-way from the configured license key and signed cloudpdfLicenseId. Add reporting-credential.ts which implements HMAC-SHA256 based derivation with a cpr_v1_ prefix. Expose getConnectedReportingCredential() on LicenseRuntime and update ConnectedUsageReporter to accept a reportingCredential (removing secret:// resolution). CLI warns if the retired env var is present and passes the derived credential when bootstrapping reporting. Tests updated to use the derived credential and a new reporting-credential unit test with fixed vectors was added. This simplifies configuration and improves security by avoiding a separately provisioned reporting secret.