### PR TITLE
Add rotated selection-handle geometry

### DIFF
--- a/.changeset/selection-handles-core-geometry.md
+++ b/.changeset/selection-handles-core-geometry.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/core-geometry': minor
+---
+
+Add `textQuadEdge` and `textQuadEquals` helpers for orientation-aware glyph edges and corner-wise text-quad change detection.

--- a/.changeset/selection-handles-plugin-selection.md
+++ b/.changeset/selection-handles-plugin-selection.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-selection': minor
+---
+
+Add framework-independent selection-handle geometry and drag policies that follow rotated text, rotated pages, and RTL selection boundaries.

--- a/.changeset/selection-handles-react.md
+++ b/.changeset/selection-handles-react.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/react': patch
+---
+
+Refactor `SelectionHandles` to use the shared selection and web primitives so handles align correctly with rotated text and rotated pages.

--- a/.changeset/selection-handles-web.md
+++ b/.changeset/selection-handles-web.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/web': minor
+---
+
+Add a shared native DOM binding for selection-handle drags that shields Stage gestures and handles pointer capture and client-delta tracking.

--- a/packages/core/geometry/src/index.ts
+++ b/packages/core/geometry/src/index.ts
@@ -647,6 +647,30 @@ export function textQuadRing(t: TextQuad): [Point, Point, Point, Point] {
   return [t.upperStart, t.upperEnd, t.lowerEnd, t.lowerStart];
 }
 
+/**
+ * One SIDE edge of the cell — the start (`US → LS`) or end (`UE → LE`) edge,
+ * ASCENT CORNER FIRST. This is the segment a caret or a selection handle
+ * occupies: its length is the glyph's ink height in the text's own frame (not
+ * the AABB height, which grows with tilt), and its direction carries the
+ * text's rotation. Which side is the selection's LEADING edge is a reading
+ * -order question — decide it with `advance`, not with geometry.
+ */
+export function textQuadEdge(t: TextQuad, side: 'start' | 'end'): [Point, Point] {
+  return side === 'start' ? [t.upperStart, t.lowerStart] : [t.upperEnd, t.lowerEnd];
+}
+
+/** Corner-wise equality — an AABB comparison would call a quad that ROTATED
+ *  in place "unchanged"; corners cannot. (Change-detection for quad consumers.) */
+export function textQuadEquals(a: TextQuad, b: TextQuad): boolean {
+  const eq = (p: Point, q: Point) => p.x === q.x && p.y === q.y;
+  return (
+    eq(a.upperStart, b.upperStart) &&
+    eq(a.upperEnd, b.upperEnd) &&
+    eq(a.lowerStart, b.lowerStart) &&
+    eq(a.lowerEnd, b.lowerEnd)
+  );
+}
+
 /** Axis-aligned bounds of a TextQuad. */
 export function textQuadBounds(t: TextQuad): Rect {
   const xs = [t.upperStart.x, t.upperEnd.x, t.lowerStart.x, t.lowerEnd.x];

--- a/packages/core/geometry/test/text-quad.test.ts
+++ b/packages/core/geometry/test/text-quad.test.ts
@@ -4,9 +4,14 @@ import {
   normalizeQuad,
   positionalQuad,
   rotate,
+  rotateAbout,
   textQuadBounds,
+  textQuadEdge,
+  textQuadEquals,
   textQuadFromRect,
   textQuadRing,
+  type Point,
+  type PointIn,
   type Quad,
   type TextQuad,
   type TextQuadIn,
@@ -88,5 +93,79 @@ describe('TextQuad', () => {
     const expected: TextQuad = turned;
     expect(textQuadBounds(expected).width).toBeCloseTo(4, 6);
     expect(textQuadBounds(expected).height).toBeCloseTo(10, 6);
+  });
+});
+
+describe('textQuadEdge', () => {
+  const cell = textQuadFromRect({ x: 100, y: 200, width: 60, height: 16 });
+
+  test('upright: the side edges ARE the rect sides, ascent corner first', () => {
+    expect(textQuadEdge(cell, 'start')).toEqual([
+      { x: 100, y: 200 },
+      { x: 100, y: 216 },
+    ]);
+    expect(textQuadEdge(cell, 'end')).toEqual([
+      { x: 160, y: 200 },
+      { x: 160, y: 216 },
+    ]);
+  });
+
+  test('length is the INK height, invariant under rotation (the AABB is not)', () => {
+    const len = (e: [Point, Point]) => Math.hypot(e[1].x - e[0].x, e[1].y - e[0].y);
+    expect(len(textQuadEdge(cell, 'start'))).toBeCloseTo(16, 9);
+    for (const deg of [30, 45, 90, 180, 270]) {
+      const turned = applyTextQuad(
+        rotate<'content'>((deg * Math.PI) / 180),
+        cell as TextQuadIn<'content'>,
+      );
+      expect(len(textQuadEdge(turned, 'start'))).toBeCloseTo(16, 9);
+      expect(len(textQuadEdge(turned, 'end'))).toBeCloseTo(16, 9);
+    }
+    // …while the AABB height balloons with tilt — why it cannot size a caret
+    const tilted = applyTextQuad(rotate<'content'>(Math.PI / 4), cell as TextQuadIn<'content'>);
+    expect(textQuadBounds(tilted).height).toBeCloseTo(76 / Math.SQRT2, 6);
+  });
+
+  test('direction carries the text rotation', () => {
+    const angle = (e: [Point, Point]) =>
+      (Math.atan2(e[1].y - e[0].y, e[1].x - e[0].x) * 180) / Math.PI;
+    expect(angle(textQuadEdge(cell, 'start'))).toBeCloseTo(90, 9); // straight down
+    const turned = applyTextQuad(rotate<'content'>(Math.PI / 4), cell as TextQuadIn<'content'>);
+    expect(angle(textQuadEdge(turned, 'start'))).toBeCloseTo(135, 9);
+  });
+
+  test('the two edges are parallel and span the cell', () => {
+    const turned = applyTextQuad(rotate<'content'>(0.7), cell as TextQuadIn<'content'>);
+    const [us, ls] = textQuadEdge(turned, 'start');
+    const [ue, le] = textQuadEdge(turned, 'end');
+    // parallel: the cross product of the two edge vectors vanishes
+    const cross =
+      (ls.x - us.x) * (le.y - ue.y) - (ls.y - us.y) * (le.x - ue.x);
+    expect(cross).toBeCloseTo(0, 9);
+    // and they are the advance-width apart
+    expect(Math.hypot(ue.x - us.x, ue.y - us.y)).toBeCloseTo(60, 9);
+  });
+});
+
+describe('textQuadEquals', () => {
+  const cell = textQuadFromRect({ x: 100, y: 200, width: 60, height: 16 });
+
+  test('identical corners are equal; any moved corner is not', () => {
+    expect(textQuadEquals(cell, textQuadFromRect({ x: 100, y: 200, width: 60, height: 16 }))).toBe(
+      true,
+    );
+    expect(textQuadEquals(cell, { ...cell, lowerEnd: { x: 161, y: 216 } })).toBe(false);
+  });
+
+  test('a rotation-in-place with a near-identical AABB still reads as a change', () => {
+    // rotate about the cell centre: the AABB stays centred (and for a square
+    // cell would be IDENTICAL) while every corner moves — the case handle
+    // re-rendering must catch
+    const c = { x: 130, y: 208 };
+    const turned = applyTextQuad(
+      rotateAbout<'content'>(c as PointIn<'content'>, Math.PI / 6),
+      cell as TextQuadIn<'content'>,
+    );
+    expect(textQuadEquals(cell, turned)).toBe(false);
   });
 });

