### PR TITLE
Enhance API schema docs, examples, and SDK generation

### DIFF
--- a/cloudpdf/contract/openapi.json
+++ b/cloudpdf/contract/openapi.json
@@ -4107,7 +4107,8 @@
           },
           "dedupMode": {
             "type": "string",
-            "enum": ["always-create", "reuse-existing"]
+            "enum": ["always-create", "reuse-existing"],
+            "description": "always-create (default) creates a new document every time. reuse-existing returns a document that already holds the same content instead of storing it twice."
           },
           "docId": {
             "type": "string",
@@ -4510,11 +4511,13 @@
                   "url": {
                     "type": "string",
                     "format": "uri",
-                    "maxLength": 8192
+                    "maxLength": 8192,
+                    "description": "The URL to fetch. Must be allowed by the deployment import policy (scheme, network range, size) and must declare a length."
                   }
                 },
                 "required": ["kind", "url"],
-                "additionalProperties": false
+                "additionalProperties": false,
+                "description": "The caller supplies the authority: a presigned S3/GCS/Azure/R2/MinIO GET, or any HTTPS endpoint the deployment import policy allows. The URL is a capability — treat it as a secret. CloudPDF never echoes its query string back in errors, logs, or stored failure reasons."
               },
               {
                 "type": "object",
@@ -4526,47 +4529,57 @@
                   "connectionId": {
                     "type": "string",
                     "minLength": 1,
-                    "maxLength": 128
+                    "maxLength": 128,
+                    "description": "The operator-registered storage connection to read from."
                   },
                   "key": {
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 1,
+                    "description": "The object key to read, inside the connection's configured scope. At most 1024 UTF-8 bytes."
                   },
                   "revision": {
                     "type": "string",
                     "minLength": 1,
-                    "maxLength": 1024
+                    "maxLength": 1024,
+                    "description": "Pins a specific version of the object. Provider-interpreted (S3 VersionId, GCS generation, Azure version id); providers without versioning reject it."
                   }
                 },
                 "required": ["kind", "connectionId", "key"],
-                "additionalProperties": false
+                "additionalProperties": false,
+                "description": "The operator pre-registered the authority: the request names a connection and a key inside it. Which provider backs the connection (S3, GCS, Azure Blob, filesystem, ...) is deployment configuration, never wire surface."
               }
-            ]
+            ],
+            "description": "Where CloudPDF pulls the bytes from. The two shapes differ in WHO supplies the authority to read, not in which storage vendor holds the file."
           },
           "expected": {
             "type": "object",
             "properties": {
               "sizeBytes": {
                 "type": "integer",
-                "minimum": 1
+                "minimum": 1,
+                "description": "Checked against the source's declared Content-Length before the transfer."
               },
               "sha256": {
                 "type": "string",
-                "pattern": "^[0-9a-f]{64}$"
+                "pattern": "^[0-9a-f]{64}$",
+                "description": "Checked against the server-observed digest after the transfer. Required when dedupMode is reuse-existing."
               }
             },
-            "additionalProperties": false
+            "additionalProperties": false,
+            "description": "Integrity pins, enforced when present. When absent, the server-observed values become authoritative."
           },
           "metadata": {
             "type": "object",
             "additionalProperties": {}
           },
           "idempotencyKey": {
-            "type": "string"
+            "type": "string",
+            "description": "Retrying with the same key resumes the same document rather than importing a second copy — including after a 502."
           },
           "dedupMode": {
             "type": "string",
-            "enum": ["always-create", "reuse-existing"]
+            "enum": ["always-create", "reuse-existing"],
+            "description": "always-create (default) creates a new document every time. reuse-existing returns a document that already holds the same content instead of storing it twice."
           },
           "docId": {
             "type": "string",
@@ -4574,7 +4587,8 @@
           },
           "mode": {
             "type": "string",
-            "enum": ["sync", "async"]
+            "enum": ["sync", "async"],
+            "description": "sync (default) holds the response open for the whole transfer. async answers 202 with the document pending and transfers in the background; it requires a connection source, and filesystem connections additionally require expected.sha256."
           }
         },
         "required": ["source"],

--- a/cloudpdf/contract/src/index.ts
+++ b/cloudpdf/contract/src/index.ts
@@ -86,7 +86,11 @@ export const adminWirePaths = {
   deploymentLicenseStatus: '/v1/deployment/license/status',
 } as const;
 
-export const DedupModeSchema = z.enum(['always-create', 'reuse-existing']);
+export const DedupModeSchema = z
+  .enum(['always-create', 'reuse-existing'])
+  .describe(
+    'always-create (default) creates a new document every time. reuse-existing returns a document that already holds the same content instead of storing it twice.',
+  );
 export type DedupMode = z.infer<typeof DedupModeSchema>;
 
 export const UploadPreferenceSchema = z.enum(['auto', 'presigned', 'proxy']);
@@ -198,22 +202,54 @@ const utf8ByteLength = (s: string): number => new TextEncoder().encode(s).length
  * no NUL); provider-exact rules live in the server's source adapters,
  * which know which backend a connection names.
  */
