### PR TITLE
Trust Keygen signed validation in EXPIRING window

### DIFF
--- a/.changeset/keygen-expiring-cloudpdf-server.md
+++ b/.changeset/keygen-expiring-cloudpdf-server.md
@@ -1,0 +1,5 @@
+---
+'@cloudpdf/server': patch
+---
+
+Keep connected licenses usable during Keygen's three-day `EXPIRING` window by relying on the signed validation decision instead of the informational status label. Licenses whose expiry has elapsed remain denied.

--- a/cloudpdf/server/src/licensing/connected-client.ts
+++ b/cloudpdf/server/src/licensing/connected-client.ts
@@ -212,10 +212,12 @@ function parseValidation(input: {
   if (code !== 'VALID') {
     throw invalidResponse(`Keygen returned valid=true with the unexpected code ${code}`);
   }
-  const status = asString(attributes['status'], 'license status').toUpperCase();
-  if (status !== 'ACTIVE') {
-    throw invalidResponse(`Keygen returned a ${status.toLowerCase()} license`);
-  }
+  // Keygen's resource status is informational, not a validation decision.
+  // In particular, a valid license becomes EXPIRING during its final 3 days,
+  // and an INACTIVE license may still validate successfully. Keep requiring a
+  // well-formed status attribute, but trust the signed validation decision in
+  // meta.valid/meta.code instead of treating ACTIVE as the only valid status.
+  asString(attributes['status'], 'license status');
   if (expiresAt !== null && new Date(expiresAt).getTime() <= input.validatedAt) {
     throw invalidResponse('Keygen returned valid=true for an expired license');
   }

--- a/cloudpdf/server/test/licensing.test.ts
+++ b/cloudpdf/server/test/licensing.test.ts
@@ -81,19 +81,21 @@ function machineCertificate(input: {
 
 function keygenValidationBody(input: {
   code: string;
+  expiry?: string;
   fingerprint: string;
   key: string;
   metadata?: Record<string, unknown>;
   nonce: number;
+  status?: string;
   valid: boolean;
 }): Record<string, unknown> {
   return {
     data: {
       attributes: {
-        expiry: '2029-02-01T00:00:00.000Z',
+        expiry: input.expiry ?? '2029-02-01T00:00:00.000Z',
         key: input.key,
         metadata: { offlineGraceHours: 72, ...input.metadata },
-        status: 'ACTIVE',
+        status: input.status ?? 'ACTIVE',
       },
       id: 'license-id',
       relationships: {
@@ -299,6 +301,79 @@ test('connected validation activates a deployment and then revalidates', async (
       }),
     }),
   );
+});
+
+test.each(['EXPIRING', 'INACTIVE'])(
+  'connected validation accepts a signed valid license with informational status %s',
+  async (status) => {
+    const { identity, privateKey } = createSigningIdentity();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        const requestBody = JSON.parse(String(init?.body)) as {
+          meta: { key: string; nonce: number; scope: { fingerprint: string } };
+        };
+        return signedKeygenResponse({
+          body: keygenValidationBody({
+            code: 'VALID',
+            fingerprint: requestBody.meta.scope.fingerprint,
+            key: requestBody.meta.key,
+            nonce: requestBody.meta.nonce,
+            status,
+            valid: true,
+          }),
+          identity,
+          privateKey,
+          url,
+        });
+      }),
+    );
+
+    await expect(
+      validateConnectedLicense({
+        fingerprint: 'deployment-fingerprint',
+        identity,
+        key: 'license-key',
+      }),
+    ).resolves.toMatchObject({ code: 'VALID', valid: true });
+  },
+);
+
+test('connected validation rejects a signed valid decision whose expiry has passed', async () => {
+  const { identity, privateKey } = createSigningIdentity();
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const requestBody = JSON.parse(String(init?.body)) as {
+        meta: { key: string; nonce: number; scope: { fingerprint: string } };
+      };
+      return signedKeygenResponse({
+        body: keygenValidationBody({
+          code: 'VALID',
+          expiry: '2020-01-01T00:00:00.000Z',
+          fingerprint: requestBody.meta.scope.fingerprint,
+          key: requestBody.meta.key,
+          nonce: requestBody.meta.nonce,
+          valid: true,
+        }),
+        identity,
+        privateKey,
+        url,
+      });
+    }),
+  );
+
+  await expect(
+    validateConnectedLicense({
+      fingerprint: 'deployment-fingerprint',
+      identity,
+      key: 'license-key',
+    }),
+  ).rejects.toMatchObject({
+    code: 'INVALID_RESPONSE',
+    message: 'Keygen returned valid=true for an expired license',
+    retryable: false,
+  });
 });
 
 test('connected validation rejects an unsigned success response', async () => {


### PR DESCRIPTION
Stop treating Keygen's resource status as the validation decision. Require a well-formed status attribute but accept informational statuses (e.g., EXPIRING, INACTIVE) and rely on the signed meta.valid/meta.code instead. Still reject licenses whose expiry timestamp has passed. Tests updated to accept EXPIRING/INACTIVE statuses and to reject a signed valid decision when expiry is elapsed. Adds a changeset describing the patch.