### PR TITLE
Add charMap to DocText response

### DIFF
--- a/cloudpdf/contract/openapi.json
+++ b/cloudpdf/contract/openapi.json
@@ -6322,6 +6322,24 @@
           "charCount": {
             "type": "integer",
             "minimum": 0
+          },
+          "charMap": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "items": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "integer",
+                  "minimum": 0
+                }
+              ]
+            }
           }
         },
         "required": ["text", "charCount"],

--- a/cloudpdf/sdk/cloudpdf-generation.json
+++ b/cloudpdf/sdk/cloudpdf-generation.json
@@ -5,7 +5,7 @@
   "source": {
     "repository": "embedpdf/embed-pdf-viewer",
     "openapi": "cloudpdf/contract/openapi.json",
-    "openapiSha256": "901c23684e7c9e33b5248942779b13537764a1d9065db815dd8aedb592c5ec59",
+    "openapiSha256": "14d95eb6c82ffd3713e871104d85ed4c8532ddb898f3b8ba6aa2d15f4bd17fbc",
     "gitCommit": null,
     "gitCommitIsDirty": null
   },

--- a/cloudpdf/sdk/src/api/types/DocText200Response.ts
+++ b/cloudpdf/sdk/src/api/types/DocText200Response.ts
@@ -3,4 +3,5 @@
 export interface DocText200Response {
     text: string;
     charCount: number;
+    charMap?: unknown[][] | undefined;
 }

--- a/cloudpdf/sdk/tests/wire/doc.test.ts
+++ b/cloudpdf/sdk/tests/wire/doc.test.ts
@@ -135,7 +135,7 @@ describe("DocClient", () => {
         const server = mockServerPool.createServer();
         const client = new CloudPDFClient({ maxRetries: 0, token: "test", environment: server.baseUrl });
 
-        const rawResponseBody = { text: "text", charCount: 1 };
+        const rawResponseBody = { text: "text", charCount: 1, charMap: [[{ key: "value" }]] };
 
         server
             .mockEndpoint()

--- a/cloudpdf/website/src/generated/sdk-snippets.json
+++ b/cloudpdf/website/src/generated/sdk-snippets.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "canonicalVersion": "3.0.0-next.4",
-  "openapiSha256": "901c23684e7c9e33b5248942779b13537764a1d9065db815dd8aedb592c5ec59",
+  "openapiSha256": "14d95eb6c82ffd3713e871104d85ed4c8532ddb898f3b8ba6aa2d15f4bd17fbc",
   "languages": {
     "typescript": {
       "label": "TypeScript",


### PR DESCRIPTION
Add an optional charMap property to the document text response: OpenAPI schema defines charMap as an array of 2-item integer pairs. Update the generated SDK type (DocText200Response) to include optional charMap, and adjust the wire test to include charMap in the mock response. Also update openapiSha256 checksums in cloudpdf-generation.json and website sdk-snippets to match the updated OpenAPI contract.