-export const AdminImportSourceSchema = z.discriminatedUnion('kind', [
-  z.object({
-    kind: z.literal('url'),
-    url: z.string().url().max(8192),
-  }),
-  z.object({
-    kind: z.literal('connection'),
-    connectionId: z.string().min(1).max(128),
-    key: z
-      .string()
-      .min(1)
-      .refine((k) => !k.includes('\0'), 'key must not contain NUL')
-      .refine((k) => utf8ByteLength(k) <= 1024, 'key must be at most 1024 UTF-8 bytes'),
-    revision: z.string().min(1).max(1024).optional(),
-  }),
-]);
+export const AdminImportSourceSchema = z
+  .discriminatedUnion('kind', [
+    z
+      .object({
+        kind: z.literal('url'),
+        url: z
+          .string()
+          .url()
+          .max(8192)
+          .describe(
+            'The URL to fetch. Must be allowed by the deployment import policy (scheme, network range, size) and must declare a length.',
+          ),
+      })
+      .describe(
+        'The caller supplies the authority: a presigned S3/GCS/Azure/R2/MinIO GET, or any HTTPS endpoint the deployment import policy allows. The URL is a capability — treat it as a secret. CloudPDF never echoes its query string back in errors, logs, or stored failure reasons.',
+      ),
+    z
+      .object({
+        kind: z.literal('connection'),
+        connectionId: z
+          .string()
+          .min(1)
+          .max(128)
+          .describe('The operator-registered storage connection to read from.'),
+        key: z
+          .string()
+          .min(1)
+          .refine((k) => !k.includes('\0'), 'key must not contain NUL')
+          .refine((k) => utf8ByteLength(k) <= 1024, 'key must be at most 1024 UTF-8 bytes')
+          .describe(
+            "The object key to read, inside the connection's configured scope. At most 1024 UTF-8 bytes.",
+          ),
+        revision: z
+          .string()
+          .min(1)
+          .max(1024)
+          .optional()
+          .describe(
+            'Pins a specific version of the object. Provider-interpreted (S3 VersionId, GCS generation, Azure version id); providers without versioning reject it.',
+          ),
+      })
+      .describe(
+        'The operator pre-registered the authority: the request names a connection and a key inside it. Which provider backs the connection (S3, GCS, Azure Blob, filesystem, ...) is deployment configuration, never wire surface.',
+      ),
+  ])
+  .describe(
+    'Where CloudPDF pulls the bytes from. The two shapes differ in WHO supplies the authority to read, not in which storage vendor holds the file.',
+  );
 export type AdminImportSource = z.infer<typeof AdminImportSourceSchema>;
 
 export const AdminDocumentImportRequestSchema = z.object({
@@ -228,12 +264,31 @@ export const AdminDocumentImportRequestSchema = z.object({
    */
   expected: z
     .object({
-      sizeBytes: z.number().int().min(1).optional(),
-      sha256: z.string().regex(sha256Hex).optional(),
+      sizeBytes: z
+        .number()
+        .int()
+        .min(1)
+        .optional()
+        .describe("Checked against the source's declared Content-Length before the transfer."),
+      sha256: z
+        .string()
+        .regex(sha256Hex)
+        .optional()
+        .describe(
+          'Checked against the server-observed digest after the transfer. Required when dedupMode is reuse-existing.',
+        ),
     })
-    .optional(),
+    .optional()
+    .describe(
+      'Integrity pins, enforced when present. When absent, the server-observed values become authoritative.',
+    ),
   metadata: z.record(z.string(), z.unknown()).optional(),
-  idempotencyKey: z.string().optional(),
+  idempotencyKey: z
+    .string()
+    .optional()
+    .describe(
+      'Retrying with the same key resumes the same document rather than importing a second copy — including after a 502.',
+    ),
   dedupMode: DedupModeSchema.optional(),
   docId: z.string().regex(docIdPattern).optional(),
   /**
@@ -245,7 +300,12 @@ export const AdminDocumentImportRequestSchema = z.object({
    * additionally require `expected.sha256`, since they have no
    * revisions to pin retries to.
    */
-  mode: z.enum(['sync', 'async']).optional(),
+  mode: z
+    .enum(['sync', 'async'])
+    .optional()
+    .describe(
+      'sync (default) holds the response open for the whole transfer. async answers 202 with the document pending and transfers in the background; it requires a connection source, and filesystem connections additionally require expected.sha256.',
+    ),
 });
 export type AdminDocumentImportRequest = z.infer<typeof AdminDocumentImportRequestSchema>;
 

--- a/cloudpdf/sdk/cloudpdf-generation.json
+++ b/cloudpdf/sdk/cloudpdf-generation.json
@@ -5,7 +5,7 @@
   "source": {
     "repository": "embedpdf/embed-pdf-viewer",
     "openapi": "cloudpdf/contract/openapi.json",
-    "openapiSha256": "b3e236a932673e27e05825352e1bc3675369d7505040bf7d7760e542aae8d38d",
+    "openapiSha256": "c28c603bef65753b06ef5668f5abee8ba584af687cdff5dcaedda864c699fc13",
     "gitCommit": null,
     "gitCommitIsDirty": null
   },

--- a/cloudpdf/sdk/src/api/resources/documents/client/requests/DocumentsImportFromRequest.ts
+++ b/cloudpdf/sdk/src/api/resources/documents/client/requests/DocumentsImportFromRequest.ts
@@ -14,26 +14,38 @@ import type * as CloudPDF from "../../../../index.js";
  */
 export interface DocumentsImportFromRequest {
     tenantId: string;
+    /** Where CloudPDF pulls the bytes from. The two shapes differ in WHO supplies the authority to read, not in which storage vendor holds the file. */
     source: CloudPDF.DocumentsImportFromRequestSource;
+    /** Integrity pins, enforced when present. When absent, the server-observed values become authoritative. */
     expected?: DocumentsImportFromRequest.Expected;
     metadata?: Record<string, unknown>;
+    /** Retrying with the same key resumes the same document rather than importing a second copy — including after a 502. */
     idempotencyKey?: string;
+    /** always-create (default) creates a new document every time. reuse-existing returns a document that already holds the same content instead of storing it twice. */
     dedupMode?: DocumentsImportFromRequest.DedupMode;
     docId?: string;
+    /** sync (default) holds the response open for the whole transfer. async answers 202 with the document pending and transfers in the background; it requires a connection source, and filesystem connections additionally require expected.sha256. */
     mode?: DocumentsImportFromRequest.Mode;
 }
 
 export namespace DocumentsImportFromRequest {
+    /**
+     * Integrity pins, enforced when present. When absent, the server-observed values become authoritative.
+     */
     export interface Expected {
+        /** Checked against the source's declared Content-Length before the transfer. */
         sizeBytes?: number | undefined;
+        /** Checked against the server-observed digest after the transfer. Required when dedupMode is reuse-existing. */
         sha256?: string | undefined;
     }
 
+    /** always-create (default) creates a new document every time. reuse-existing returns a document that already holds the same content instead of storing it twice. */
     export const DedupMode = {
         AlwaysCreate: "always-create",
         ReuseExisting: "reuse-existing",
     } as const;
     export type DedupMode = (typeof DedupMode)[keyof typeof DedupMode];
+    /** sync (default) holds the response open for the whole transfer. async answers 202 with the document pending and transfers in the background; it requires a connection source, and filesystem connections additionally require expected.sha256. */
     export const Mode = {
         Sync: "sync",
         Async: "async",

--- a/cloudpdf/sdk/src/api/resources/documents/client/requests/DocumentsInitRequest.ts
+++ b/cloudpdf/sdk/src/api/resources/documents/client/requests/DocumentsInitRequest.ts
@@ -14,6 +14,7 @@ export interface DocumentsInitRequest {
     contentSha256: string;
     metadata?: Record<string, unknown>;
     idempotencyKey?: string;
+    /** always-create (default) creates a new document every time. reuse-existing returns a document that already holds the same content instead of storing it twice. */
     dedupMode?: DocumentsInitRequest.DedupMode;
     docId?: string;
     uploadTtlSec?: number;
@@ -21,6 +22,7 @@ export interface DocumentsInitRequest {
 }
 
 export namespace DocumentsInitRequest {
+    /** always-create (default) creates a new document every time. reuse-existing returns a document that already holds the same content instead of storing it twice. */
     export const DedupMode = {
         AlwaysCreate: "always-create",
         ReuseExisting: "reuse-existing",

--- a/cloudpdf/sdk/src/api/resources/documents/types/DocumentsImportFromRequestSource.ts
+++ b/cloudpdf/sdk/src/api/resources/documents/types/DocumentsImportFromRequestSource.ts
@@ -2,20 +2,31 @@
 
 import type * as CloudPDF from "../../../index.js";
 
+/**
+ * Where CloudPDF pulls the bytes from. The two shapes differ in WHO supplies the authority to read, not in which storage vendor holds the file.
+ */
 export type DocumentsImportFromRequestSource =
+    /**
+     * The caller supplies the authority: a presigned S3/GCS/Azure/R2/MinIO GET, or any HTTPS endpoint the deployment import policy allows. The URL is a capability — treat it as a secret. CloudPDF never echoes its query string back in errors, logs, or stored failure reasons. */
     | CloudPDF.DocumentsImportFromRequestSource.Url
+    /**
+     * The operator pre-registered the authority: the request names a connection and a key inside it. Which provider backs the connection (S3, GCS, Azure Blob, filesystem, ...) is deployment configuration, never wire surface. */
     | CloudPDF.DocumentsImportFromRequestSource.Connection;
 
 export namespace DocumentsImportFromRequestSource {
     export interface Url {
         kind: "url";
+        /** The URL to fetch. Must be allowed by the deployment import policy (scheme, network range, size) and must declare a length. */
         url: string;
     }
 
     export interface Connection {
         kind: "connection";
+        /** The operator-registered storage connection to read from. */
         connectionId: string;
+        /** The object key to read, inside the connection's configured scope. At most 1024 UTF-8 bytes. */
         key: string;
+        /** Pins a specific version of the object. Provider-interpreted (S3 VersionId, GCS generation, Azure version id); providers without versioning reject it. */
         revision?: string | undefined;
     }
 }

--- a/cloudpdf/website/scripts/check-api-reference.mjs
+++ b/cloudpdf/website/scripts/check-api-reference.mjs
@@ -41,6 +41,8 @@ for (const operationId of Object.keys(manifest.operations ?? {})) {
     failures.push(`Unknown snippet operation: ${operationId}`);
 }
 
+failures.push(...unrenderableSchemas(openapi));
+
 if (failures.length) {
   console.error(
     `API reference manifest validation failed:\n${failures.map((value) => `- ${value}`).join('\n')}`,
@@ -54,3 +56,144 @@ if (failures.length) {
 console.log(
   `API reference manifest is valid (${operations.length} operations × ${LANGUAGE_NAMES.length} SDKs).`,
 );
+
+console.log(
+  'Every documented schema renders: refs resolve, unions are labelled, objects have fields.',
+);
+
+/**
+ * The reference renders whatever the contract emits, so a schema the page
+ * cannot show becomes a silent hole rather than a build failure — `source`
+ * shipped as `object | object` with nothing under it. These are the three
+ * shapes that produce a dead end, checked here as a property of the
+ * CONTRACT so that a new one fails the build instead of the reader:
+ *
+ *   - a `$ref` that resolves to nothing;
+ *   - a union of objects with no property pinned to a distinct literal in
+ *     every branch, leaving the variants nameable only as "Option 1";
+ *   - an object with no properties, no union, and no `additionalProperties`,
+ *     which renders as the bare word `object`.
+ *
+ * The resolver mirrors src/lib/api-reference.ts — deliberately a second
+ * implementation, so this asserts the contract rather than the renderer.
+ */
+function unrenderableSchemas(document) {
+  const problems = [];
+  const visited = new Set();
+
+  const resolve = (schema) => {
+    if (!schema?.$ref) return schema;
+    if (!schema.$ref.startsWith('#/')) return undefined;
+    let node = document;
+    for (const segment of schema.$ref.slice(2).split('/')) {
+      const key = segment.replaceAll('~1', '/').replaceAll('~0', '~');
+      node = Array.isArray(node) ? node[Number(key)] : node?.[key];
+      if (node === undefined) return undefined;
+    }
+    return node;
+  };
+
+  const literalOf = (schema) => {
+    if (schema?.const !== undefined) return String(schema.const);
+    if (Array.isArray(schema?.enum) && schema.enum.length === 1) return String(schema.enum[0]);
+    return undefined;
+  };
+
+  /** Mirrors unionDiscriminator(): one property, a distinct literal per branch. */
+  const isLabelled = (variants) => {
+    const pinned = variants.map((variant) => {
+      const properties = resolve(variant)?.properties ?? {};
+      return new Map(
+        Object.entries(properties).flatMap(([name, property]) => {
+          const literal = literalOf(property);
+          return literal === undefined ? [] : [[name, literal]];
+        }),
+      );
+    });
+    return [...pinned[0].keys()].some((property) => {
+      if (!pinned.every((branch) => branch.has(property))) return false;
+      const values = pinned.map((branch) => branch.get(property));
+      return new Set(values).size === values.length;
+    });
+  };
+
+  const walk = (schema, where) => {
+    if (!schema || typeof schema !== 'object') return;
+
+    if (schema.$ref) {
+      const target = resolve(schema);
+      if (!target) {
+        problems.push(`${where}: $ref does not resolve (${schema.$ref})`);
+        return;
+      }
+      if (visited.has(schema.$ref)) return;
+      visited.add(schema.$ref);
+      walk(target, where);
+      return;
+    }
+
+    const variants = schema.oneOf ?? schema.anyOf;
+    if (variants) {
+      const structured = variants.filter((variant) => resolve(variant)?.properties);
+      if (structured.length > 1 && !isLabelled(variants)) {
+        problems.push(
+          `${where}: union of ${variants.length} object variants has no discriminating literal ` +
+            `- the reference can only label them "Option 1", "Option 2", ...`,
+        );
+      }
+      variants.forEach((variant, index) => walk(variant, `${where}/${index}`));
+      return;
+    }
+
+    if (schema.allOf) {
+      schema.allOf.forEach((member, index) => walk(member, `${where}&${index}`));
+      return;
+    }
+
+    if (Array.isArray(schema.items)) {
+      schema.items.forEach((item, index) => walk(item, `${where}[${index}]`));
+      return;
+    }
+    if (schema.items) {
+      walk(schema.items, `${where}[]`);
+      return;
+    }
+
+    if (schema.properties) {
+      for (const [name, property] of Object.entries(schema.properties)) {
+        walk(property, `${where}.${name}`);
+      }
+      return;
+    }
+
+    // An open schema (`z.unknown()`, or the recursion back-edge the emitter
+    // substitutes for a self-reference) is honest surface: it renders as
+    // `unknown` and promises nothing. An object that declares itself an
+    // object and then carries nothing is the dead end.
+    const valueMap =
+      schema.additionalProperties !== undefined && schema.additionalProperties !== false;
+    if (schema.type === 'object' && !valueMap) {
+      problems.push(`${where}: renders as a bare "object" - no properties, union, or value map`);
+    }
+  };
+
+  for (const [path, pathItem] of Object.entries(document.paths ?? {})) {
+    for (const [method, operation] of Object.entries(pathItem)) {
+      if (!operation?.operationId) continue;
+      const at = `${operation.operationId} (${method.toUpperCase()} ${path})`;
+      for (const parameter of operation.parameters ?? []) {
+        walk(parameter.schema, `${at} parameter ${parameter.name}`);
+      }
+      for (const [type, media] of Object.entries(operation.requestBody?.content ?? {})) {
+        walk(media.schema, `${at} request ${type}`);
+      }
+      for (const [status, response] of Object.entries(operation.responses ?? {})) {
+        for (const [type, media] of Object.entries(response.content ?? {})) {
+          walk(media.schema, `${at} ${status} ${type}`);
+        }
+      }
+    }
+  }
+
+  return problems;
+}

--- a/cloudpdf/website/src/components/docs/api-reference.tsx
+++ b/cloudpdf/website/src/components/docs/api-reference.tsx
@@ -9,8 +9,14 @@ import {
   getSdkLanguages,
   getSecurityScheme,
   isOperatorOnly,
-  resolveSchema,
+  exampleRequestBody,
+  requestBodyChoice,
+  schemaFields,
   schemaType,
+  unionDiscriminator,
+  unionVariants,
+  unwrapSchema,
+  variantLabels,
   type ApiParameter,
   type JsonSchema,
 } from '@/lib/api-reference';
@@ -18,10 +24,11 @@ import {
 import { Heading } from './heading';
 import { methodStyle } from './method-badge';
 import { Tabs } from './tabs';
+import { VariantTabs } from './variant-tabs';
 
 const highlighterPromise = createHighlighter({
   themes: ['material-theme-palenight'],
-  langs: ['typescript', 'python', 'php', 'csharp', 'go', 'java', 'ruby'],
+  langs: ['typescript', 'python', 'php', 'csharp', 'go', 'java', 'ruby', 'json'],
 });
 
 const STATUS_STYLES: Record<string, string> = {
@@ -212,6 +219,7 @@ export async function ApiOperation({ operationId }: { operationId: string }) {
               </div>
             ))}
           </div>
+          <RequestBodyExample operation={operation} />
         </Section>
       ) : null}
 
@@ -220,6 +228,7 @@ export async function ApiOperation({ operationId }: { operationId: string }) {
           The selected SDK is remembered across the API reference. Values are examples; replace them
           with identifiers and input from your application.
         </p>
+        <SdkChoiceNote operation={operation} operationId={operationId} />
         <ApiSnippet operationId={operationId} />
       </Section>
 
@@ -259,6 +268,91 @@ export async function ApiOperation({ operationId }: { operationId: string }) {
         </div>
       </Section>
     </>
+  );
+}
+
+/**
+ * The body a caller actually sends, one tab per shape when the body offers
+ * a choice. Derived from the schema, so it cannot drift from the field list
+ * above it — and it is the one place the reference spells out the union
+ * branch the generated SDK example did not take.
+ */
+async function RequestBodyExample({ operation }: { operation: Operation }) {
+  const choice = requestBodyChoice(operation);
+  const examples = choice
+    ? choice.variants.map((variant, index) => ({
+        label: choice.labels[index],
+        json: exampleRequestBody(operation, { property: choice.property, variant }),
+      }))
+    : [{ label: 'application/json', json: exampleRequestBody(operation) }];
+  // Binary and scalar bodies have nothing to spell out.
+  if (examples.every((example) => ['', '{}', 'null'].includes(example.json))) return null;
+
+  const highlighter = await highlighterPromise;
+  const blocks = examples.map((example) => ({
+    ...example,
+    html: highlighter.codeToHtml(example.json, { lang: 'json', theme: 'material-theme-palenight' }),
+  }));
+
+  return (
+    <>
+      <p className={HINT}>
+        {choice
+          ? 'A complete body for each shape. Strings stand in for your own values.'
+          : 'A complete body with every required field. Strings stand in for your own values.'}
+      </p>
+      <Tabs items={blocks.map((block) => block.label)}>
+        {blocks.map((block) => (
+          <div
+            key={block.label}
+            className={SNIPPET_PANEL}
+            dangerouslySetInnerHTML={{ __html: block.html }}
+          />
+        ))}
+      </Tabs>
+    </>
+  );
+}
+
+/**
+ * Fern generates one example per operation and takes the first branch of
+ * any union in the body, so an operation whose body offers a choice ships
+ * an example that silently shows one side of it. Say which side — but only
+ * after confirming the generated snippet really took that branch.
+ */
+function SdkChoiceNote({ operation, operationId }: { operation: Operation; operationId: string }) {
+  const choice = requestBodyChoice(operation);
+  if (!choice) return null;
+
+  const [shown, ...rest] = choice.labels;
+  const source = getOperationSnippets(operationId).find(
+    (snippet) => snippet.language === 'typescript',
+  )?.source;
+  if (!source?.includes(`"${shown}"`)) return null;
+
+  return (
+    <p className={HINT}>
+      This body offers a choice, and the example takes one branch: it sends{' '}
+      {choice.property ? (
+        <>
+          <code>{choice.property}</code> as <code>{shown}</code>
+        </>
+      ) : (
+        <code>{shown}</code>
+      )}
+      . The{' '}
+      <a href="#request-body" className="text-cp-blue font-semibold hover:underline">
+        request body
+      </a>{' '}
+      above carries {rest.length === 1 ? 'the other shape' : `the other ${rest.length} shapes`} —{' '}
+      {rest.map((label, index) => (
+        <Fragment key={label}>
+          {index > 0 ? ', ' : ''}
+          <code>{label}</code>
+        </Fragment>
+      ))}
+      .
+    </p>
   );
 }
 
@@ -308,11 +402,7 @@ function EndpointPath({ path }: { path: string }) {
   );
 }
 
-function Authentication({
-  operation,
-}: {
-  operation: ReturnType<typeof getApiOperation>['operation'];
-}) {
+function Authentication({ operation }: { operation: Operation }) {
   const schemes = [
     ...new Set((operation.security ?? []).flatMap((alternative) => Object.keys(alternative))),
   ];
@@ -380,6 +470,8 @@ function ChipRow({ label, values }: { label: string; values: string[] }) {
   );
 }
 
+type Operation = ReturnType<typeof getApiOperation>['operation'];
+
 type Side = 'request' | 'response';
 
 type Field = {
@@ -402,20 +494,45 @@ function parameterField(parameter: ApiParameter): Field {
   };
 }
 
-/** Object properties, unwrapping a `$ref` and/or an array wrapper on the way. */
-function childFields(schema?: JsonSchema): Field[] {
-  if (!schema) return [];
-  let resolved = resolveSchema(schema).schema;
-  if (resolved.type === 'array' && resolved.items) {
-    resolved = resolveSchema(resolved.items).schema;
-  }
-  return Object.entries(resolved.properties ?? {}).map(([name, property]) => ({
-    key: name,
-    name,
-    schema: property,
-    required: (resolved.required ?? []).includes(name),
-    description: property.description,
+function fieldsOf(schema?: JsonSchema): Field[] {
+  return schemaFields(schema).map((field) => ({ key: field.name, ...field }));
+}
+
+/**
+ * A union's branches as tabs. The same control serves the body root and
+ * every union-typed field below it, so a choice looks like a choice
+ * wherever the reader meets one.
+ */
+function VariantPanels({
+  variants,
+  side,
+  depth,
+}: {
+  variants: JsonSchema[];
+  side: Side;
+  depth: number;
+}) {
+  const labels = variantLabels(variants);
+  const branches = variants.map((variant, index) => ({
+    label: labels[index],
+    description: unwrapSchema(variant)?.description,
+    fields: fieldsOf(variant),
   }));
+
+  return (
+    <VariantTabs labels={labels} discriminator={unionDiscriminator(variants)?.property}>
+      {branches.map((branch) => (
+        <div key={branch.label}>
+          {branch.description ? (
+            <p className="border-cp-borderSoft text-cp-muted border-b px-4 py-3 font-sans text-[14.5px] leading-[1.6]">
+              {branch.description}
+            </p>
+          ) : null}
+          <FieldList fields={branch.fields} side={side} depth={depth} />
+        </div>
+      ))}
+    </VariantTabs>
+  );
 }
 
 function FieldList({ fields, side, depth = 0 }: { fields: Field[]; side: Side; depth?: number }) {
@@ -429,7 +546,13 @@ function FieldList({ fields, side, depth = 0 }: { fields: Field[]; side: Side; d
 }
 
 function FieldRow({ field, side, depth }: { field: Field; side: Side; depth: number }) {
-  const children = depth < MAX_FIELD_DEPTH ? childFields(field.schema) : [];
+  // A union nests one visual level (the tabs) but not one SCHEMA level: its
+  // branches describe this field, so they spend the same depth budget its
+  // properties would have. Without that, a union inside a union inside a
+  // union — annotation, action target, destination — runs out before it
+  // reaches the fields that matter.
+  const variants = depth < MAX_FIELD_DEPTH ? unionVariants(field.schema) : [];
+  const children = depth < MAX_FIELD_DEPTH && !variants.length ? fieldsOf(field.schema) : [];
 
   return (
     <div className="px-4 py-3.5">
@@ -455,7 +578,11 @@ function FieldRow({ field, side, depth }: { field: Field; side: Side; depth: num
           {field.description}
         </p>
       ) : null}
-      {children.length ? (
+      {variants.length ? (
+        <div className="mt-3">
+          <VariantPanels variants={variants} side={side} depth={depth + 1} />
+        </div>
+      ) : children.length ? (
         <div className="border-cp-borderSoft mt-3 rounded-[10px] border bg-[#FBFCFE]">
           <FieldList fields={children} side={side} depth={depth + 1} />
         </div>
@@ -499,9 +626,9 @@ function SchemaBlock({
   side: Side;
   required?: boolean;
 }) {
-  const resolved = schema ? resolveSchema(schema).schema : undefined;
-  const variants = resolved?.anyOf ?? resolved?.oneOf ?? [];
-  const fields = childFields(schema);
+  const resolved = schema ? unwrapSchema(schema) : undefined;
+  const variants = unionVariants(schema);
+  const fields = fieldsOf(schema);
 
   return (
     <>
@@ -520,32 +647,13 @@ function SchemaBlock({
         </p>
       ) : null}
       {variants.length ? (
-        <div className="divide-cp-borderSoft divide-y">
-          {variants.map((variant, index) => (
-            <div key={index} className="px-4 py-3.5">
-              <div className="font-display text-cp-navy mb-2.5 text-[13.5px] font-bold">
-                {variantLabel(variant) ?? `Option ${index + 1}`}
-              </div>
-              <div className="border-cp-borderSoft rounded-[10px] border bg-[#FBFCFE]">
-                <FieldList fields={childFields(variant)} side={side} depth={1} />
-              </div>
-            </div>
-          ))}
+        <div className="px-4 py-3.5">
+          <VariantPanels variants={variants} side={side} depth={0} />
         </div>
       ) : fields.length ? (
         <FieldList fields={fields} side={side} />
       ) : null}
     </>
   );
-}
-
-/** anyOf branches are usually tagged unions — label them by the tag literal. */
-function variantLabel(variant: JsonSchema) {
-  const resolved = resolveSchema(variant).schema;
-  for (const property of Object.values(resolved.properties ?? {})) {
-    if (property.const !== undefined) return String(property.const);
-    if (property.enum?.length === 1) return String(property.enum[0]);
-  }
-  return resolveSchema(variant).name;
 }
 

--- a/cloudpdf/website/src/components/docs/variant-tabs.tsx
+++ b/cloudpdf/website/src/components/docs/variant-tabs.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Children, isValidElement, useState, type ReactNode } from 'react';
+
+/**
+ * The branches of a union in a request or response schema. A union is the
+ * one place where a field list cannot just nest: the reader has to pick a
+ * shape, and the shapes are alternatives, not siblings. Tabs say that, and
+ * they stay readable where a stacked list does not — the annotation union
+ * has nineteen branches.
+ *
+ * Unlike the SDK-language switcher this is deliberately NOT persisted:
+ * which annotation subtype you were last reading says nothing about which
+ * import source you want now.
+ */
+export function VariantTabs({
+  labels,
+  discriminator,
+  children,
+}: {
+  labels: string[];
+  /** The property that selects the branch, when the union has one. */
+  discriminator?: string;
+  children: ReactNode;
+}) {
+  const [active, setActive] = useState(0);
+  const panels = Children.toArray(children).filter(isValidElement);
+  const index = Math.min(active, panels.length - 1);
+
+  return (
+    <div className="border-cp-borderSoft overflow-hidden rounded-[10px] border bg-[#FBFCFE]">
+      <div className="border-cp-borderSoft flex items-center gap-1 overflow-x-auto border-b bg-[#F4F7FD] px-2 py-[7px] [scrollbar-width:thin]">
+        <span className="text-cp-muted shrink-0 px-1.5 font-sans text-[11px] font-bold uppercase tracking-[0.06em]">
+          {discriminator ? `${discriminator} =` : 'one of'}
+        </span>
+        {labels.map((label, position) => (
+          <button
+            key={label}
+            type="button"
+            onClick={() => setActive(position)}
+            aria-pressed={position === index}
+            className={`inline-flex shrink-0 cursor-pointer items-center whitespace-nowrap rounded-[7px] px-[9px] py-[5px] font-mono text-[12px] font-semibold leading-none transition ${
+              position === index
+                ? 'bg-cp-navy text-white'
+                : 'text-cp-muted hover:text-cp-navy hover:bg-white'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+      {panels[index]}
+    </div>
+  );
+}

--- a/cloudpdf/website/src/generated/sdk-snippets.json
+++ b/cloudpdf/website/src/generated/sdk-snippets.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 2,
   "canonicalVersion": "3.0.0-next.6",
-  "openapiSha256": "b3e236a932673e27e05825352e1bc3675369d7505040bf7d7760e542aae8d38d",
+  "openapiSha256": "c28c603bef65753b06ef5668f5abee8ba584af687cdff5dcaedda864c699fc13",
   "languages": {
     "typescript": {
       "label": "TypeScript",

--- a/cloudpdf/website/src/lib/api-reference-markdown.ts
+++ b/cloudpdf/website/src/lib/api-reference-markdown.ts
@@ -4,13 +4,20 @@ import {
   getApiGroups,
   getApiOperation,
   getApiVersion,
+  exampleRequestBody,
   getGrantIndex,
   getOperationCount,
   getOperationSnippets,
   getSdkLanguages,
   getSecurityScheme,
-  resolveSchema,
+  requestBodyChoice,
+  schemaFields,
   schemaType,
+  unionDiscriminator,
+  unionVariants,
+  unwrapSchema,
+  variantLabels,
+  type ApiOperation,
   type ApiParameter,
   type JsonSchema,
 } from './api-reference';
@@ -37,18 +44,23 @@ type Field = {
   location?: string;
 };
 
-function childFields(schema?: JsonSchema): Field[] {
-  if (!schema) return [];
-  let resolved = resolveSchema(schema).schema;
-  if (resolved.type === 'array' && resolved.items) {
-    resolved = resolveSchema(resolved.items).schema;
-  }
-  return Object.entries(resolved.properties ?? {}).map(([name, property]) => ({
-    name,
-    schema: property,
-    required: (resolved.required ?? []).includes(name),
-    description: property.description,
-  }));
+/**
+ * One list item per union branch, labelled by the tag that selects it —
+ * the Markdown counterpart of the page's variant tabs. Nothing here may
+ * show less than the page: a reader who fetches the `.md` sees the same
+ * branches, in the same order, under the same labels.
+ */
+function variantItems(variants: JsonSchema[], depth: number): AstNode[] {
+  const labels = variantLabels(variants);
+  return variants.map((variant, index) => {
+    const description = unwrapSchema(variant)?.description;
+    const children: AstNode[] = [
+      paragraph([strong(labels[index]), ...(description ? [text(` — ${description}`)] : [])]),
+    ];
+    const fields = schemaFields(variant);
+    if (fields.length > 0) children.push(list(fields.map((field) => fieldItem(field, depth))));
+    return listItem(children);
+  });
 }
 
 function fieldItem(field: Field, depth: number): AstNode {
@@ -58,8 +70,13 @@ function fieldItem(field: Field, depth: number): AstNode {
   if (field.description) head.push(text(` — ${field.description}`));
 
   const children: AstNode[] = [paragraph(head)];
-  const nested = depth < MAX_FIELD_DEPTH ? childFields(field.schema) : [];
-  if (nested.length > 0) {
+  // A union spends the same depth budget its properties would have — see
+  // the note on FieldRow in components/docs/api-reference.tsx.
+  const variants = depth < MAX_FIELD_DEPTH ? unionVariants(field.schema) : [];
+  const nested = depth < MAX_FIELD_DEPTH && !variants.length ? schemaFields(field.schema) : [];
+  if (variants.length > 0) {
+    children.push(list(variantItems(variants, depth + 1)));
+  } else if (nested.length > 0) {
     children.push(list(nested.map((child) => fieldItem(child, depth + 1))));
   }
   return listItem(children);
@@ -71,23 +88,43 @@ function schemaNodes(contentType: string, schema: JsonSchema | undefined): AstNo
   ];
   if (!schema) return nodes;
 
-  const resolved = resolveSchema(schema).schema;
-  if (resolved.description) nodes.push(paragraph([text(resolved.description)]));
+  const resolved = unwrapSchema(schema);
+  if (resolved?.description) nodes.push(paragraph([text(resolved.description)]));
 
-  const variants = resolved.anyOf ?? resolved.oneOf ?? [];
+  const variants = unionVariants(schema);
   if (variants.length > 0) {
-    for (const [index, variant] of variants.entries()) {
-      const label = resolveSchema(variant).name ?? `Option ${index + 1}`;
-      nodes.push(paragraph([strong(label)]));
-      const fields = childFields(variant);
-      if (fields.length > 0) nodes.push(list(fields.map((field) => fieldItem(field, 1))));
-    }
+    const discriminator = unionDiscriminator(variants);
+    nodes.push(
+      paragraph([
+        text('One of'),
+        ...(discriminator ? [text(', selected by '), inlineCode(discriminator.property)] : []),
+        text(':'),
+      ]),
+      list(variantItems(variants, 0)),
+    );
     return nodes;
   }
 
-  const fields = childFields(schema);
+  const fields = schemaFields(schema);
   if (fields.length > 0) nodes.push(list(fields.map((field) => fieldItem(field, 0))));
   return nodes;
+}
+
+/** The wire body, one block per shape — the page's example, in Markdown. */
+function requestBodyExampleNodes(operation: ApiOperation): AstNode[] {
+  const choice = requestBodyChoice(operation);
+  const examples = choice
+    ? choice.variants.map((variant, index) => ({
+        label: choice.labels[index],
+        json: exampleRequestBody(operation, { property: choice.property, variant }),
+      }))
+    : [{ label: '', json: exampleRequestBody(operation) }];
+  if (examples.every((example) => ['', '{}', 'null'].includes(example.json))) return [];
+
+  return examples.flatMap((example) => [
+    paragraph([strong(example.label ? `Example — ${example.label}` : 'Example')]),
+    code('json', example.json),
+  ]);
 }
 
 /* ---------- component projections ---------- */
@@ -160,6 +197,7 @@ function projectApiOperation(operationId: string): AstNode[] {
     for (const [contentType, media] of Object.entries(operation.requestBody.content ?? {})) {
       nodes.push(...schemaNodes(contentType, media.schema));
     }
+    nodes.push(...requestBodyExampleNodes(operation));
   }
 
   nodes.push(heading(2, 'SDK examples'));

--- a/cloudpdf/website/src/lib/api-reference.ts
+++ b/cloudpdf/website/src/lib/api-reference.ts
@@ -12,7 +12,8 @@ export type JsonSchema = {
   const?: unknown;
   default?: unknown;
   nullable?: boolean;
-  items?: JsonSchema;
+  /** An array's element schema, or its positional schemas when it is a tuple. */
+  items?: JsonSchema | JsonSchema[];
   properties?: Record<string, JsonSchema>;
   required?: string[];
   additionalProperties?: boolean | JsonSchema;
@@ -268,23 +269,288 @@ export function getGrantIndex(kind: 'x-required-capability' | 'x-required-scope'
     .map(([grant, operations]) => ({ grant, operations }));
 }
 
-export function resolveSchema(schema: JsonSchema): { name?: string; schema: JsonSchema } {
-  if (!schema.$ref) return { schema };
-  const name = schema.$ref.split('/').at(-1);
-  const resolved = name ? openapi.components.schemas[name] : undefined;
-  return { name, schema: resolved ?? schema };
+/**
+ * A `$ref` target. Reused sub-schemas are emitted as pointers INTO the
+ * component that first declared them (`.../DocAnnotationsList200Response/
+ * properties/annotations/items/anyOf/0/properties/color`), so resolving only
+ * `#/components/schemas/{name}` left several hundred refs unresolved — they
+ * rendered as their last path segment with no fields beneath it.
+ */
+function pointerTarget(ref: string): JsonSchema | undefined {
+  if (!ref.startsWith('#/')) return undefined;
+  let node: unknown = openapi;
+  for (const segment of ref.slice(2).split('/')) {
+    const key = segment.replaceAll('~1', '/').replaceAll('~0', '~');
+    if (Array.isArray(node)) node = node[Number(key)];
+    else if (node && typeof node === 'object') node = (node as Record<string, unknown>)[key];
+    else return undefined;
+  }
+  return node && typeof node === 'object' ? (node as JsonSchema) : undefined;
 }
 
+/** The schema name of a component ref — undefined for a pointer into one. */
+function componentName(ref: string): string | undefined {
+  return /^#\/components\/schemas\/([^/]+)$/.exec(ref)?.[1];
+}
+
+export function resolveSchema(schema: JsonSchema): { name?: string; schema: JsonSchema } {
+  if (!schema.$ref) return { schema };
+  return { name: componentName(schema.$ref), schema: pointerTarget(schema.$ref) ?? schema };
+}
+
+/**
+ * The schema a field really shows: past its `$ref`, and past one array
+ * wrapper, since a list of X documents as the fields of X.
+ */
+export function unwrapSchema(schema?: JsonSchema): JsonSchema | undefined {
+  if (!schema) return undefined;
+  const resolved = resolveSchema(schema).schema;
+  if (resolved.type === 'array' && resolved.items && !Array.isArray(resolved.items)) {
+    return resolveSchema(resolved.items).schema;
+  }
+  return resolved;
+}
+
+/**
+ * The branches of a union worth showing as separate shapes — empty for
+ * everything else. A union of scalars (`"*" | "docs.read" | ...`) or of
+ * tuples is already fully described by its type string, so only unions with
+ * at least one structured branch earn variant tabs.
+ */
+export function unionVariants(schema?: JsonSchema): JsonSchema[] {
+  const resolved = unwrapSchema(schema);
+  const variants = resolved?.oneOf ?? resolved?.anyOf ?? [];
+  return variants.some((variant) => resolveSchema(variant).schema.properties) ? variants : [];
+}
+
+/** Object properties, unwrapping a `$ref` and/or an array wrapper on the way. */
+export function schemaFields(schema?: JsonSchema): Array<{
+  name: string;
+  schema: JsonSchema;
+  required: boolean;
+  description?: string;
+}> {
+  const resolved = unwrapSchema(schema);
+  return Object.entries(resolved?.properties ?? {}).map(([name, property]) => ({
+    name,
+    schema: property,
+    required: (resolved?.required ?? []).includes(name),
+    description: property.description,
+  }));
+}
+
+/** The literal a schema pins, when it pins exactly one. */
+function literalOf(schema: JsonSchema): string | undefined {
+  if (schema.const !== undefined) return String(schema.const);
+  if (schema.enum?.length === 1) return String(schema.enum[0]);
+  return undefined;
+}
+
+/**
+ * The property every branch of a union pins to a DIFFERENT literal — computed
+ * across the branches rather than per branch, because a branch can pin more
+ * than one: three of the nineteen annotation variants pin `intent` as well as
+ * `subtype`, and labelling each branch by its own first literal mixed the two
+ * vocabularies (`highlight`, `underline`, `ink-highlight`, ...).
+ */
+export function unionDiscriminator(
+  variants: JsonSchema[],
+): { property: string; values: string[] } | undefined {
+  if (variants.length < 2) return undefined;
+  const pinned = variants.map((variant) => {
+    const properties = resolveSchema(variant).schema.properties ?? {};
+    return new Map(
+      Object.entries(properties).flatMap(([name, property]) => {
+        const literal = literalOf(property);
+        return literal === undefined ? [] : [[name, literal] as const];
+      }),
+    );
+  });
+
+  for (const property of pinned[0].keys()) {
+    if (!pinned.every((branch) => branch.has(property))) continue;
+    const values = pinned.map((branch) => branch.get(property)!);
+    if (new Set(values).size === values.length) return { property, values };
+  }
+  return undefined;
+}
+
+/** Display labels for a union's branches, in branch order. */
+export function variantLabels(variants: JsonSchema[]): string[] {
+  const discriminator = unionDiscriminator(variants);
+  return variants.map(
+    (variant, index) =>
+      discriminator?.values[index] ?? resolveSchema(variant).name ?? `Option ${index + 1}`,
+  );
+}
+
+/** Past this many branches a union prints its count instead of its labels. */
+const UNION_SUMMARY_LIMIT = 4;
+
 export function schemaType(schema?: JsonSchema): string {
+  return typeString(schema, new Set());
+}
+
+function typeString(schema: JsonSchema | undefined, seen: Set<string>): string {
   if (!schema) return 'unknown';
-  if (schema.$ref) return schema.$ref.split('/').at(-1) ?? 'object';
+  if (schema.$ref) {
+    const name = componentName(schema.$ref);
+    if (name) return name;
+    // A pointer into a component names a property, not a type — show the
+    // shape it points at instead. `seen` guards a pathological cycle.
+    if (seen.has(schema.$ref)) return 'object';
+    const target = pointerTarget(schema.$ref);
+    return target ? typeString(target, new Set([...seen, schema.$ref])) : 'object';
+  }
   if (schema.const !== undefined) return JSON.stringify(schema.const);
   if (schema.enum) return schema.enum.map((value) => JSON.stringify(value)).join(' | ');
-  if (schema.oneOf) return schema.oneOf.map(schemaType).join(' | ');
-  if (schema.anyOf) return schema.anyOf.map(schemaType).join(' | ');
-  if (schema.allOf) return schema.allOf.map(schemaType).join(' & ');
-  if (schema.type === 'array') return `${schemaType(schema.items)}[]`;
+
+  const variants = schema.oneOf ?? schema.anyOf;
+  if (variants) return unionString(variants, seen);
+  if (schema.allOf) return schema.allOf.map((member) => typeString(member, seen)).join(' & ');
+
+  if (schema.type === 'array') {
+    if (Array.isArray(schema.items)) {
+      return `[${schema.items.map((item) => typeString(item, seen)).join(', ')}]`;
+    }
+    const item = typeString(schema.items, seen);
+    // `"a" | "b"[]` reads as a union with an array on the end.
+    return /^\d+ variants$/.test(item) || item.includes(' | ') ? `(${item})[]` : `${item}[]`;
+  }
+
+  // `z.unknown()` and the recursion back-edge the emitter substitutes for a
+  // self-reference both arrive as an open schema. The reference says
+  // `unknown` — true, and unlike `object` it does not promise fields.
+  if (
+    schema.type === undefined &&
+    !schema.properties &&
+    schema.additionalProperties === undefined
+  ) {
+    return 'unknown';
+  }
 
   const type = Array.isArray(schema.type) ? schema.type.join(' | ') : (schema.type ?? 'object');
   return schema.format ? `${type}<${schema.format}>` : type;
+}
+
+/**
+ * A union reads as the choice it offers: a tagged union prints its tag
+ * literals (`"url" | "connection"`), a union of enums merges into one enum,
+ * anything else falls back to its branch types. Past a handful of branches
+ * the list stops being readable and becomes a count — the variant tabs
+ * under the row carry the detail.
+ */
+function unionString(variants: JsonSchema[], seen: Set<string>): string {
+  const literals = variants.flatMap((variant) => {
+    const resolved = resolveSchema(variant).schema;
+    if (resolved.properties) return [];
+    if (resolved.const !== undefined) return [JSON.stringify(resolved.const)];
+    return (resolved.enum ?? []).map((value) => JSON.stringify(value));
+  });
+  if (literals.length >= variants.length) return [...new Set(literals)].join(' | ');
+
+  if (variants.length > UNION_SUMMARY_LIMIT) return `${variants.length} variants`;
+  const discriminator = unionDiscriminator(variants);
+  if (discriminator) return discriminator.values.map((value) => JSON.stringify(value)).join(' | ');
+  return variants.map((variant) => typeString(variant, seen)).join(' | ');
+}
+
+/**
+ * The choice a request body puts to the caller: the union at its root, or
+ * the first property that is one. Fern generates a single example per
+ * operation and takes the first branch of any union in it, so without this
+ * the docs would show one shape of a two-shape body and say nothing about
+ * the other.
+ */
+export function requestBodyChoice(
+  operation: ApiOperation,
+): { property?: string; variants: JsonSchema[]; labels: string[] } | undefined {
+  const schema = jsonBodySchema(operation);
+  if (!schema) return undefined;
+
+  const rootVariants = unionVariants(schema);
+  if (rootVariants.length > 1) {
+    return { variants: rootVariants, labels: variantLabels(rootVariants) };
+  }
+  for (const field of schemaFields(schema)) {
+    const variants = unionVariants(field.schema);
+    if (variants.length > 1) {
+      return { property: field.name, variants, labels: variantLabels(variants) };
+    }
+  }
+  return undefined;
+}
+
+/** A body the reference can show as JSON — `documents.uploadProxy` sends bytes. */
+function jsonBodySchema(operation: ApiOperation): JsonSchema | undefined {
+  return operation.requestBody?.content?.['application/json']?.schema;
+}
+
+/** Guards against a schema that nests further than any real request body. */
+const MAX_EXAMPLE_DEPTH = 8;
+
+/**
+ * A JSON value standing in for a schema: required fields only (they are
+ * what a caller must send), enum and literal values verbatim, and property
+ * names as string placeholders — the same convention the generated SDK
+ * examples use (`url: "url"`), so the wire example and the SDK example
+ * describe one request rather than two.
+ */
+function exampleValue(schema: JsonSchema | undefined, name: string, depth = 0): unknown {
+  const resolved = schema ? resolveSchema(schema).schema : undefined;
+  if (!resolved || depth > MAX_EXAMPLE_DEPTH) return null;
+  if (resolved.const !== undefined) return resolved.const;
+  if (resolved.enum?.length) return resolved.enum[0];
+
+  const variants = resolved.oneOf ?? resolved.anyOf;
+  if (variants?.length) return exampleValue(variants[0], name, depth + 1);
+
+  if (resolved.type === 'array') {
+    if (Array.isArray(resolved.items)) {
+      return resolved.items.map((item) => exampleValue(item, name, depth + 1));
+    }
+    return [exampleValue(resolved.items, name, depth + 1)];
+  }
+
+  if (resolved.properties) {
+    const required = new Set(resolved.required ?? []);
+    const entries = Object.entries(resolved.properties);
+    // An all-optional body would otherwise example as `{}`.
+    const shown = required.size ? entries.filter(([key]) => required.has(key)) : entries;
+    return Object.fromEntries(shown.map(([key, p]) => [key, exampleValue(p, key, depth + 1)]));
+  }
+
+  switch (Array.isArray(resolved.type) ? resolved.type[0] : resolved.type) {
+    case 'integer':
+    case 'number':
+      return 1;
+    case 'boolean':
+      return true;
+    case 'string':
+      return name;
+    case 'object':
+      return {};
+    default:
+      return null;
+  }
+}
+
+/** The request body a caller would send, with one branch of `choice` taken. */
+export function exampleRequestBody(
+  operation: ApiOperation,
+  choice?: { property?: string; variant: JsonSchema },
+): string {
+  const schema = jsonBodySchema(operation);
+  if (!schema) return '';
+  const body = exampleValue(schema, 'body');
+  if (!choice) return JSON.stringify(body, null, 2);
+  if (!choice.property) return JSON.stringify(exampleValue(choice.variant, 'body'), null, 2);
+  return JSON.stringify(
+    {
+      ...(body as Record<string, unknown>),
+      [choice.property]: exampleValue(choice.variant, choice.property),
+    },
+    null,
+    2,
+  );
 }

--- a/fern/scripts/sync-sdk-repository.mjs
+++ b/fern/scripts/sync-sdk-repository.mjs
@@ -79,6 +79,102 @@ function run(command, args, options = {}) {
   return options.capture ? (result.stdout ?? '').trim() : '';
 }
 
+const requiredMergeCheck = 'Build and validate';
+
+function positiveIntegerEnvironment(name, fallback, { allowZero = false } = {}) {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  const minimum = allowZero ? 0 : 1;
+  if (!Number.isInteger(value) || value < minimum) {
+    throw new Error(`${name} must be an integer greater than or equal to ${minimum}`);
+  }
+  return value;
+}
+
+function requiredCheckState(statusCheckRollup) {
+  const check = statusCheckRollup.find(
+    (candidate) =>
+      candidate.name === requiredMergeCheck || candidate.context === requiredMergeCheck,
+  );
+  if (!check) return 'missing';
+
+  if (check.__typename === 'StatusContext') {
+    if (check.state === 'SUCCESS') return 'success';
+    if (check.state === 'PENDING' || check.state === 'EXPECTED') return 'pending';
+    return 'failure';
+  }
+
+  if (check.status !== 'COMPLETED') return 'pending';
+  return check.conclusion === 'SUCCESS' ? 'success' : 'failure';
+}
+
+async function mergeGeneratedPullRequest(pullRequestUrl, expectedHeadSha) {
+  const attempts = positiveIntegerEnvironment('SDK_AUTO_MERGE_MAX_ATTEMPTS', 30);
+  const interval = positiveIntegerEnvironment('SDK_AUTO_MERGE_POLL_INTERVAL_MS', 1000, {
+    allowZero: true,
+  });
+  let lastReason = 'GitHub has not returned pull request state';
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const state = JSON.parse(
+      run(
+        'gh',
+        [
+          'pr',
+          'view',
+          pullRequestUrl,
+          '--repo',
+          repository.slug,
+          '--json',
+          'headRefOid,mergeable,mergeStateStatus,statusCheckRollup',
+        ],
+        { cwd: checkoutDirectory, capture: true },
+      ),
+    );
+    const checkState = requiredCheckState(state.statusCheckRollup ?? []);
+
+    if (state.headRefOid !== expectedHeadSha) {
+      lastReason = `GitHub still reports head ${state.headRefOid ?? 'unknown'}`;
+    } else if (state.mergeable === 'CONFLICTING' || state.mergeStateStatus === 'DIRTY') {
+      throw new Error(`${repository.slug}: generated pull request has merge conflicts`);
+    } else if (checkState === 'failure') {
+      throw new Error(`${repository.slug}: required check ${requiredMergeCheck} failed`);
+    } else if (state.mergeable === 'UNKNOWN') {
+      lastReason = 'GitHub is still calculating mergeability';
+    } else if (checkState === 'missing') {
+      lastReason = `required check ${requiredMergeCheck} is not registered yet`;
+    } else if (state.mergeStateStatus === 'CLEAN' && checkState === 'success') {
+      // Once all requirements have already passed, GitHub rejects the
+      // enablePullRequestAutoMerge mutation. Merge directly, but only after
+      // proving the required check belongs to the exact head we pushed.
+      run('gh', ['pr', 'merge', pullRequestUrl, '--squash', '--delete-branch'], {
+        cwd: checkoutDirectory,
+      });
+      console.log(`${repository.slug}: required checks passed; pull request merged`);
+      return;
+    } else if (state.mergeStateStatus !== 'CLEAN') {
+      // Waiting until the current head and its required check are visible avoids
+      // racing GitHub's post-push mergeability recalculation. Native auto-merge
+      // can now safely wait for the pending check or any other repository rule.
+      run('gh', ['pr', 'merge', pullRequestUrl, '--auto', '--squash', '--delete-branch'], {
+        cwd: checkoutDirectory,
+      });
+      console.log(`${repository.slug}: auto-merge enabled`);
+      return;
+    } else {
+      lastReason = `${requiredMergeCheck} is ${checkState} while GitHub still reports CLEAN`;
+    }
+
+    if (attempt < attempts) {
+      console.log(`${repository.slug}: waiting for merge state (${lastReason})`);
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+  }
+
+  throw new Error(`${repository.slug}: timed out waiting to configure auto-merge: ${lastReason}`);
+}
+
 function copyTree(source, target, sourceRoot = source) {
   mkdirSync(target, { recursive: true });
   for (const entry of readdirSync(source, { withFileTypes: true })) {
@@ -168,6 +264,10 @@ try {
       ],
       { cwd: checkoutDirectory },
     );
+    const pushedHeadSha = run('git', ['rev-parse', 'HEAD'], {
+      cwd: checkoutDirectory,
+      capture: true,
+    });
     // The clone is intentionally shallow and tracks only main, so generic
     // --force-with-lease cannot infer the expected value for a previously used
     // automation branch. Pin the lease to the exact SHA observed above. An
@@ -199,7 +299,7 @@ try {
         '--jq',
         '.[0].url // ""',
       ],
-      { capture: true },
+      { cwd: checkoutDirectory, capture: true },
     );
 
     if (!pullRequestUrl) {
@@ -232,14 +332,13 @@ This PR updates generated source and repository-owned automation. Registry publi
           '--body-file',
           bodyPath,
         ],
-        { capture: true },
+        { cwd: checkoutDirectory, capture: true },
       );
     }
 
     console.log(`${repository.slug}: ${pullRequestUrl}`);
     if (process.env.SDK_AUTO_MERGE === 'true') {
-      run('gh', ['pr', 'merge', pullRequestUrl, '--auto', '--squash', '--delete-branch']);
-      console.log(`${repository.slug}: auto-merge enabled`);
+      await mergeGeneratedPullRequest(pullRequestUrl, pushedHeadSha);
     }
   }
 } finally {

--- a/fern/scripts/sync-sdk-repository.test.mjs
+++ b/fern/scripts/sync-sdk-repository.test.mjs
@@ -40,6 +40,7 @@ test('sync creates and safely updates a reused PR branch while preserving reposi
     const generated = join(fixture, 'generated');
     const fakeBin = join(fixture, 'bin');
     const ghLog = join(fixture, 'gh.log');
+    const ghViewCount = join(fixture, 'gh-view-count');
     const inspection = join(fixture, 'inspection');
     mkdirSync(seed);
     mkdirSync(join(seed, '.github', 'workflows'), { recursive: true });
@@ -84,6 +85,24 @@ printf '%s\\n' "$*" >> "$GH_LOG"
 case "$1 $2" in
   "pr list") exit 0 ;;
   "pr create") printf '%s\\n' 'https://github.com/embedpdf/cloudpdf-sdk-python/pull/1' ;;
+  "pr view")
+    count=0
+    if [ -f "$GH_VIEW_COUNT" ]; then count="$(cat "$GH_VIEW_COUNT")"; fi
+    count=$((count + 1))
+    printf '%s\\n' "$count" > "$GH_VIEW_COUNT"
+    head_oid="$(git rev-parse HEAD)"
+    case "$count" in
+      1)
+        printf '{"headRefOid":"%s","mergeable":"UNKNOWN","mergeStateStatus":"UNKNOWN","statusCheckRollup":[]}\\n' "$head_oid"
+        ;;
+      2)
+        printf '{"headRefOid":"%s","mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED","statusCheckRollup":[{"__typename":"CheckRun","name":"Build and validate","status":"IN_PROGRESS","conclusion":null}]}\\n' "$head_oid"
+        ;;
+      *)
+        printf '{"headRefOid":"%s","mergeable":"MERGEABLE","mergeStateStatus":"CLEAN","statusCheckRollup":[{"__typename":"CheckRun","name":"Build and validate","status":"COMPLETED","conclusion":"SUCCESS"}]}\\n' "$head_oid"
+        ;;
+    esac
+    ;;
   "pr merge") exit 0 ;;
   *) printf '%s\\n' "unexpected gh invocation: $*" >&2; exit 1 ;;
 esac
@@ -96,11 +115,14 @@ esac
         ...process.env,
         PATH: `${fakeBin}:${process.env.PATH}`,
         GH_LOG: ghLog,
+        GH_VIEW_COUNT: ghViewCount,
         GH_TOKEN: 'fixture-token',
         SDK_GITHUB_TOKEN: 'fixture-token',
         SDK_GENERATED_DIRECTORY: generated,
         SDK_REPOSITORY_REMOTE_URL: remote,
         SDK_AUTO_MERGE: 'true',
+        SDK_AUTO_MERGE_MAX_ATTEMPTS: '5',
+        SDK_AUTO_MERGE_POLL_INTERVAL_MS: '0',
       },
     });
 
@@ -112,11 +134,14 @@ esac
         ...process.env,
         PATH: `${fakeBin}:${process.env.PATH}`,
         GH_LOG: ghLog,
+        GH_VIEW_COUNT: ghViewCount,
         GH_TOKEN: 'fixture-token',
         SDK_GITHUB_TOKEN: 'fixture-token',
         SDK_GENERATED_DIRECTORY: generated,
         SDK_REPOSITORY_REMOTE_URL: remote,
         SDK_AUTO_MERGE: 'true',
+        SDK_AUTO_MERGE_MAX_ATTEMPTS: '5',
+        SDK_AUTO_MERGE_POLL_INTERVAL_MS: '0',
       },
     });
 
@@ -130,7 +155,14 @@ esac
     assert.ok(existsSync(join(inspection, '.github', 'workflows', 'sdk-ci.yml')));
     assert.equal(existsSync(join(inspection, 'node_modules')), false);
     const ghInvocations = readFileSync(ghLog, 'utf8');
-    assert.match(ghInvocations, /pr merge .* --auto --squash --delete-branch/);
+    const mergeInvocations = ghInvocations
+      .split('\n')
+      .filter((invocation) => invocation.startsWith('pr merge '));
+    assert.equal(mergeInvocations.length, 2);
+    assert.match(mergeInvocations[0], /--auto --squash --delete-branch/);
+    assert.doesNotMatch(mergeInvocations[1], /--auto/);
+    assert.match(mergeInvocations[1], /--squash --delete-branch/);
+    assert.equal(ghInvocations.match(/^pr view /gm)?.length, 3);
     assert.equal(ghInvocations.match(/^pr create /gm)?.length, 2);
   } finally {
     rmSync(fixture, { recursive: true, force: true });


### PR DESCRIPTION
Add rich descriptions to the OpenAPI contract and zod schemas (import sources, expected integrity, dedup/mode, idempotency). Regenerate SDK artifacts (bumped openapiSha256) and add JSDoc comments to generated request types. Improve website API reference: add request-body examples, union/variant handling (variant tabs component), robust schema resolution (unwrapSchema, unionVariants, variantLabels) and a validator for unrenderable schemas. Update sync-sdk-repository script to robustly handle auto-merge by checking the required "Build and validate" check (polling + test updates).