### PR TITLE
Handle bodyless JSON requests

### DIFF
--- a/.changeset/cloudpdf-server-empty-json-body.md
+++ b/.changeset/cloudpdf-server-empty-json-body.md
@@ -1,0 +1,8 @@
+---
+'@cloudpdf/server': patch
+---
+
+Accepts bodyless requests that carry `Content-Type: application/json` instead of failing them with an unhandled 500.
+
+- An empty JSON body now parses as no body rather than `FST_ERR_CTP_EMPTY_JSON_BODY` — the shape the generated PHP, Go, and Ruby SDKs (and clients with default JSON headers) send for bodyless calls such as document delete. Non-empty bodies still go through Fastify's default parser, keeping its prototype-poisoning protection, and routes that require a body still reject its absence with a 400.
+- The error handler now honors Fastify's `statusCode` on framework errors, so parser and payload rejections (empty or malformed JSON, body limits) surface as the 4xx client errors they are instead of being logged and returned as "unhandled error" 500s.

--- a/cloudpdf/server/src/app/buildApp.ts
+++ b/cloudpdf/server/src/app/buildApp.ts
@@ -433,6 +433,27 @@ async function buildAppUnchecked(opts: BuildAppOptions): Promise<AppBundle> {
     { parseAs: 'buffer', bodyLimit: opts.bodyLimit ?? 50 * 1024 * 1024 },
     (_req, body, done) => done(null, body),
   );
+  // Fastify's stock JSON parser rejects a bodyless request that still
+  // advertises `Content-Type: application/json` (FST_ERR_CTP_EMPTY_JSON_BODY).
+  // Real clients send exactly that shape on bodyless calls — the Fern
+  // PHP/Go/Ruby SDKs stamp the header unconditionally, as do axios
+  // instances with default headers and `curl -H` scripts — so treat an
+  // empty body as no body. Non-empty bodies still go through the default
+  // parser (keeping secure-json-parse's prototype-poisoning protection),
+  // and handlers that require a body still 400 on `undefined` via their
+  // zod parsing.
+  const defaultJsonParser = app.getDefaultJsonParser('error', 'error');
+  app.addContentTypeParser<string>(
+    'application/json',
+    { parseAs: 'string', bodyLimit: opts.bodyLimit ?? 50 * 1024 * 1024 },
+    (req, body, done) => {
+      if (body === '' || body == null) {
+        done(null, undefined);
+        return;
+      }
+      defaultJsonParser(req, body, done);
+    },
+  );
 
   // Optional revocation + JWKS persistence guards. Both are no-ops
   // unless explicitly enabled — admin-only tests / dev runs don't
@@ -921,9 +942,16 @@ async function buildAppUnchecked(opts: BuildAppOptions): Promise<AppBundle> {
       });
       return;
     }