--- a/packages/framework/react/src/selection.tsx
+++ b/packages/framework/react/src/selection.tsx
@@ -17,13 +17,27 @@ export * from '@embedpdf/plugin-selection';
 // re-exported here so app code has one import for the whole feature.
 export { copySelection } from '@embedpdf/web';
 import * as React from 'react';
-import { useEffect, useRef, useState } from 'react';
-import type { Rect } from '@embedpdf/core-geometry';
-import type { CapabilityToken, PageObjectNumber } from '@embedpdf/core';
-import { SelectionToken, type SelectionMenuAnchor } from '@embedpdf/plugin-selection';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { textQuadEquals } from '@embedpdf/core-geometry';
+import type { CapabilityToken } from '@embedpdf/core';
+import {
+  HANDLE_BAR,
+  HANDLE_HEAD,
+  HANDLE_PAD,
+  SelectionToken,
+  createSelectionHandleDrag,
+  selectionHandleGeom,
+  type SelectionHandleEndpoint,
+  type SelectionHandleView,
+  type SelectionMenuAnchor,
+} from '@embedpdf/plugin-selection';
 import { SelectionToken as SelectionHostToken } from '@embedpdf/plugin-selection/internal';
 import { StageToken, type StageCapability } from '@embedpdf/plugin-stage';
