### PR TITLE
Preserve CORS headers on hijacked SSE responses

### DIFF
--- a/.changeset/cloudpdf-server-sse-cors.md
+++ b/.changeset/cloudpdf-server-sse-cors.md
@@ -1,0 +1,5 @@
+---
+'@cloudpdf/server': patch
+---
+
+Preserves configured CORS response headers on the hijacked server-sent events stream, allowing browser clients on permitted origins to subscribe to document layer events.

--- a/cloudpdf/server/src/routes/events.ts
+++ b/cloudpdf/server/src/routes/events.ts
@@ -70,8 +70,15 @@ export async function registerEventsRoutes(
     const head = await layerAuditHead(opts.db, ctx.tenantId, docId, layerName);
     const requested = parseLastEventId(req);
 
+    // CORS (and any other Fastify hook) has queued its response headers on
+    // the reply. Hijacking bypasses Fastify's normal send path, so preserve
+    // those headers explicitly when switching to the raw SSE response.
+    const headers = reply.getHeaders();
     reply.hijack();
     const raw = reply.raw;
+    for (const [name, value] of Object.entries(headers)) {
+      if (value !== undefined) raw.setHeader(name, value);
+    }
     raw.writeHead(200, {
       'content-type': 'text/event-stream',
       'cache-control': 'no-cache, no-transform',

--- a/cloudpdf/server/test/events-sse.test.ts
+++ b/cloudpdf/server/test/events-sse.test.ts
@@ -166,6 +166,31 @@ describe('GET /events — the SSE half of the document event stream', () => {
     await sse.close();
   });
 
+  test('the hijacked SSE response preserves wildcard CORS headers', async () => {
+    const tenantId = 'tenant-sse';
+    const docId = 'docssecors';
+    const layerName = 'alice';
+    const origin = 'https://customer.example';
+    await seedDocument(fx, tenantId, docId, { pageCount: 1 });
+
+    const abort = new AbortController();
+    try {
+      const res = await fetch(`${fx.baseUrl}/v1/docs/${docId}/layers/${layerName}/events`, {
+        headers: {
+          Authorization: `Bearer ${docToken(tenantId, docId, layerName)}`,
+          Accept: 'text/event-stream',
+          Origin: origin,
+        },
+        signal: abort.signal,
+      });
+      expect(res.status).toBe(200);
+      expect(res.headers.get('access-control-allow-origin')).toBe(origin);
+      expect(res.headers.get('vary')).toContain('Origin');
+    } finally {
+      abort.abort();
+    }
+  });
+
   test('Last-Event-ID resumes exactly: only rows past the cursor are replayed', async () => {
     const tenantId = 'tenant-sse';
     const docId = 'docsse002';
@@ -332,6 +357,7 @@ async function buildFixture(): Promise<Fixture> {
   const bundle = await buildAppForTesting({
     licenseGate: createValidTestLicenseGate(),
     verifier: { mode: 'hs256', secret: SECRET },
+    corsOrigins: '*',
     workerEntry: STUB_ENTRY,
     poolSize: 1,
     db,


### PR DESCRIPTION
When hijacking Fastify replies for server-sent events the normal hook path (including CORS) was bypassed. This change copies reply.getHeaders() onto the raw response before switching to the SSE stream, ensuring configured CORS (and other) headers are preserved. Adds a test that asserts Access-Control-Allow-Origin/Vary are present for SSE responses and enables corsOrigins='*' in the test fixture. Also adds a changeset noting the patch.