-    const e = err as Error & { code?: string; status?: number };
+    const e = err as Error & { code?: string; status?: number; statusCode?: number };
     if (e.status && typeof e.status === 'number') {
       reply.code(e.status).send({ error: { code: e.code ?? 'Unknown', message: e.message } });
+      return;
+    }
+    // Fastify's own errors (body parsing, payload limits, validation) carry
+    // `statusCode`, not `status`. Pass 4xx through as the client errors they
+    // are; 5xx still falls to the unhandled branch below so it gets logged.
+    if (typeof e.statusCode === 'number' && e.statusCode >= 400 && e.statusCode < 500) {
+      reply.code(e.statusCode).send({ error: { code: e.code ?? 'Unknown', message: e.message } });
       return;
     }
     if (e.code === 'NotFound') {

--- a/cloudpdf/server/test/empty-json-body.test.ts
+++ b/cloudpdf/server/test/empty-json-body.test.ts
@@ -1,0 +1,135 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import type { Kysely } from 'kysely';
+import {
+  createSqliteDb,
+  migrate,
+  sqliteMigrations,
+  FsObjectStore,
+  type AppBundle,
+  type DbSchema,
+} from '../src/index';
+import { buildAppForTesting } from '../src/app/buildApp';
+import { createValidTestLicenseGate } from '../src/licensing/testing';
+
+const API_TOKEN = 'empty-json-body-api-token';
+
+/**
+ * Bodyless requests that still advertise `Content-Type: application/json`.
+ *
+ * The Fern PHP/Go/Ruby SDKs stamp that header on every JSON-API call, body
+ * or not, so a plain SDK `documents.delete()` arrives exactly like this.
+ * Fastify's stock parser turned it into FST_ERR_CTP_EMPTY_JSON_BODY, and the
+ * error handler — which only recognized service errors' `status` — escalated
+ * the intended 400 into an "unhandled error" 500.
+ */
+describe('bodyless requests with a JSON content type', () => {
+  let bundle: AppBundle;
+  let db: Kysely<DbSchema>;
+  let storageRoot: string;
+
+  beforeAll(async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'embedpdf-empty-json-'));
+    db = createSqliteDb({ path: ':memory:' });
+    await migrate(db, { source: { kind: 'inline', migrations: sqliteMigrations } });
+    bundle = await buildAppForTesting({
+      licenseGate: createValidTestLicenseGate(),
+      verifier: { mode: 'hs256', secret: 'empty-json-body-secret' },
+      apiAuthTokens: [API_TOKEN],
+      workerEntry: null,
+      db,
+      objectStore: new FsObjectStore({ root: storageRoot }),
+      autoProvisionTenant: true,
+      sweepIntervalMs: 0,
+    });
+  });
+
+  afterAll(async () => {
+    await bundle.shutdown();
+    await db.destroy();
+    await rm(storageRoot, { recursive: true, force: true });
+  });
+
+  const auth = { authorization: `Bearer ${API_TOKEN}` };
+
+  test('bodyless DELETE carrying the stray JSON header succeeds', async () => {
+    const res = await bundle.app.inject({
+      method: 'DELETE',
+      url: '/v1/tenants/local/documents/no-such-doc',
+      headers: { ...auth, 'content-type': 'application/json' },
+    });
+    // Delete is idempotent, so a missing doc is still a 204. Before the
+    // tolerant parser this request died with a 500 before the handler ran.
+    expect(res.statusCode).toBe(204);
+  });
+
+  test('the charset-parameter variant of the header is tolerated too', async () => {
+    const res = await bundle.app.inject({
+      method: 'DELETE',
+      url: '/v1/tenants/local/documents/no-such-doc',
+      headers: { ...auth, 'content-type': 'application/json; charset=utf-8' },
+    });
+    expect(res.statusCode).toBe(204);
+  });
+
+  test('a bodyless DELETE with no content type keeps working', async () => {
+    const res = await bundle.app.inject({
+      method: 'DELETE',
+      url: '/v1/tenants/local/documents/no-such-doc',
+      headers: auth,
+    });
+    expect(res.statusCode).toBe(204);
+  });
+
+  test('an empty body does not satisfy a route that requires one', async () => {
+    const res = await bundle.app.inject({
+      method: 'POST',
+      url: '/v1/tenants/local/documents/init',
+      headers: { ...auth, 'content-type': 'application/json' },
+    });
+    // Tolerance yields `req.body === undefined`; the handler's zod parse
+    // still rejects it as a client error.
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: { code: 'InvalidArg' } });
+  });
+
+  test('a valid JSON body still parses and reaches the handler', async () => {
+    const res = await bundle.app.inject({
+      method: 'POST',
+      url: '/v1/tenants/local/documents/init',
+      headers: { ...auth, 'content-type': 'application/json' },
+      payload: '{}',
+    });
+    // {} parses fine and fails the handler's schema — proof the non-empty
+    // path still delegates to the real parser.
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toMatchObject({ error: { code: 'InvalidArg' } });
+  });
+
+  test("malformed JSON maps to Fastify's 400, not an unhandled 500", async () => {
+    const res = await bundle.app.inject({
+      method: 'POST',
+      url: '/v1/tenants/local/documents/init',
+      headers: { ...auth, 'content-type': 'application/json' },
+      payload: '{"contentLength":',
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  test('prototype-poisoning protection survives the tolerant parser', async () => {
+    const res = await bundle.app.inject({
+      method: 'POST',
+      url: '/v1/tenants/local/documents/init',
+      headers: { ...auth, 'content-type': 'application/json' },
+      payload: '{"__proto__": {"admin": true}}',
+    });
+    expect(res.statusCode).toBe(400);
+    // Rejected at the content-type-parser layer (secure-json-parse fires,
+    // Fastify wraps it as an FST_ERR_CTP_* invalid-JSON error). Had the
+    // payload been accepted, it would have reached zod and come back as
+    // InvalidArg instead.
+    expect(res.json().error.code).toMatch(/^FST_ERR_CTP_/);
+  });
+});


### PR DESCRIPTION
This patch treats empty JSON bodies as no body for requests that include `Content-Type: application/json`, so bodyless SDK calls no longer trigger Fastify's `FST_ERR_CTP_EMPTY_JSON_BODY` 500. Non-empty JSON still uses Fastify's normal parser, preserving prototype-poisoning protections, and routes that require a body continue to reject missing input with a 400. The app error handler also forwards Fastify 4xx parser/payload errors using `statusCode`, so client-side validation and payload issues surface as proper 400s instead of unhandled 500s.