-import { wireSelectionClipboard, type SelectionClipboardOptions } from '@embedpdf/web';
+import {
+  attachSelectionHandle,
+  wireSelectionClipboard,
+  type SelectionClipboardOptions,
+} from '@embedpdf/web';
 import { Anchored, type AnchoredPlacement } from './anchored';
 import {
   shallowArray,
@@ -142,20 +156,18 @@ export function SelectionMenu({ children, gap = 8, placement = 'top' }: Selectio
 }
 
 // ── selection handles (the touch affordance) ────────────────────────────────
+//
+// Policy lives out of this file, per the layering razor: the geometry and the
+// drag session are `@embedpdf/plugin-selection`'s pure `handles` module (one
+// source for every adapter), the native listener mechanics are
+// `@embedpdf/web`'s `attachSelectionHandle` (the down-shield timing subtlety
+// lives ONCE), and this component keeps what only React can do —
+// subscriptions, markup, theming.
 
-interface Endpoint {
-  pon: PageObjectNumber;
-  rect: Rect;
-  /** Reading direction of the boundary glyph's segment (+1 = the frame's +x)
-   *  — decides which side of the glyph is the selection's leading edge. */
-  advance: 1 | -1;
-}
 interface Endpoints {
-  start: Endpoint;
-  end: Endpoint;
+  start: SelectionHandleEndpoint;
+  end: SelectionHandleEndpoint;
 }
-const sameRect = (a: Rect, b: Rect) =>
-  a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height;
 const sameEndpoints = (a: Endpoints | null, b: Endpoints | null): boolean => {
   if (a === b) return true;
   if (!a || !b) return false;
@@ -164,64 +176,24 @@ const sameEndpoints = (a: Endpoints | null, b: Endpoints | null): boolean => {
     a.end.pon === b.end.pon &&
     a.start.advance === b.start.advance &&
     a.end.advance === b.end.advance &&
-    sameRect(a.start.rect, b.start.rect) &&
-    sameRect(a.end.rect, b.end.rect)
+    // corner-wise, so a boundary that ROTATES without moving its bounding box
+    // still re-renders (an AABB comparison would call that "unchanged")
+    textQuadEquals(a.start.glyphQuad, b.start.glyphQuad) &&
+    textQuadEquals(a.end.glyphQuad, b.end.glyphQuad)
   );
 };
 
-// The iOS caret-handle geometry: a thin BAR that *is* the selection's edge —
-// spanning the boundary line's full (projected) height, flush at the start /
-// end of the highlight — capped by a circle above (start) or below (end). The
-// bar scales with zoom like the text; the head stays screen-constant.
-const HANDLE_HEAD = 12; // px — the circle
-const HANDLE_BAR = 2; // px — the caret bar
-const HANDLE_PAD = 14; // px — invisible finger padding around the visual
-
-/**
- * The handle's event shell. The pointer-DOWN shield must be a NATIVE listener:
- * the stage's gesture controller listens natively on the container, so a
- * React-synthetic stopPropagation (which runs at the React root, after the
- * container) would be too late — the controller would already be panning
- * underneath the handle drag. (This is the same shield `<Anchored>` installs
- * for menus.) Once the down is captured here, the real pointer retargets to
- * this element, so the move/up handlers can stay ordinary props.
- */
-function HandleShell({
-  style,
-  onDown,
-  onPointerMove,
-  onPointerUp,
-  children,
-}: {
-  style: React.CSSProperties;
-  onDown: (e: PointerEvent) => void;
-  onPointerMove: (e: React.PointerEvent) => void;
-  onPointerUp: (e: React.PointerEvent) => void;
-  children: React.ReactNode;
-}) {
-  const ref = useRef<HTMLDivElement>(null);
-  const downRef = useRef(onDown);
-  downRef.current = onDown;
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const down = (e: PointerEvent) => downRef.current(e);
-    el.addEventListener('pointerdown', down);
-    return () => el.removeEventListener('pointerdown', down);
-  }, []);
-  return (
-    <div
-      ref={ref}
-      style={style}
-      onPointerMove={onPointerMove}
-      onPointerUp={onPointerUp}
-      onPointerCancel={onPointerUp}
-    >
-      {children}
-    </div>
-  );
-}
-const rectCenter = (r: Rect) => ({ x: r.x + r.width / 2, y: r.y + r.height / 2 });
+/** The plugin's structural view over this Stage: point-exact projection in,
+ *  page resolution out. (`pageRectToScreen` is the AABB projector — upright
+ *  overlays only — and would collapse exactly the orientation handles need.) */
+const handleView = (stage: StageCapability): SelectionHandleView => ({
+  toOverlay: (pon, pt) => {
+    const world = stage.pageToWorld(pon, pt);
+    return world ? stage.toScreen(world) : null;
+  },
+  pageAt: (overlay) => stage.pageAt(overlay),
+  pointOnPage: (pon, overlay) => stage.pointOnPage(pon, overlay),
+});
 
 export interface SelectionHandlesProps {
   /** Handle colour (default: the selection blue). */
@@ -232,20 +204,19 @@ export interface SelectionHandlesProps {
 
 /**
  * iOS-style draggable selection handles. Each is drawn the way the platform
- * draws them: a thin caret BAR that forms the selection's own start/end edge,
- * spanning that line's height and scaling with zoom, capped by a
- * screen-constant circle — above the first line at the start, below the last
- * line at the end. Connected to the highlight, never floating beside it.
+ * draws them: a thin caret BAR that forms the selection's own start/end edge
+ * — the boundary glyph's oriented edge, so rotated text and rotated pages
+ * carry the handle with them — capped by a screen-constant circle, above the
+ * first line at the start, below the last line at the end.
  *
  * On touch, where a caret drag isn't available, the handles ARE the way to
  * grow or shrink a selection: a long-press selects a word, then each handle
- * extends from the OPPOSITE endpoint (drag the end handle and the start stays
- * anchored, and vice versa), snapping to glyphs and crossing pages exactly
- * like a pointer drag — it rides the same `beginAt`/`extendTo` gesture path,
- * so highlights, menus, and commit signals all behave identically. Mount in
- * the `<Stage>` overlay slot next to `<SelectionMenu>`; outside a Stage it
- * renders nothing (a `PageView` has no camera to project through).
- * Pointer-isolated, so grabbing a handle never pans the stage.
+ * extends from the OPPOSITE endpoint, snapping to glyphs and crossing pages
+ * exactly like a pointer drag — it rides the same `beginAt`/`extendTo`
+ * gesture path, so highlights, menus, and commit signals all behave
+ * identically. Mount in the `<Stage>` overlay slot next to `<SelectionMenu>`;
+ * outside a Stage it renders nothing (a `PageView` has no camera to project
+ * through). Pointer-isolated, so grabbing a handle never pans the stage.
  */
 export function SelectionHandles({ color = '#2196f3', token = StageToken }: SelectionHandlesProps) {
   const host = useCapability(SelectionHostToken);
@@ -258,134 +229,122 @@ export function SelectionHandles({ color = '#2196f3', token = StageToken }: Sele
       const s = c.snapshot();
       if (!s.start || !s.end) return null;
       return {
-        start: { pon: s.start.pon, rect: s.start.rect, advance: s.start.advance },
-        end: { pon: s.end.pon, rect: s.end.rect, advance: s.end.advance },
+        start: { pon: s.start.pon, glyphQuad: s.start.glyphQuad, advance: s.start.advance },
+        end: { pon: s.end.pon, glyphQuad: s.end.glyphQuad, advance: s.end.advance },
       };
     },
     sameEndpoints,
   );
-  // The handles are positioned by PROJECTING the endpoint rects through the
+  // The handles are positioned by PROJECTING the endpoint corners through the
   // camera, so they must re-render whenever the camera moves — visiblePages is
   // the stage's reference-stable revision for exactly that (the same value the
   // page surfaces re-render on, so handle and highlight move in one commit).
   useKernelValue(() => stage?.visiblePages() ?? null);
   const [dragging, setDragging] = useState<'start' | 'end' | null>(null);
-  const drag = useRef<{
-    baseVpt: { x: number; y: number };
-    baseClient: { x: number; y: number };
-    anchorPon: PageObjectNumber;
-    anchorPoint: { x: number; y: number };
-    begun: boolean;
-    lastPon: PageObjectNumber;
-  } | null>(null);
+  // The web binder's `arm` must read the CURRENT endpoints/stage at pointer
+  // down, not the ones captured when the listener attached — a stable ref
+  // callback with a live arm-source is the standard escape from that.
+  const armSource = useRef<{ stage: StageCapability; endpoints: Endpoints } | null>(null);
+  armSource.current = stage && endpoints ? { stage, endpoints } : null;
+  const bindHandle = useMemo(() => {
+    const detach: Partial<Record<'start' | 'end', () => void>> = {};
+    const make = (role: 'start' | 'end') => (el: HTMLDivElement | null) => {
+      detach[role]?.();
+      delete detach[role];
+      if (!el) return;
+      detach[role] = attachSelectionHandle(el, {
+        arm: () => {
+          const src = armSource.current;
+          if (!src) return null;
+          const view = handleView(src.stage);
+          const geom = selectionHandleGeom(view, src.endpoints[role], role);
+          if (!geom) return null;
+          const opposite = src.endpoints[role === 'start' ? 'end' : 'start'];
+          const drag = createSelectionHandleDrag(
+            host,
+            view,
+            opposite,
+            src.endpoints[role].pon,
+          );
+          setDragging(role);
+          return {
+            // the point the user grabbed: the bar's midpoint
+            base: {
+              x: (geom.bar.from.x + geom.bar.to.x) / 2,
+              y: (geom.bar.from.y + geom.bar.to.y) / 2,
+            },
+            session: {
+              move: drag.move,
+              end: () => {
+                drag.end(); // settle → menu reappears, onCommit fires
+                setDragging(null);
+              },
+            },
+          };
+        },
+      });
+    };
+    return { start: make('start'), end: make('end') };
+  }, [host]);
 
   if (!stage || !endpoints || !visible) return null;
   // Hidden while a pointer drag-select is in flight (like the menu) — but a
   // HANDLE drag is itself a selection gesture, so it keeps its handles.
   if (selecting && !dragging) return null;
-
-  const startDrag = (role: 'start' | 'end') => (e: PointerEvent) => {
-    const dragged = endpoints[role];
-    const opposite = endpoints[role === 'start' ? 'end' : 'start'];
-    const screen = stage.pageRectToScreen(dragged.pon, dragged.rect);
-    if (!screen) return;
-    e.preventDefault();
-    e.stopPropagation(); // native: fires BEFORE the stage controller's listener
-    try {
-      (e.currentTarget as Element).setPointerCapture(e.pointerId);
-    } catch {
-      // best-effort, like the scrollbar: an already-released pointer (pen/touch
-      // races, synthetic events in tests) throws — the drag must still arm.
-    }
-    drag.current = {
-      // Track by DELTAS from the endpoint's own screen position — no DOM
-      // geometry reads, and client↔viewport conversion cancels out.
-      baseVpt: { x: screen.x + screen.width / 2, y: screen.y + screen.height / 2 },
-      baseClient: { x: e.clientX, y: e.clientY },
-      anchorPon: opposite.pon,
-      anchorPoint: rectCenter(opposite.rect),
-      begun: false,
-      lastPon: dragged.pon,
-    };
-    setDragging(role);
-  };
-  const moveDrag = (e: React.PointerEvent) => {
-    const d = drag.current;
-    if (!d) return;
-    const vpt = {
-      x: d.baseVpt.x + (e.clientX - d.baseClient.x),
-      y: d.baseVpt.y + (e.clientY - d.baseClient.y),
-    };
-    if (!d.begun) {
-      // Re-root the drag gesture at the FIXED endpoint; every move then
-      // extends toward the finger — the pointer-drag path, re-anchored.
-      if (!host.beginAt(d.anchorPon, d.anchorPoint)) return;
-      d.begun = true;
-    }
-    const hit = stage.pageAt(vpt);
-    if (hit) {
-      d.lastPon = hit.pon;
-      host.extendTo(hit.pon, hit.point);
-    } else {
-      // Over a gap: project onto the last page's plane (unclamped) so the
-      // selection keeps tracking instead of freezing at the page edge.
-      const p = stage.pointOnPage(d.lastPon, vpt);
-      if (p) host.extendTo(d.lastPon, p);
-    }
-  };
-  const endDrag = () => {
-    if (!drag.current) return;
-    const begun = drag.current.begun;
-    drag.current = null;
-    setDragging(null);
-    if (begun) host.end(); // settle → menu reappears, onCommit fires
-  };
+  const view = handleView(stage);
 
   const renderHandle = (role: 'start' | 'end') => {
-    const ep = endpoints[role];
-    // Overlay space: the stage container's px — the same space Anchored uses.
-    const r = stage.pageRectToScreen(ep.pon, ep.rect);
-    if (!r) return null; // endpoint page not laid out right now
-    // The selection's edge at this endpoint: the boundary glyph's LEADING side
-    // at the start, TRAILING side at the end — mirrored for an RTL segment.
-    const leading = role === 'start' ? ep.advance > 0 : ep.advance < 0;
-    const edgeX = leading ? r.x : r.x + r.width;
-    const visualTop = role === 'start' ? r.y - HANDLE_HEAD : r.y;
+    const geom = selectionHandleGeom(view, endpoints[role], role);
+    if (!geom) return null; // endpoint page not laid out right now
+    // The shell is laid out UPRIGHT in its own frame — bar of the edge's
+    // length, head stacked above (start) or below (end) — then rotated onto
+    // the projected edge. The pivot is the bar's ascent-side tip, the one
+    // point that must land exactly on the glyph corner.
+    const barTop = HANDLE_PAD + (role === 'start' ? HANDLE_HEAD : 0);
+    const pivotX = HANDLE_PAD + HANDLE_BAR / 2;
     return (
-      <HandleShell
+      <div
         key={role}
-        onDown={startDrag(role)}
-        onPointerMove={moveDrag}
-        onPointerUp={endDrag}
+        ref={bindHandle[role]}
         style={{
           position: 'absolute',
-          left: edgeX - HANDLE_BAR / 2 - HANDLE_PAD,
-          top: visualTop - HANDLE_PAD,
+          left: geom.bar.from.x - pivotX,
+          top: geom.bar.from.y - barTop,
           width: HANDLE_BAR + 2 * HANDLE_PAD,
-          height: r.height + HANDLE_HEAD + 2 * HANDLE_PAD,
+          height: geom.length + HANDLE_HEAD + 2 * HANDLE_PAD,
+          // Upright text carries NO transform — pixel-identical to an
+          // axis-aligned box (the geometry's float-noise guard decides).
+          ...(geom.upright
+            ? null
+            : {
+                transform: `rotate(${geom.rotation}deg)`,
+                transformOrigin: `${pivotX}px ${barTop}px`,
+              }),
           touchAction: 'none',
           cursor: 'grab',
           pointerEvents: 'auto',
         }}
       >
-        {/* the caret bar — the selection's own edge, spanning the line height */}
+        {/* the caret bar — the selection's own edge, spanning the glyph's ink
+            height (which is why it stays the text's height at any tilt) */}
         <div
           style={{
             position: 'absolute',
             left: HANDLE_PAD,
-            top: HANDLE_PAD + (role === 'start' ? HANDLE_HEAD : 0),
+            top: barTop,
             width: HANDLE_BAR,
-            height: r.height,
+            height: geom.length,
             background: color,
             borderRadius: HANDLE_BAR / 2,
           }}
         />
-        {/* the head — flush against the bar: above the first line / below the last */}
+        {/* the head — flush against the bar, beyond the ascent at the start and
+            past the baseline at the end, in the TEXT's frame */}
         <div
           style={{
             position: 'absolute',
-            left: HANDLE_PAD + HANDLE_BAR / 2 - HANDLE_HEAD / 2,
-            top: role === 'start' ? HANDLE_PAD : HANDLE_PAD + r.height,
+            left: pivotX - HANDLE_HEAD / 2,
+            top: role === 'start' ? HANDLE_PAD : HANDLE_PAD + geom.length,
             width: HANDLE_HEAD,
             height: HANDLE_HEAD,
             borderRadius: '50%',
@@ -393,7 +352,7 @@ export function SelectionHandles({ color = '#2196f3', token = StageToken }: Sele
             boxShadow: '0 1px 4px rgba(0, 0, 0, 0.35)',
           }}
         />
-      </HandleShell>
+      </div>
     );
   };
 
@@ -404,6 +363,7 @@ export function SelectionHandles({ color = '#2196f3', token = StageToken }: Sele
     </>
   );
 }
+
 
 export type SelectionClipboardProps = Pick<SelectionClipboardOptions, 'prefetch'>;
 

--- a/packages/framework/web/src/index.ts
+++ b/packages/framework/web/src/index.ts
@@ -39,6 +39,8 @@ export type {
   StagePointerKind,
   StageWheelSample,
 } from './stage-gestures';
+export { attachSelectionHandle } from './selection-handles';
+export type { AttachSelectionHandleOptions, SelectionHandleSession } from './selection-handles';
 export { createStageSurface } from './stage-surface';
 export type {
   StageSurfaceHost,

--- a/packages/framework/web/src/selection-handles.test.ts
+++ b/packages/framework/web/src/selection-handles.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import { attachSelectionHandle } from './selection-handles';
+import type { SelectionHandleSession } from './selection-handles';
+
+// Fake element (the repo's no-jsdom pattern): listeners captured and fired by
+// hand, so the shield, capture tolerance, delta mapping, and teardown are all
+// assertable.
+
+function harness(armResult: () => { base: { x: number; y: number }; session: SelectionHandleSession } | null) {
+  const listeners = new Map<string, (e: unknown) => void>();
+  const captured: number[] = [];
+  const el = {
+    addEventListener: (t: string, fn: (e: unknown) => void) => listeners.set(t, fn),
+    removeEventListener: (t: string) => listeners.delete(t),
+    setPointerCapture: (id: number) => captured.push(id),
+  } as unknown as HTMLElement;
+  const arm = vi.fn(armResult);
+  const detach = attachSelectionHandle(el, { arm });
+  const fire = (type: string, e: Record<string, unknown>) =>
+    listeners.get(type)?.({ preventDefault: vi.fn(), stopPropagation: vi.fn(), ...e });
+  return { listeners, captured, arm, detach, fire };
+}
+
+const session = () => ({ move: vi.fn(), end: vi.fn() });
+
+describe('attachSelectionHandle', () => {
+  it('down arms, shields natively, captures; moves map client deltas from the base', () => {
+    const s = session();
+    const h = harness(() => ({ base: { x: 500, y: 300 }, session: s }));
+    const down = { pointerId: 4, clientX: 1000, clientY: 800, preventDefault: vi.fn(), stopPropagation: vi.fn() };
+    h.listeners.get('pointerdown')!(down);
+    expect(down.stopPropagation).toHaveBeenCalled(); // the stage never sees it
+    expect(down.preventDefault).toHaveBeenCalled();
+    expect(h.captured).toEqual([4]);
+    h.fire('pointermove', { pointerId: 4, clientX: 1030, clientY: 790 });
+    expect(s.move).toHaveBeenCalledWith({ x: 530, y: 290 }); // base + delta
+    h.fire('pointermove', { pointerId: 9, clientX: 0, clientY: 0 }); // foreign pointer
+    expect(s.move).toHaveBeenCalledTimes(1);
+    h.fire('pointerup', { pointerId: 4, clientX: 1030, clientY: 790 });
+    expect(s.end).toHaveBeenCalledTimes(1);
+    h.fire('pointermove', { pointerId: 4, clientX: 2000, clientY: 2000 });
+    expect(s.move).toHaveBeenCalledTimes(1); // drag closed
+  });
+
+  it('declined arm: nothing captured, nothing shielded, nothing moves', () => {
+    const h = harness(() => null);
+    const down = { pointerId: 4, clientX: 0, clientY: 0, preventDefault: vi.fn(), stopPropagation: vi.fn() };
+    h.listeners.get('pointerdown')!(down);
+    expect(down.stopPropagation).not.toHaveBeenCalled(); // press falls through
+    expect(h.captured).toEqual([]);
+    h.fire('pointermove', { pointerId: 4, clientX: 10, clientY: 10 });
+    expect(h.arm).toHaveBeenCalledTimes(1);
+  });
+
+  it('a throwing setPointerCapture still arms the drag (the scrollbar precedent)', () => {
+    const s = session();
+    const listeners = new Map<string, (e: unknown) => void>();
+    const el = {
+      addEventListener: (t: string, fn: (e: unknown) => void) => listeners.set(t, fn),
+      removeEventListener: (t: string) => listeners.delete(t),
+      setPointerCapture: () => {
+        throw new Error('released pointer');
+      },
+    } as unknown as HTMLElement;
+    attachSelectionHandle(el, { arm: () => ({ base: { x: 0, y: 0 }, session: s }) });
+    listeners.get('pointerdown')!({
+      pointerId: 1, clientX: 0, clientY: 0, preventDefault: vi.fn(), stopPropagation: vi.fn(),
+    });
+    listeners.get('pointermove')!({ pointerId: 1, clientX: 5, clientY: 5 });
+    expect(s.move).toHaveBeenCalledWith({ x: 5, y: 5 });
+  });
+
+  it('pointercancel settles like a release, and detach removes every listener', () => {
+    const s = session();
+    const h = harness(() => ({ base: { x: 0, y: 0 }, session: s }));
+    h.fire('pointerdown', { pointerId: 2, clientX: 0, clientY: 0 });
+    h.fire('pointercancel', { pointerId: 2 });
+    expect(s.end).toHaveBeenCalledTimes(1);
+    h.detach();
+    expect(h.listeners.size).toBe(0);
+  });
+});

--- a/packages/framework/web/src/selection-handles.ts
+++ b/packages/framework/web/src/selection-handles.ts
@@ -1,0 +1,99 @@
+/**
+ * Selection-handle DOM binding — the listener mechanics of dragging one
+ * handle element, shared by every framework adapter (the policy — geometry
+ * and the drag session — lives in `@embedpdf/plugin-selection`'s pure
+ * `handles` module; this file never imports it, per the layering law:
+ * structural interfaces only).
+ *
+ * The load-bearing subtlety this module owns: the pointer-DOWN shield must be
+ * a NATIVE listener. The stage's gesture controller listens natively on the
+ * container, so a framework-synthetic stopPropagation (React runs its
+ * handlers at the root, AFTER the container's native ones) would be too late
+ * — the stage would already be panning underneath the handle drag. Once the
+ * down is captured here, movement tracks by CLIENT DELTAS from the handle's
+ * own base point: no DOM geometry reads, and the client↔overlay conversion
+ * cancels out.
+ */
+
+interface SurfacePoint {
+  x: number;
+  y: number;
+}
+
+/** The armed drag the adapter hands back — plugin-selection's
+ *  `SelectionHandleDragSession` satisfies it. */
+export interface SelectionHandleSession {
+  move(overlay: SurfacePoint): void;
+  end(): void;
+}
+
+export interface AttachSelectionHandleOptions {
+  /**
+   * Called at pointer-down to arm a drag: return the drag session plus the
+   * handle's current BASE point in overlay space (the bar's midpoint — the
+   * point the user grabbed). Return null to decline (endpoint vanished, page
+   * not laid out) — the press then does nothing and nothing is captured.
+   */
+  arm(): { base: SurfacePoint; session: SelectionHandleSession } | null;
+}
+
+/** Bind one handle element. Returns the detach fn. */
+export function attachSelectionHandle(
+  el: HTMLElement,
+  options: AttachSelectionHandleOptions,
+): () => void {
+  let active: {
+    session: SelectionHandleSession;
+    base: SurfacePoint;
+    baseClient: SurfacePoint;
+    pointerId: number;
+  } | null = null;
+
+  const onMove = (e: PointerEvent) => {
+    if (!active || e.pointerId !== active.pointerId) return;
+    active.session.move({
+      x: active.base.x + (e.clientX - active.baseClient.x),
+      y: active.base.y + (e.clientY - active.baseClient.y),
+    });
+  };
+  // Release and system-cancel settle identically: the selection's own commit
+  // semantics live in the session; there is no half-state to revert here.
+  const onUp = (e: PointerEvent) => {
+    if (!active || e.pointerId !== active.pointerId) return;
+    const s = active.session;
+    active = null;
+    s.end();
+  };
+  const onDown = (e: PointerEvent) => {
+    if (active) return;
+    const armed = options.arm();
+    if (!armed) return;
+    e.preventDefault();
+    e.stopPropagation(); // native: fires BEFORE the stage controller's listener
+    try {
+      el.setPointerCapture(e.pointerId);
+    } catch {
+      // best-effort, like the scrollbar: an already-released pointer
+      // (pen/touch races, synthetic events in tests) throws — the drag must
+      // still arm, and the window-less capture path still delivers to `el`.
+    }
+    active = {
+      session: armed.session,
+      base: armed.base,
+      baseClient: { x: e.clientX, y: e.clientY },
+      pointerId: e.pointerId,
+    };
+  };
+
+  el.addEventListener('pointerdown', onDown);
+  el.addEventListener('pointermove', onMove);
+  el.addEventListener('pointerup', onUp);
+  el.addEventListener('pointercancel', onUp);
+  return () => {
+    el.removeEventListener('pointerdown', onDown);
+    el.removeEventListener('pointermove', onMove);
+    el.removeEventListener('pointerup', onUp);
+    el.removeEventListener('pointercancel', onUp);
+    active = null;
+  };
+}

--- a/packages/plugin/selection/src/handles.test.ts
+++ b/packages/plugin/selection/src/handles.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Handle policy against a fake view — the rotation coverage the React-bound
+ * version could never have: geometry at every quarter turn plus 45°, RTL edge
+ * choice, and the drag session's re-root/gap/commit rules.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { textQuadFromRect } from '@embedpdf/core-geometry';
+import type { Point, TextQuad } from '@embedpdf/core-geometry';
+import {
+  HANDLE_HEAD,
+  createSelectionHandleDrag,
+  selectionHandleGeom,
+} from './handles';
+import type { SelectionHandleEndpoint, SelectionHandleView } from './handles';
+
+const rotQuad = (q: TextQuad, deg: number, px: number, py: number): TextQuad => {
+  const r = (deg * Math.PI) / 180;
+  const c = Math.cos(r);
+  const s = Math.sin(r);
+  const m = (p: Point) => ({
+    x: px + (p.x - px) * c - (p.y - py) * s,
+    y: py + (p.x - px) * s + (p.y - py) * c,
+  });
+  return {
+    upperStart: m(q.upperStart),
+    upperEnd: m(q.upperEnd),
+    lowerStart: m(q.lowerStart),
+    lowerEnd: m(q.lowerEnd),
+  };
+};
+
+/** Identity projection with a zoom factor — page space IS overlay space × zoom. */
+const view = (zoom = 1): SelectionHandleView => ({
+  toOverlay: (_pon, pt) => ({ x: pt.x * zoom, y: pt.y * zoom }),
+  pageAt: () => null,
+  pointOnPage: () => null,
+});
+
+const CELL = textQuadFromRect({ x: 100, y: 200, width: 60, height: 16 });
+const ep = (glyphQuad: TextQuad, advance: 1 | -1 = 1): SelectionHandleEndpoint => ({
+  pon: 7,
+  glyphQuad,
+  advance,
+});
+
+describe('selectionHandleGeom', () => {
+  it('upright: bar IS the rect side, marked upright, head stacked beyond it', () => {
+    const start = selectionHandleGeom(view(), ep(CELL), 'start')!;
+    expect(start.bar.from).toEqual({ x: 100, y: 200 }); // ascent corner first
+    expect(start.bar.to).toEqual({ x: 100, y: 216 });
+    expect(start.length).toBeCloseTo(16, 9);
+    expect(start.rotation).toBeCloseTo(0, 9);
+    expect(start.upright).toBe(true);
+    expect(start.head).toEqual({ x: 100, y: 200 - HANDLE_HEAD / 2 }); // above the ascent
+    const end = selectionHandleGeom(view(), ep(CELL), 'end')!;
+    expect(end.bar.from).toEqual({ x: 160, y: 200 });
+    expect(end.head).toEqual({ x: 160, y: 216 + HANDLE_HEAD / 2 }); // past the baseline
+  });
+
+  it('bar length is the INK height at every rotation — never the AABB height', () => {
+    for (const deg of [30, 45, 90, 180, 270]) {
+      const g = selectionHandleGeom(view(), ep(rotQuad(CELL, deg, 100, 200)), 'start')!;
+      expect(g.length).toBeCloseTo(16, 6);
+      expect(g.upright).toBe(false);
+      // the bar's screen angle tracks the text's tilt exactly
+      expect(((g.rotation % 360) + 360) % 360).toBeCloseTo(deg % 360, 6);
+    }
+  });
+
+  it('zoom scales the projected geometry with no extra factor', () => {
+    const g = selectionHandleGeom(view(2.5), ep(rotQuad(CELL, 45, 100, 200)), 'start')!;
+    expect(g.length).toBeCloseTo(40, 6); // 16 × 2.5
+  });
+
+  it('RTL: the LEADING edge mirrors — start takes the end-side edge', () => {
+    const ltr = selectionHandleGeom(view(), ep(CELL, 1), 'start')!;
+    const rtl = selectionHandleGeom(view(), ep(CELL, -1), 'start')!;
+    expect(ltr.bar.from.x).toBeCloseTo(100, 9);
+    expect(rtl.bar.from.x).toBeCloseTo(160, 9); // the cell's end side
+    // …and the same mirroring under rotation
+    const rtl45 = selectionHandleGeom(view(), ep(rotQuad(CELL, 45, 100, 200), -1), 'start')!;
+    expect(rtl45.length).toBeCloseTo(16, 6);
+  });
+
+  it('null when the page is not laid out or the cell is degenerate', () => {
+    const dead: SelectionHandleView = { ...view(), toOverlay: () => null };
+    expect(selectionHandleGeom(dead, ep(CELL), 'start')).toBeNull();
+    const flat = textQuadFromRect({ x: 0, y: 0, width: 10, height: 0 });
+    expect(selectionHandleGeom(view(), ep(flat), 'start')).toBeNull();
+  });
+});
+
+describe('createSelectionHandleDrag', () => {
+  const target = () => ({
+    beginAt: vi.fn(() => true),
+    extendTo: vi.fn(),
+    end: vi.fn(),
+  });
+
+  it('re-roots ONCE at the opposite cell centre, then extends toward the pointer', () => {
+    const t = target();
+    const v: SelectionHandleView = {
+      ...view(),
+      pageAt: (o) => ({ pon: 9, point: { x: o.x, y: o.y } }),
+    };
+    const session = createSelectionHandleDrag(t, v, ep(CELL), 7);
+    session.move({ x: 300, y: 400 });
+    session.move({ x: 310, y: 410 });
+    expect(t.beginAt).toHaveBeenCalledTimes(1);
+    expect(t.beginAt).toHaveBeenCalledWith(7, { x: 130, y: 208 }); // the cell centre
+    expect(t.extendTo).toHaveBeenNthCalledWith(1, 9, { x: 300, y: 400 });
+    expect(t.extendTo).toHaveBeenNthCalledWith(2, 9, { x: 310, y: 410 });
+    session.end();
+    expect(t.end).toHaveBeenCalledTimes(1);
+  });
+
+  it('the re-root anchor stays inside a ROTATED opposite glyph (cell centre, not AABB corner)', () => {
+    const t = target();
+    const v: SelectionHandleView = { ...view(), pageAt: (o) => ({ pon: 9, point: o }) };
+    const session = createSelectionHandleDrag(t, v, ep(rotQuad(CELL, 45, 100, 200)), 7);
+    session.move({ x: 0, y: 0 });
+    const [, anchor] = t.beginAt.mock.calls[0]!;
+    // the centre of the rotated cell = the upright centre rotated about the pivot
+    const r = Math.PI / 4;
+    const cx = 100 + (130 - 100) * Math.cos(r) - (208 - 200) * Math.sin(r);
+    const cy = 200 + (130 - 100) * Math.sin(r) + (208 - 200) * Math.cos(r);
+    expect(anchor.x).toBeCloseTo(cx, 9);
+    expect(anchor.y).toBeCloseTo(cy, 9);
+  });
+
+  it('over a gap, projects onto the LAST page hit so the selection keeps tracking', () => {
+    const t = target();
+    const v: SelectionHandleView = {
+      toOverlay: (_p, pt) => pt,
+      pageAt: vi
+        .fn<(o: Point) => { pon: number; point: Point } | null>()
+        .mockReturnValueOnce({ pon: 9, point: { x: 1, y: 2 } })
+        .mockReturnValue(null),
+      pointOnPage: (pon, o) => ({ x: o.x + pon, y: o.y }),
+    };
+    const session = createSelectionHandleDrag(t, v, ep(CELL), 7);
+    session.move({ x: 10, y: 10 }); // hits page 9
+    session.move({ x: 20, y: 20 }); // gap → projects onto page 9's plane
+    expect(t.extendTo).toHaveBeenLastCalledWith(9, { x: 29, y: 20 });
+  });
+
+  it('before any page hit, the gap fallback uses the DRAGGED endpoint page', () => {
+    const t = target();
+    const v: SelectionHandleView = {
+      toOverlay: (_p, pt) => pt,
+      pageAt: () => null,
+      pointOnPage: (pon, o) => ({ x: o.x + pon, y: o.y }),
+    };
+    const session = createSelectionHandleDrag(t, v, ep(CELL), 7);
+    session.move({ x: 5, y: 5 });
+    expect(t.extendTo).toHaveBeenCalledWith(7, { x: 12, y: 5 });
+  });
+
+  it('a refused re-root arms nothing; end() without arming settles nothing', () => {
+    const t = { beginAt: vi.fn(() => false), extendTo: vi.fn(), end: vi.fn() };
+    const v: SelectionHandleView = { ...view(), pageAt: (o) => ({ pon: 9, point: o }) };
+    const session = createSelectionHandleDrag(t, v, ep(CELL), 7);
+    session.move({ x: 10, y: 10 });
+    expect(t.extendTo).not.toHaveBeenCalled();
+    session.end();
+    expect(t.end).not.toHaveBeenCalled(); // an untouched press commits nothing
+  });
+});

--- a/packages/plugin/selection/src/handles.ts
+++ b/packages/plugin/selection/src/handles.ts
@@ -1,0 +1,160 @@
+/**
+ * Selection handles — the pure policy half (the `wheel.ts` convention).
+ *
+ * A handle IS the boundary glyph's leading (or trailing) edge: a segment
+ * between two corners of the glyph's ORIENTED cell, with the grab head just
+ * beyond the ascent at the start / past the baseline at the end. Bar length,
+ * angle, and head all derive from that one segment, so rotated text and
+ * rotated pages are carried by construction — the AABB never enters.
+ *
+ * Everything here is DOM-free and framework-free: geometry is pure given a
+ * projector, and the drag session speaks the selection's own gesture verbs
+ * (`beginAt`/`extendTo`/`end` — the same ones the pointer handler uses; a
+ * handle drag IS a selection gesture, re-anchored). The framework adapters
+ * keep only subscriptions and markup; the DOM listener mechanics live in
+ * `@embedpdf/web`'s `attachSelectionHandle`.
+ *
+ * The view dependency is STRUCTURAL (satisfied by five lines over
+ * `StageCapability`) so this plugin stays stage-free — selection also runs
+ * in stage-less hosts (`PageView`) — and the math tests run against a fake.
+ */
+import { textQuadEdge } from '@embedpdf/core-geometry';
+import type { Point, TextQuad } from '@embedpdf/core-geometry';
+import type { PageObjectNumber } from '@embedpdf/core';
+
+/** What handle geometry & drags need from the hosting view. */
+export interface SelectionHandleView {
+  /** Page content point → overlay px. Must be POINT-exact (compose
+   *  `pageToWorld` with `toScreen`); an AABB projector loses orientation. */
+  toOverlay(pon: PageObjectNumber, pt: Point): Point | null;
+  /** Overlay px → the page under it, or null over a gap. */
+  pageAt(overlay: Point): { pon: PageObjectNumber; point: Point } | null;
+  /** Overlay px → a SPECIFIC page's content space, unclamped. */
+  pointOnPage(pon: PageObjectNumber, overlay: Point): Point | null;
+}
+
+/** One selection boundary, as the handle needs it (a `SelectionEndpoint` slice). */
+export interface SelectionHandleEndpoint {
+  pon: PageObjectNumber;
+  /** The boundary glyph's own oriented cell, page content space. */
+  glyphQuad: TextQuad;
+  /** Reading direction of its segment (+1 = the frame's +x) — decides which
+   *  side of the cell is the selection's leading edge. */
+  advance: 1 | -1;
+}
+
+/** The gesture verbs a handle drag drives — `SelectionHostCapability` satisfies it. */
+export interface SelectionHandleTarget {
+  beginAt(pon: PageObjectNumber, point: Point): boolean;
+  extendTo(pon: PageObjectNumber, point: Point): void;
+  end(): void;
+}
+
+// The iOS caret-handle design, one source for every adapter: a thin BAR that
+// is the selection's edge, capped by a screen-constant circle; PAD is the
+// invisible finger padding around the visual.
+export const HANDLE_HEAD = 12; // px — the circle
+export const HANDLE_BAR = 2; // px — the caret bar
+export const HANDLE_PAD = 14; // px — grab padding
+
+/** Tilts within ~0.05° of upright render untransformed (float-noise guard —
+ *  and the dominant case stays pixel-identical to an axis-aligned box). */
+const HANDLE_ROT_EPSILON = 0.05;
+
+export interface SelectionHandleGeom {
+  /** The projected edge, ascent corner first, overlay px. */
+  bar: { from: Point; to: Point };
+  /** The glyph's ink height on screen — zoom scaling comes free. */
+  length: number;
+  /** Degrees clockwise; 0 when the text is upright on screen. */
+  rotation: number;
+  /** True within the epsilon of upright: render with NO transform. */
+  upright: boolean;
+  /** Centre of the grab head, overlay px. */
+  head: Point;
+}
+
+const midpoint = (a: Point, b: Point): Point => ({ x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 });
+
+/**
+ * The handle's geometry for one endpoint, in overlay space. Null when the
+ * endpoint's page isn't laid out (or the cell is degenerate) — render nothing.
+ */
+export function selectionHandleGeom(
+  view: SelectionHandleView,
+  ep: SelectionHandleEndpoint,
+  role: 'start' | 'end',
+): SelectionHandleGeom | null {
+  // Which SIDE of the cell is this selection's edge is a reading-order
+  // question (`advance`), never a geometric one.
+  const leading = role === 'start' ? ep.advance > 0 : ep.advance < 0;
+  const [upperPage, lowerPage] = textQuadEdge(ep.glyphQuad, leading ? 'start' : 'end');
+  const upper = view.toOverlay(ep.pon, upperPage);
+  const lower = view.toOverlay(ep.pon, lowerPage);
+  if (!upper || !lower) return null;
+  const dx = lower.x - upper.x;
+  const dy = lower.y - upper.y;
+  const length = Math.hypot(dx, dy);
+  if (length === 0) return null;
+  // 0° when the text is upright: the bar runs straight down the screen.
+  const rotation = (Math.atan2(dy, dx) * 180) / Math.PI - 90;
+  const upright = Math.abs(rotation) < HANDLE_ROT_EPSILON;
+  const ux = dx / length;
+  const uy = dy / length;
+  const head =
+    role === 'start'
+      ? { x: upper.x - (ux * HANDLE_HEAD) / 2, y: upper.y - (uy * HANDLE_HEAD) / 2 }
+      : { x: lower.x + (ux * HANDLE_HEAD) / 2, y: lower.y + (uy * HANDLE_HEAD) / 2 };
+  return { bar: { from: upper, to: lower }, length, rotation, upright, head };
+}
+
+export interface SelectionHandleDragSession {
+  /** Feed the pointer's current overlay position. */
+  move(overlay: Point): void;
+  /** The pointer released (or was cancelled): settle the gesture. */
+  end(): void;
+}
+
+/**
+ * One armed handle drag. Dragging a handle extends from the OPPOSITE
+ * endpoint: the first movement re-roots the selection gesture at that
+ * endpoint's cell centre, and every position then extends toward the pointer
+ * — snapping to glyphs and crossing pages exactly like a pointer drag,
+ * firing the same change/commit signals. Over a gap the point projects onto
+ * the last page hit (unclamped), so the selection keeps tracking instead of
+ * freezing at a page edge. `end()` commits only if the drag actually
+ * re-rooted; an untouched press settles nothing.
+ */
+export function createSelectionHandleDrag(
+  selection: SelectionHandleTarget,
+  view: SelectionHandleView,
+  opposite: SelectionHandleEndpoint,
+  draggedPon: PageObjectNumber,
+): SelectionHandleDragSession {
+  // The fixed anchor: the opposite endpoint's cell CENTRE — orientation-free
+  // (a parallelogram's diagonal midpoints coincide), so it lands inside the
+  // glyph for rotated text too.
+  const q = opposite.glyphQuad;
+  const anchorPoint = midpoint(midpoint(q.upperStart, q.lowerEnd), midpoint(q.upperEnd, q.lowerStart));
+  let begun = false;
+  let lastPon = draggedPon;
+  return {
+    move: (overlay) => {
+      if (!begun) {
+        if (!selection.beginAt(opposite.pon, anchorPoint)) return;
+        begun = true;
+      }
+      const hit = view.pageAt(overlay);
+      if (hit) {
+        lastPon = hit.pon;
+        selection.extendTo(hit.pon, hit.point);
+      } else {
+        const p = view.pointOnPage(lastPon, overlay);
+        if (p) selection.extendTo(lastPon, p);
+      }
+    },
+    end: () => {
+      if (begun) selection.end(); // settle → menu reappears, onCommit fires
+    },
+  };
+}

--- a/packages/plugin/selection/src/index.ts
+++ b/packages/plugin/selection/src/index.ts
@@ -26,6 +26,22 @@ export type {
   TextRange,
 } from './types';
 export type { SelectionSegment } from './geometry';
+// Selection-handle policy (the touch affordance): pure geometry + the drag
+// session, consumed by the framework adapters' handle views.
+export {
+  HANDLE_BAR,
+  HANDLE_HEAD,
+  HANDLE_PAD,
+  createSelectionHandleDrag,
+  selectionHandleGeom,
+} from './handles';
+export type {
+  SelectionHandleDragSession,
+  SelectionHandleEndpoint,
+  SelectionHandleGeom,
+  SelectionHandleTarget,
+  SelectionHandleView,
+} from './handles';
 
 /**
  * The selection capability token, narrowed to the public


### PR DESCRIPTION
Adds orientation-aware text-quad helpers and a shared selection-handle geometry/drag policy across core, plugin, web, and React layers. Handles now follow rotated text and rotated pages, while native pointer shielding and client-delta tracking keep drag behavior reliable and consistent.