### PR TITLE
Add 'share' OpenInput and engine share handling

### DIFF
--- a/.changeset/cloudpdf-engine-open-share.md
+++ b/.changeset/cloudpdf-engine-open-share.md
@@ -1,0 +1,9 @@
+---
+'@cloudpdf/engine': minor
+---
+
+`open({ kind: 'share' })`: the engine resolves public share tokens itself.
+
+- The share arm exchanges `shr_…` for a session JWT on the engine's own transport (`baseUrl` + configured `fetch`) and delegates to the `token` arm, so the handle binds to a self-renewing source — revoking or editing the share retargets the open at the next renewal. Works on an engine constructed with no engine-level token at all.
+- Exchange failures surface as `EngineError`s — on `open()` and on every later renewal (RPCs, SSE reconnects) — never as raw `ShareExchangeError`s. Protected grants reject with the new `EngineErrorCode.SharePasswordRequired`; the wire code and HTTP status ride in `details`, the original error in `cause`. The mapping is exported as `engineErrorFromShareExchange`.
+- `shareSessionSource` now declares its concrete return type (`() => Promise<string>`) instead of the `TokenSource` union; `HttpClient` exposes `baseUrl` and `fetchImpl` getters.

--- a/.changeset/cloudpdf-viewer-share-passthrough.md
+++ b/.changeset/cloudpdf-viewer-share-passthrough.md
@@ -1,0 +1,9 @@
+---
+'@cloudpdf/viewer': minor
+---
+
+Share sources pass through to the engine; the viewer-only share vocabulary is retired.
+
+- `{ kind: 'share' }` is a standard `OpenInput` kind now, resolved by `engine.open()` itself — `resolveCloudConfig` no longer lowers share entries into token sources, and no longer re-threads `baseUrl`/`fetch` into the exchange.
+- BREAKING (prerelease line): on share sources the grant passphrase field is `sharePassword` (was `password`, which now means the PDF's own encryption password — the same slot every other kind uses). The top-level `shareToken`/`sharePassword` shorthands are unchanged.
+- `CloudShareSource` and `CloudInitialDocument` remain as deprecated aliases of `OpenInputShare` and `InitialDocument`.

--- a/.changeset/engine-core-open-input-share.md
+++ b/.changeset/engine-core-open-input-share.md
@@ -1,0 +1,9 @@
+---
+'@embedpdf/engine-core': minor
+---
+
+Adds `share` to the `OpenInput` union and a `SharePasswordRequired` engine error code.
+
+- `OpenInputShare` (`{ kind: 'share', shareToken, sharePassword?, password? }`) is the third cloud reference form, alongside `id` and `token`: a public share token from the dashboard's embed snippet, resolved by the cloud engine itself. Rejected by `@embedpdf/engine`, like the other cloud kinds.
+- `sharePassword` is the grant's passphrase (checked at exchange); `password` stays the PDF's own encryption password, same slot as every other kind.
+- `EngineErrorCode.SharePasswordRequired` is the prompt-and-retry signal for protected grants — the share sibling of `DocPasswordRequired`.

--- a/cloudpdf/engine/src/CloudEngine.ts
+++ b/cloudpdf/engine/src/CloudEngine.ts
@@ -12,6 +12,7 @@ import { generateUuid } from '@embedpdf/engine-services';
 
 import { CloudDocumentHandle } from './document/CloudDocumentHandle';
 import { CloudDocumentSecurityService } from './document/CloudDocumentSecurityService';
+import { engineErrorFromShareExchange, ShareExchangeError, shareSessionSource } from './share';
 import { decodeUnverifiedClaims } from './transport/decodeUnverifiedClaims';
 import { HttpClient, type HttpClientOptions } from './transport/HttpClient';
 
@@ -54,8 +55,33 @@ export class CloudEngine implements Engine {
 
     // Presence-based precedence, same rule the local engine documents: an
     // options.password key wins (even explicitly null), else input.password.
+    // For 'share' inputs `input.password` is still the PDF password — the
+    // grant passphrase travels separately as `input.sharePassword`.
     const effectivePassword =
       options && 'password' in options ? (options.password ?? null) : (input.password ?? null);
+
+    if (input.kind === 'share') {
+      // Open by public share token: exchange `shr_…` for a short-lived
+      // doc-scoped session JWT, then delegate to the 'token' arm — the
+      // handle binds to a SELF-RENEWING source, so revoking or editing
+      // the share retargets this open at the next renewal. The exchange
+      // rides the engine's own transport config (baseUrl + fetch);
+      // exchange failures surface as EngineErrors on open AND on every
+      // later renewal (RPCs, SSE reconnects), never as raw
+      // ShareExchangeErrors.
+      const raw = shareSessionSource(this.http.baseUrl, input.shareToken, {
+        ...(input.sharePassword !== undefined ? { password: input.sharePassword } : {}),
+        fetch: this.http.fetchImpl,
+      });
+      const token = async () => {
+        try {
+          return await raw();
+        } catch (error) {
+          throw error instanceof ShareExchangeError ? engineErrorFromShareExchange(error) : error;
+        }
+      };
+      return this.open({ kind: 'token', token, password: input.password ?? null }, options);
+    }
 
     if (input.kind === 'token') {
       // Open by doc-scoped JWT. We never verify the token SDK-side
@@ -146,7 +172,7 @@ export class CloudEngine implements Engine {
     return AbortablePromise.rejectReason(
       new EngineError(
         EngineErrorCode.InvalidArg,
-        `cloud engine supports OpenInput.kind === 'token' or 'id' (got '${(input as { kind?: string }).kind}')`,
+        `cloud engine supports OpenInput.kind === 'token', 'id', or 'share' (got '${(input as { kind?: string }).kind}')`,
       ),
     );
   }

--- a/cloudpdf/engine/src/index.ts
+++ b/cloudpdf/engine/src/index.ts
@@ -20,7 +20,12 @@ export { HttpClient } from './transport/HttpClient';
 export type { HttpClientOptions } from './transport/HttpClient';
 export { decodeUnverifiedClaims } from './transport/decodeUnverifiedClaims';
 export type { UnverifiedClaims } from './transport/decodeUnverifiedClaims';
-export { exchangeShareToken, shareSessionSource, ShareExchangeError } from './share';
+export {
+  exchangeShareToken,
+  shareSessionSource,
+  ShareExchangeError,
+  engineErrorFromShareExchange,
+} from './share';
 export type { ShareSession, ShareExchangeOptions } from './share';
 
 import { CloudEngine, type CloudEngineOptions } from './CloudEngine';
@@ -69,6 +74,7 @@ export type {
   DocumentCapabilities,
   PageHandle,
   OpenInput,
+  OpenInputShare,
   OpenOptions,
   TokenSource,
   MetadataService,

--- a/cloudpdf/engine/src/share.ts
+++ b/cloudpdf/engine/src/share.ts
@@ -1,4 +1,4 @@
-import type { TokenSource } from '@embedpdf/engine-core/runtime';
+import { EngineError, EngineErrorCode } from '@embedpdf/engine-core/runtime';
 
 /**
  * Share-session exchange: the client half of the no-backend embed flow.
@@ -6,7 +6,7 @@ import type { TokenSource } from '@embedpdf/engine-core/runtime';
  * A share token (`shr_…`) is a REFERENCE to a stored grant on the
  * server, not a credential — `exchangeShareToken` trades it for an
  * ordinary short-lived doc JWT, and `shareSessionSource` wraps that in
- * a self-renewing {@link TokenSource}. Because the engine's transport
+ * a self-renewing token source. Because the engine's transport
  * invokes its token source on every request (and SSE reconnects call
  * it again), renewal is nothing more than "exchange again when the
  * cached session is nearly out" — no timers, no listeners.
@@ -78,11 +78,45 @@ export async function exchangeShareToken(
   return (await res.json()) as ShareSession;
 }
 
+/**
+ * Lift a {@link ShareExchangeError} into the engine's error taxonomy, so
+ * `open({ kind: 'share' })` and every later renewal fail with the same
+ * `EngineError` family as all other engine calls. The wire code and HTTP
+ * status survive in `details`; the original error rides as `cause`.
+ *
+ * `SharePasswordRequired` gets its own engine code — it is the one outcome
+ * callers branch on programmatically (prompt for the grant passphrase and
+ * retry). Everything else maps by meaning, with the HTTP status as the
+ * fallback discriminator.
+ */
+export function engineErrorFromShareExchange(error: ShareExchangeError): EngineError {
+  const code =
+    error.code === 'SharePasswordRequired'
+      ? EngineErrorCode.SharePasswordRequired
+      : error.code === 'NotFound'
+        ? EngineErrorCode.NotFound
+        : error.code === 'ShareExpired' ||
+            error.code === 'OriginNotAllowed' ||
+            error.code === 'OriginRequired'
+          ? EngineErrorCode.Forbidden
+          : error.status === 401
+            ? EngineErrorCode.Unauthenticated
+            : error.status === 400
+              ? EngineErrorCode.InvalidArg
+              : EngineErrorCode.Unknown;
+  return new EngineError(code, `share exchange failed: ${error.message}`, {
+    details: { shareCode: error.code, status: error.status },
+    cause: error,
+  });
+}
+
 /** Renew this many seconds before `expiresAt` so in-flight requests never race expiry. */
 const RENEW_MARGIN_SECONDS = 60;
 
 /**
- * A caching, self-renewing {@link TokenSource} over the exchange.
+ * A caching, self-renewing token source over the exchange — the callable
+ * member of the engine's `TokenSource` union, assignable wherever one is
+ * taken.
  * Concurrent callers share one in-flight exchange; a failed exchange
  * clears it so the next request retries rather than caching the error.
  */
@@ -90,7 +124,7 @@ export function shareSessionSource(
   baseUrl: string,
   shareToken: string,
   opts: ShareExchangeOptions = {},
-): TokenSource {
+): () => Promise<string> {
   let session: ShareSession | null = null;
   let inflight: Promise<string> | null = null;
   return async () => {

--- a/cloudpdf/engine/src/transport/HttpClient.ts
+++ b/cloudpdf/engine/src/transport/HttpClient.ts
@@ -59,18 +59,33 @@ export interface HttpFileResponse {
 }
 
 export class HttpClient {
-  private readonly baseUrl: string;
+  private readonly base: string;
   private readonly tokenFn: (() => string | Promise<string>) | null;
   private readonly fetchFn: typeof globalThis.fetch;
   private readonly sessionId: string | null;
   private cdnBinding: CdnBinding | null = null;
 
   constructor(opts: HttpClientOptions) {
-    this.baseUrl = opts.baseUrl.replace(/\/$/, '');
+    this.base = opts.baseUrl.replace(/\/$/, '');
     const token = opts.token;
     this.tokenFn = token === undefined ? null : typeof token === 'function' ? token : () => token;
     this.sessionId = opts.sessionId ?? null;
     this.fetchFn = opts.fetch ?? globalThis.fetch.bind(globalThis);
+  }
+
+  /** Normalized server base URL (no trailing slash). */
+  get baseUrl(): string {
+    return this.base;
+  }
+
+  /**
+   * The fetch implementation this client sends requests through (injected
+   * or global). Exposed so sibling transports spawned per-open — the
+   * share-session exchange, most of all — ride the same fetch the engine
+   * was configured with (test doubles, SSR `Origin`-attaching wrappers).
+   */
+  get fetchImpl(): typeof globalThis.fetch {
+    return this.fetchFn;
   }
 
   /**

--- a/cloudpdf/engine/test/share-session.test.ts
+++ b/cloudpdf/engine/test/share-session.test.ts
@@ -17,15 +17,22 @@ import {
 } from '@cloudpdf/server';
 import { buildAppForTesting } from '../../server/src/app/buildApp';
 import { createValidTestLicenseGate } from '../../server/src/licensing/testing';
+import { EngineError, EngineErrorCode } from '@embedpdf/engine-core/runtime';
 import { createCloudEngine } from '../src/index';
 import { exchangeShareToken, shareSessionSource, ShareExchangeError } from '../src/share';
 
 /**
- * SDK side of the no-backend embed flow: a share token exchanged into a
- * self-renewing TokenSource that drives an ordinary
- * `open({ kind: 'token' })`. The exchange endpoint requires a browser
- * Origin header — browsers send it automatically; here (Node) the
- * fetch wrapper plays the browser.
+ * SDK side of the no-backend embed flow, at both levels:
+ *
+ *   - the primitives: a share token exchanged into a self-renewing
+ *     token source that drives an ordinary `open({ kind: 'token' })`
+ *   - the engine arm: `open({ kind: 'share' })`, which performs the
+ *     exchange itself on the engine's own transport (baseUrl + fetch)
+ *     and surfaces exchange failures as EngineErrors
+ *
+ * The exchange endpoint requires a browser Origin header — browsers
+ * send it automatically; here (Node) the fetch wrapper plays the
+ * browser.
  */
 
 const STUB_ENTRY = fileURLToPath(
@@ -124,11 +131,18 @@ async function createShare(body: Record<string, unknown>): Promise<string> {
   return ((await res.json()) as { share: { id: string } }).share.id;
 }
 
-/** Node fetch playing the browser: attach Origin like a cross-origin page would. */
+/**
+ * Node fetch playing the browser: attach Origin like a cross-origin page
+ * would. Merges via `Headers` — engine transport passes a `Headers`
+ * instance, which a plain object spread would silently flatten to `{}`
+ * (dropping `Authorization`).
+ */
 function browserFetch(origin: string, counter?: { exchanges: number }): typeof fetch {
   return async (input, init) => {
     if (counter && String(input).endsWith('/v1/share-sessions')) counter.exchanges += 1;
-    return fetch(input, { ...init, headers: { ...(init?.headers ?? {}), origin } });
+    const headers = new Headers(init?.headers);
+    headers.set('origin', origin);
+    return fetch(input, { ...init, headers });
   };
 }
 
@@ -212,6 +226,88 @@ describe('share sessions (SDK)', () => {
         }),
       });
       expect(again.id).toBe('doc-multi-b');
+    } finally {
+      await engine.destroy();
+    }
+  });
+
+  test("open({ kind: 'share' }) exchanges on the engine's own transport", async () => {
+    await seedDocument('doc-open-share');
+    const shareId = await createShare({
+      docId: 'doc-open-share',
+      scope: ['doc.open', 'doc.render'],
+      origins: ['https://acme.com'],
+    });
+
+    // The Origin-attaching fetch is configured on the ENGINE, not the
+    // open call — proving the share arm forwards the engine's transport
+    // (fetchImpl + baseUrl) into the exchange. No engine-level token:
+    // the anonymous-engine embed scenario.
+    const counter = { exchanges: 0 };
+    const engine = createCloudEngine({
+      baseUrl: fx.baseUrl,
+      fetch: browserFetch('https://acme.com', counter),
+    });
+    try {
+      const handle = await engine.open({ kind: 'share', shareToken: shareId });
+      expect(handle.id).toBe('doc-open-share');
+      expect(counter.exchanges).toBe(1);
+    } finally {
+      await engine.destroy();
+    }
+  });
+
+  test("open({ kind: 'share' }) with a passphrase-protected grant", async () => {
+    await seedDocument('doc-open-share-pass');
+    const shareId = await createShare({
+      docId: 'doc-open-share-pass',
+      scope: ['doc.open'],
+      password: 'open-sesame',
+    });
+
+    const engine = createCloudEngine({
+      baseUrl: fx.baseUrl,
+      fetch: browserFetch('https://acme.com'),
+    });
+    try {
+      // Without the passphrase: an EngineError with the dedicated code —
+      // the prompt-and-retry signal — never a raw ShareExchangeError.
+      try {
+        await engine.open({ kind: 'share', shareToken: shareId });
+        expect.unreachable('share open without a passphrase must reject');
+      } catch (err) {
+        expect(err).toBeInstanceOf(EngineError);
+        expect(EngineError.is(err, EngineErrorCode.SharePasswordRequired)).toBe(true);
+        expect((err as EngineError).details).toMatchObject({
+          shareCode: 'SharePasswordRequired',
+        });
+      }
+
+      // With it: an ordinary handle.
+      const handle = await engine.open({
+        kind: 'share',
+        shareToken: shareId,
+        sharePassword: 'open-sesame',
+      });
+      expect(handle.id).toBe('doc-open-share-pass');
+    } finally {
+      await engine.destroy();
+    }
+  });
+
+  test("open({ kind: 'share' }) maps unknown grants to NotFound", async () => {
+    const engine = createCloudEngine({
+      baseUrl: fx.baseUrl,
+      fetch: browserFetch('https://acme.com'),
+    });
+    try {
+      try {
+        await engine.open({ kind: 'share', shareToken: `shr_${'B'.repeat(24)}` });
+        expect.unreachable('unknown share must reject');
+      } catch (err) {
+        expect(err).toBeInstanceOf(EngineError);
+        expect(EngineError.is(err, EngineErrorCode.NotFound)).toBe(true);
+      }
     } finally {
       await engine.destroy();
     }

--- a/cloudpdf/viewer/main/src/config.ts
+++ b/cloudpdf/viewer/main/src/config.ts
@@ -13,37 +13,26 @@
  */
 import {
   cloudEngine,
-  shareSessionSource,
   type CloudEngineOptions,
+  type OpenInputShare,
   type TokenSource,
 } from '@cloudpdf/engine';
 import type { EngineFactory, InitialDocument } from '@embedpdf/viewer/core';
 
 /**
- * The cloud-only document source: a public share token, resolved to a
- * self-renewing session at open time. This `kind` exists ONLY in the
- * cloud vocabulary — `resolveCloudConfig` lowers it to the open-source
- * viewer's ordinary `{ kind: 'token' }` before the kernel ever sees
- * it, so the engine-agnostic core never learns what a share is.
+ * @deprecated `{ kind: 'share' }` is a standard `OpenInput` kind now
+ * (`OpenInputShare` from `@cloudpdf/engine`), understood by
+ * `engine.open()` directly. Note the grant passphrase field is
+ * `sharePassword` (was `password` on the old viewer-only type).
  */
-export interface CloudShareSource {
-  kind: 'share';
-  /** Public share token (`shr_…`) from the dashboard's embed snippet. */
-  shareToken: string;
-  /** Passphrase for a protected share. */
-  password?: string;
-}
+export type CloudShareSource = OpenInputShare;
 
 /**
- * `InitialDocument`, cloud edition: every open-source `source` still
- * works, plus `{ kind: 'share' }`. Each entry is its own tab with its
- * own credential — mixing share tokens, doc JWTs, and ids in one
- * viewer is fully supported, and every share entry exchanges and
- * renews independently.
+ * @deprecated Cloud share sources are part of the standard `OpenInput`
+ * union, so the ordinary `InitialDocument` from `@embedpdf/viewer/core`
+ * already admits them. Use it directly.
  */
-export type CloudInitialDocument = Omit<InitialDocument, 'source'> & {
-  source: InitialDocument['source'] | CloudShareSource;
-};
+export type CloudInitialDocument = InitialDocument;
 
 /** The cloud connection, plus the document shorthands. */
 export interface CloudSource extends CloudEngineOptions {
@@ -54,20 +43,21 @@ export interface CloudSource extends CloudEngineOptions {
   docId?: string;
   /**
    * Sugar: open one document by its public share token (`shr_…`, from
-   * the dashboard's embed snippet). The token is exchanged for a
-   * short-lived session JWT and silently re-exchanged near expiry —
-   * revoking or editing the share on the server retargets every
-   * embedded copy at the next renewal. No backend required. For
-   * multiple documents, use `documents` with `{ kind: 'share' }`
-   * sources instead.
+   * the dashboard's embed snippet) — `open({ kind: 'share' })`. The
+   * engine exchanges it for a short-lived session JWT and silently
+   * re-exchanges near expiry — revoking or editing the share on the
+   * server retargets every embedded copy at the next renewal. No
+   * backend required. For multiple documents, use `documents` with
+   * `{ kind: 'share' }` sources instead.
    */
   shareToken?: string;
   /** Passphrase for a protected `shareToken`. */
   sharePassword?: string;
   /** Full control, exactly as the open-source viewer takes it — one tab per
-   *  entry, each with its own source, including cloud `{ kind: 'share' }`
-   *  entries. Wins over the `docToken`/`docId`/`shareToken` shorthands. */
-  documents?: CloudInitialDocument[];
+   *  entry, each with its own source, including `{ kind: 'share' }` entries
+   *  (a standard OpenInput kind the cloud engine resolves itself). Wins over
+   *  the `docToken`/`docId`/`shareToken` shorthands. */
+  documents?: InitialDocument[];
 }
 
 /**
@@ -81,6 +71,11 @@ export interface CloudSource extends CloudEngineOptions {
  *
  * The engine comes back as a THUNK, which is what gives the viewer ownership of
  * its lifetime: created on mount, destroyed on unmount.
+ *
+ * Document sources need no lowering here: `{ kind: 'share' }` is part of the
+ * standard `OpenInput` union and the cloud engine resolves it itself
+ * (exchange, renewal, revocation-at-renewal). This module only expands the
+ * one-document shorthands.
  *
  * The return type is deliberately INFERRED. The destructuring below is the only
  * statement of what this module consumes, so what passes through in `rest` and
@@ -104,41 +99,21 @@ export function resolveCloudConfig<T extends CloudSource>(options: T) {
 
   const engine: EngineFactory = () => cloudEngine({ baseUrl, token, sessionId, fetch: fetchFn });
 
-  // A share token becomes a self-renewing doc-token source: the
-  // exchanged JWT carries `doc_id`, so downstream this is exactly the
-  // `docToken` path — the transport re-invokes the source per request
-  // and picks up fresh sessions transparently.
-  const shareTokenSource = (token_: string, password?: string): TokenSource =>
-    shareSessionSource(baseUrl, token_, {
-      ...(password !== undefined ? { password } : {}),
-      ...(fetchFn ? { fetch: fetchFn } : {}),
-    });
-
-  // Lower cloud `{ kind: 'share' }` sources before the kernel sees the
-  // list: each entry gets its OWN exchanging source, so a multi-tab
-  // viewer mixes shares, doc JWTs, and ids freely and every share
-  // renews (and can be revoked) independently.
-  const lowerDocument = (doc: CloudInitialDocument): InitialDocument => {
-    // `OpenSource` includes a thunk variant, so narrow past functions
-    // before reading the discriminant.
-    if (typeof doc.source === 'function' || doc.source.kind !== 'share') {
-      return doc as InitialDocument;
-    }
-    const { shareToken: share, password } = doc.source;
-    return { ...doc, source: { kind: 'token', token: shareTokenSource(share, password) } };
-  };
-
-  const initialDocuments: InitialDocument[] = documents
-    ? documents.map(lowerDocument)
-    : [
-        ...(docToken !== undefined
-          ? [{ source: { kind: 'token' as const, token: docToken } }]
-          : []),
-        ...(shareToken !== undefined
-          ? [{ source: { kind: 'token' as const, token: shareTokenSource(shareToken, sharePassword) } }]
-          : []),
-        ...(docId !== undefined ? [{ source: { kind: 'id' as const, id: docId } }] : []),
-      ];
+  const initialDocuments: InitialDocument[] = documents ?? [
+    ...(docToken !== undefined ? [{ source: { kind: 'token' as const, token: docToken } }] : []),
+    ...(shareToken !== undefined
+      ? [
+          {
+            source: {
+              kind: 'share' as const,
+              shareToken,
+              ...(sharePassword !== undefined ? { sharePassword } : {}),
+            },
+          },
+        ]
+      : []),
+    ...(docId !== undefined ? [{ source: { kind: 'id' as const, id: docId } }] : []),
+  ];
 
   return { ...rest, engine, documents: initialDocuments };
 }

--- a/cloudpdf/viewer/main/src/index.ts
+++ b/cloudpdf/viewer/main/src/index.ts
@@ -39,8 +39,9 @@ export type { ShareSession, ShareExchangeOptions } from '@cloudpdf/engine';
 export { resolveCloudConfig } from './config';
 export type { CloudSource, CloudShareSource, CloudInitialDocument } from './config';
 
-// `documents` is omitted from the base so the CLOUD list type (which
-// additionally accepts `{ kind: 'share' }` sources) governs.
+// `documents` is omitted from the base so CloudSource's list (same
+// InitialDocument type — `{ kind: 'share' }` is a standard OpenInput
+// kind now) governs without a conflicting redeclaration.
 export interface CloudInitOptions
   extends Omit<InitOptions, 'engine' | 'src' | 'documents'>,
     CloudSource {}

--- a/cloudpdf/website/src/content/docs/engine/getting-started/authentication.mdx
+++ b/cloudpdf/website/src/content/docs/engine/getting-started/authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: Authentication
-description: How the cloud engine authenticates — doc-scoped JWTs, opening by token vs. by id, and why scope lives server-side.
+description: How the cloud engine authenticates — doc-scoped JWTs, public share tokens, opening by token vs. by id vs. by share, and why scope lives server-side.
 ---
 
 import { Callout } from '@/components/docs/callout';
@@ -31,16 +31,18 @@ const engine = createCloudEngine({
   can't be replayed against other documents.
 </Callout>
 
-## Two ways to open
+## Three ways to open
 
-The cloud engine accepts exactly two `OpenInput` shapes.
+The cloud engine accepts exactly three `OpenInput` shapes. Pick by where the
+credential comes from: your backend mints one (`token`), your frontend holds a
+tenant session (`id`), or there is no backend at all (`share`).
 
 ### Open by token
 
-Use this for share-link / embed UX, where the bearer is authorized for exactly
-one document. Pass a **doc-scoped JWT** whose `doc_id` claim identifies the
-document. Each `open({ kind: 'token' })` is independent — one engine can hold
-many handles, each carrying its own per-document token.
+Use this when your backend mints **doc-scoped JWTs** — for example a logged-in
+reviewer authorized for exactly one document. The token's `doc_id` claim
+identifies the document. Each `open({ kind: 'token' })` is independent — one
+engine can hold many handles, each carrying its own per-document token.
 
 ```ts
 const doc = await engine.open({
@@ -68,6 +70,33 @@ const doc = await engine.open({
 
 Without a per-open `token`, the engine uses the token supplied at construction.
 
+### Open by share token
+
+Use this for the no-backend embed flow: a **public share token** (`shr_…`) from
+the dashboard's embed snippet. A share token is a reference to a stored grant
+on the server, not a credential — the engine exchanges it for a short-lived
+doc-scoped session JWT and silently re-exchanges near expiry, so revoking or
+editing the share retargets every embedded copy at the next renewal.
+
+```ts
+const engine = createCloudEngine({ baseUrl: 'https://pdf.your-app.com' });
+const doc = await engine.open({
+  kind: 'share',
+  shareToken: 'shr_9f2k…',
+  sharePassword: 'open-sesame', // only for passphrase-protected grants
+});
+```
+
+`sharePassword` is the grant's passphrase, checked at the exchange; `password`
+remains the PDF's own encryption password, the same slot every other kind uses.
+A protected grant opened without its passphrase rejects with
+`EngineErrorCode.SharePasswordRequired` — prompt and retry.
+
+The exchange endpoint checks the browser's `Origin` header against the grant's
+allowlist, and the capabilities the handle gets are the ones the grant carries.
+For custom flows (pre-exchange to inspect a `docId`, hand-rolled prompts), the
+primitives `exchangeShareToken` and `shareSessionSource` remain exported.
+
 ## Scope and identity live on the server
 
 Authorization — what the caller may do (`doc.text.copy`, `doc.annotate.read`,
@@ -86,13 +115,14 @@ accept them as client options.
 
 ## Anonymous engines
 
-If every `open()` supplies its own doc-scoped token, the engine itself needs no
-credentials — omit `token` at construction. Requests then go out without an
-`Authorization` header until a per-open token is provided.
+If every `open()` supplies its own credential — a doc-scoped token or a public
+share token — the engine itself needs none: omit `token` at construction.
+Requests then go out without an `Authorization` header until a per-open
+credential is provided.
 
 ```ts
 const engine = createCloudEngine({ baseUrl: 'https://pdf.your-app.com' });
-const doc = await engine.open({ kind: 'token', token: shareLinkJwt });
+const doc = await engine.open({ kind: 'share', shareToken: 'shr_9f2k…' });
 ```
 
 ## What failures look like

--- a/cloudpdf/website/src/content/docs/engine/getting-started/index.mdx
+++ b/cloudpdf/website/src/content/docs/engine/getting-started/index.mdx
@@ -77,7 +77,7 @@ storage credentials or your tenant secret.
   />
   <Card
     title="Authentication"
-    description="Doc-scoped tokens, opening by token vs. by id."
+    description="Doc-scoped tokens, public share tokens, opening by token vs. by id vs. by share."
     href="/docs/engine/getting-started/authentication"
   />
   <Card

--- a/packages/engine/core/src/dto/OpenInput.ts
+++ b/packages/engine/core/src/dto/OpenInput.ts
@@ -85,9 +85,9 @@ export interface OpenInputById {
  * `GET /v1/docs/:docId/head`. The returned handle is bound to this
  * token; subsequent operations on it carry that bearer.
  *
- * Use this for share-link / embed-link UX where the bearer of the
- * token is authorised for exactly one document (e.g. a third-party
- * reviewer the customer has shared a single doc with).
+ * Use this when your backend mints doc-scoped JWTs itself (e.g. a
+ * logged-in reviewer authorised for exactly one document). For the
+ * no-backend public-share flow, use `kind: 'share'` instead.
  *
  * Rejected by `@embedpdf/engine`.
  */
@@ -103,7 +103,37 @@ export interface OpenInputToken {
   password?: string | null;
 }
 
-export type OpenInput = OpenInputBytes | OpenInputLayerBytes | OpenInputById | OpenInputToken;
+/**
+ * Cloud-engine: open via a public share token (`shr_…`) from the
+ * dashboard's embed snippet. A share token is a REFERENCE to a
+ * stored grant on the server, not a credential — the engine
+ * exchanges it for a short-lived doc-scoped session JWT and
+ * silently re-exchanges near expiry, so revoking or editing the
+ * share retargets every embedded copy at the next renewal. No
+ * backend required; the engine itself may be constructed with no
+ * engine-level token at all.
+ *
+ * Rejected by `@embedpdf/engine`.
+ */
+export interface OpenInputShare {
+  kind: 'share';
+  /** Public share token (`shr_…`) identifying the grant. */
+  shareToken: string;
+  /**
+   * Passphrase for a protected grant. This is the SHARE passphrase,
+   * checked by the exchange endpoint — not the PDF's encryption
+   * password, which stays in `password` like every other kind.
+   */
+  sharePassword?: string;
+  password?: string | null;
+}
+
+export type OpenInput =
+  | OpenInputBytes
+  | OpenInputLayerBytes
+  | OpenInputById
+  | OpenInputToken
+  | OpenInputShare;
 
 export interface OpenOptions {
   password?: string | null;

--- a/packages/engine/core/src/errors/EngineErrorCode.ts
+++ b/packages/engine/core/src/errors/EngineErrorCode.ts
@@ -5,6 +5,14 @@ export const EngineErrorCode = {
   DocOpenFailed: 'DocOpenFailed',
   DocPasswordRequired: 'DocPasswordRequired',
   DocPasswordIncorrect: 'DocPasswordIncorrect',
+  /**
+   * A share-token exchange (`open({ kind: 'share' })`) needs the grant's
+   * passphrase: none was supplied, or the supplied one was rejected —
+   * indistinguishable by design, mirroring the server. Prompt and retry
+   * with `sharePassword`. Distinct from `DocPasswordRequired`, which is
+   * about the PDF's own encryption password.
+   */
+  SharePasswordRequired: 'SharePasswordRequired',
   Aborted: 'Aborted',
   Network: 'Network',
   Unauthenticated: 'Unauthenticated',

--- a/packages/engine/core/src/shared.ts
+++ b/packages/engine/core/src/shared.ts
@@ -14,6 +14,7 @@ export type {
   OpenInputLayerSource,
   OpenInputById,
   OpenInputToken,
+  OpenInputShare,
   OpenOptions,
   TokenSource,
 } from './dto/OpenInput';

--- a/website/src/content/docs/engine/getting-started.mdx
+++ b/website/src/content/docs/engine/getting-started.mdx
@@ -82,7 +82,8 @@ const engine = cloudEngine({ baseUrl: 'https://pdf.example.com', token });
 Two deliberate differences surface the split:
 
 - **What `open()` accepts.** Local opens `{ kind: 'bytes' }`; cloud opens
-  `{ kind: 'id' }` / `{ kind: 'token' }`, addressing server-side documents.
+  `{ kind: 'id' }` / `{ kind: 'token' }` / `{ kind: 'share' }`, addressing
+  server-side documents by id, doc-scoped JWT, or public share token.
 - **Fonts.** `cloudEngine()` has no `fallbackFonts` option — fallback fonts are
   a server policy on the cloud (`engine.fonts` is undefined there).
 


### PR DESCRIPTION
Introduce OpenInputShare and add engine-level support for opening public share tokens. CloudEngine now exchanges shr_… tokens via its own transport and maps ShareExchangeError into EngineError (including new EngineErrorCode.SharePasswordRequired). shareSessionSource return type clarified; HttpClient exposes baseUrl and fetchImpl. Viewer no longer lowers share sources (shares pass through to the engine). Tests and docs updated, plus accompanying changeset files.