### PR TITLE
Scope tile state by view; ladder reset behavior

### DIFF
--- a/.changeset/double-tap-ladder-reset.md
+++ b/.changeset/double-tap-ladder-reset.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-stage': patch
+---
+
+Double-tap from a pinched-in zoom returns to fit-width instead of climbing (the iOS rule). The zoom ladder previously picked "the first posture meaningfully above the current zoom," so a pinch to a level between fit-width and detail made a double-tap zoom IN further. The rule is now: the ladder ascends only from ON a rung (within ±10% of a posture) — a tap at a posture moves to the next, wrapping past the top — while a pinch to any other level is leaving the ladder, and a double-tap there RESETS to the base fit ("take me back to reading"), never a further zoom-in. Everything that already felt right is unchanged: zoomed-out → fit-width, fit-width → detail, detail → fit-width.

--- a/.changeset/tile-view-scoping-plugin-render.md
+++ b/.changeset/tile-view-scoping-plugin-render.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-render': minor
+---
+
+Scope tile state by view and page so multiple views of the same page can plan rasters independently without invalidating each other. Replace the flat tile methods with a reference-stable `render.tilesFor(view)` handle that binds the view identity for planning, paint reporting, and release.

--- a/.changeset/tile-view-scoping-react.md
+++ b/.changeset/tile-view-scoping-react.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/react': patch
+---
+
+Give every Stage lens and standalone `PageView` a stable view identity and use its scoped tile handle. Thumbnail and secondary views can no longer clear the main view's high-resolution tiles.

--- a/packages/framework/react/src/page-view.tsx
+++ b/packages/framework/react/src/page-view.tsx
@@ -10,7 +10,7 @@
  * and clipping-immune.
  */
 import * as React from 'react';
-import { useMemo, useRef } from 'react';
+import { useId, useMemo, useRef } from 'react';
 import { NO_FRAME, pageTransform, type PageFrame } from '@embedpdf/core-geometry';
 import { observeClientGeometry } from '@embedpdf/web';
 import { ProjectorProvider, type ProjectorBinding, type ViewProjector } from './anchored';
@@ -75,12 +75,21 @@ export function PageView({
       }),
     [base?.size.width, base?.size.height, base?.userUnit, rotation, width, dpr],
   );
+  // This instance's VIEW identity: two PageViews of the same page (a compare
+  // strip) must plan rasters independently, like two stage lenses do.
+  const viewId = useId();
   const ctx = useMemo(
     () =>
-      makePageContext(docId ?? '', pon, page, pageFrame, transform, () =>
-        ref.current!.getBoundingClientRect(),
+      makePageContext(
+        docId ?? '',
+        `page-view:${viewId}`,
+        pon,
+        page,
+        pageFrame,
+        transform,
+        () => ref.current!.getBoundingClientRect(),
       ),
-    [docId, pon, page, pageFrame, transform],
+    [docId, pon, page, pageFrame, transform, viewId],
   );
   // The PageView's ViewProjector: no camera, so anchored UI positions by
   // MEASURING the DOM (client space → portal + position:fixed, immune to

--- a/packages/framework/react/src/render.tsx
+++ b/packages/framework/react/src/render.tsx
@@ -140,11 +140,16 @@ function TilePlane({ annotations, fadeMs }: { annotations: boolean; fadeMs: numb
   const demand: PageViewDemand = page.getViewDemand?.() ?? {
     desiredDeviceWidth: page.transform.deviceWidth,
   };
-  const plan = useSelector(RenderToken, (c) =>
-    c.tilePlan(page.pon, demand, { includeAnnotations: annotations }),
+  // THIS view's tile surface: state is per view × page, so a thumbnail
+  // rail's never-engaging demand cannot disturb the main lens's plan (shared
+  // state made the main view lose its tiles whenever a rail opened). The
+  // handle is reference-stable per view — a clean dependency.
+  const tiles = render.tilesFor(page.view);
+  const plan = useSelector(RenderToken, () =>
+    tiles.plan(page.pon, demand, { includeAnnotations: annotations }),
   );
-  // Lens unmounted: stop in-flight tile fetches; resolved bytes stay cached.
-  useEffect(() => () => render.releaseTiles(page.pon), [render, page.pon]);
+  // View unmounted its plane: stop in-flight fetches; resolved bytes stay cached.
+  useEffect(() => () => tiles.release(page.pon), [tiles, page.pon]);
   if (plan.paint.length === 0) return null;
   const t = page.transform;
   const s = t.viewScale;
@@ -181,8 +186,8 @@ function TilePlane({ annotations, fadeMs }: { annotations: boolean; fadeMs: numb
             height: source.rect.height * s,
           }}
           fadeMs={fadeMs}
-          onPainted={() => render.tilePainted(page.pon, source.key)}
-          onUnpainted={() => render.tileUnpainted(page.pon, source.key)}
+          onPainted={() => tiles.painted(page.pon, source.key)}
+          onUnpainted={() => tiles.unpainted(page.pon, source.key)}
         />
       ))}
     </div>

--- a/packages/framework/react/src/runtime.tsx
+++ b/packages/framework/react/src/runtime.tsx
@@ -404,6 +404,15 @@ export interface PageContextValue {
    * a thumbnail-sized demand turns into "never engages" by arithmetic).
    */
   getViewDemand?: () => PageViewDemand;
+  /**
+   * The hosting VIEW's identity — the stage lens id (`stage.lensId()`) or a
+   * per-instance PageView id. IDENTITY, not an option: per-view raster
+   * planning (tiles) keys its state by this, so two views showing the SAME
+   * page never fight over one plan (a thumbnail rail's never-engaging demand
+   * must not disturb the main view's tiles). Every page context host must
+   * say which view it is.
+   */
+  view: string;
 }
 
 const PageCtx = createContext<PageContextValue | null>(null);
@@ -417,6 +426,7 @@ export function usePage(): PageContextValue {
 
 export function makePageContext(
   documentId: string,
+  view: string,
   pon: number,
   pageIndex: number,
   frame: PageFrame,
@@ -426,6 +436,7 @@ export function makePageContext(
 ): PageContextValue {
   return {
     documentId,
+    view,
     pon,
     pageIndex,
     frame,

--- a/packages/framework/react/src/stage.tsx
+++ b/packages/framework/react/src/stage.tsx
@@ -77,6 +77,9 @@ function PageSurface({
     () =>
       makePageContext(
         documentId,
+        // the hosting lens — per-view raster planning keys tile state by it,
+        // so a thumbnail rail and the main view never fight over one plan
+        stage.lensId(),
         page.pon,
         page.pageIndex,
         frame,

--- a/packages/plugin/render/src/capability.ts
+++ b/packages/plugin/render/src/capability.ts
@@ -10,7 +10,13 @@ import { resolveRenderOptions, type ResolvedRenderOptions } from './paint-plan';
 import { RasterStore } from './raster-store';
 import { baseAskWidth, resolveStrategy, type ResolvedStrategy } from './strategy';
 import { TileManager } from './tile-manager';
-import type { RenderAction, RenderCapability, RenderPluginOptions, RenderState } from './types';
+import type {
+  RenderAction,
+  RenderCapability,
+  RenderPluginOptions,
+  RenderState,
+  ViewTiles,
+} from './types';
 
 /**
  * The render capability: the ONE place STRATEGY (plugin options — what the
@@ -129,6 +135,9 @@ export function createRenderCapability(
 
   // Tiling shares THIS store, THIS strategy, THIS ledger — one scheduler,
   // one budget, one invalidation truth.
+  // View-scoped tile handles (see RenderCapability.tilesFor).
+  const viewTiles = new Map<string, ViewTiles>();
+
   const tiles = new TileManager({
     store,
     options: resolved,
@@ -195,17 +204,20 @@ export function createRenderCapability(
       };
     },
     renderPolicy: policy,
-    tilePlan(pon, demand, opts) {
-      return tiles.plan(pon, demand, opts?.includeAnnotations ?? true);
-    },
-    tilePainted(pon, key) {
-      tiles.sourcePainted(pon, key);
-    },
-    tileUnpainted(pon, key) {
-      tiles.sourceUnpainted(pon, key);
-    },
-    releaseTiles(pon) {
-      tiles.releasePage(pon);
+    tilesFor(view) {
+      // One handle per view, reference-stable (a clean hook dependency); the
+      // map lives for the document, like the state it scopes.
+      let handle = viewTiles.get(view);
+      if (!handle) {
+        handle = {
+          plan: (pon, demand, opts) => tiles.plan(view, pon, demand, opts?.includeAnnotations ?? true),
+          painted: (pon, key) => tiles.sourcePainted(view, pon, key),
+          unpainted: (pon, key) => tiles.sourceUnpainted(view, pon, key),
+          release: (pon) => tiles.releasePage(view, pon),
+        };
+        viewTiles.set(view, handle);
+      }
+      return handle;
     },
     renderEpoch(pon, includeAnnotations = true) {
       // The sum of two monotonic counters is itself a valid monotonic version:

--- a/packages/plugin/render/src/render.test.ts
+++ b/packages/plugin/render/src/render.test.ts
@@ -113,6 +113,13 @@ describe('effects + capability wired together', () => {
     };
   }
 
+  it('tilesFor binds the view once: stable per view, distinct across views', () => {
+    const h = harness();
+    const main = h.capability.tilesFor('stage');
+    expect(h.capability.tilesFor('stage')).toBe(main); // reference-stable (hook dep)
+    expect(h.capability.tilesFor('stage-thumbs')).not.toBe(main); // its own state
+  });
+
   it('a confirmed annotation event bumps renderEpoch for that page only', () => {
     const h = harness();
     expect(h.capability.renderEpoch(22)).toBe(0);

--- a/packages/plugin/render/src/tile-manager.test.ts
+++ b/packages/plugin/render/src/tile-manager.test.ts
@@ -34,7 +34,7 @@ function harness(opts?: { policy?: unknown; tiling?: TilesOptions }) {
   let advances = 0;
   let epoch = 0;
 
-  const manager = new TileManager({
+  const raw = new TileManager({
     store,
     // bleed 0 keeps the geometry assertions exact; bleed has its own tests.
     options: resolveRenderOptions({ tiles: { settleMs: 0, bleed: 0, ...opts?.tiling } }),
@@ -61,6 +61,18 @@ function harness(opts?: { policy?: unknown; tiling?: TilesOptions }) {
     },
   });
 
+  // The tests predate the view axis and address one implicit view; this
+  // facade binds it (trailing `view` overrides for multi-view tests) so the
+  // suite exercises the REAL required-view API through one seam.
+  const manager = {
+    plan: (pon: number, demand: Parameters<TileManager['plan']>[2], ann: boolean, view = 'test') =>
+      raw.plan(view, pon, demand, ann),
+    sourcePainted: (pon: number, key: string, view = 'test') => raw.sourcePainted(view, pon, key),
+    sourceUnpainted: (pon: number, key: string, view = 'test') =>
+      raw.sourceUnpainted(view, pon, key),
+    releasePage: (pon: number, view = 'test') => raw.releasePage(view, pon),
+    stats: (pon: number, view = 'test') => raw.stats(view, pon),
+  };
   return {
     manager,
     pending,
@@ -392,5 +404,71 @@ describe('settle convergence (regression: a zoom must always land on its final l
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe('per-VIEW tile state (multi-lens isolation)', () => {
+  // The "sidebar opens, main view goes blurry" regression: the rail's
+  // below-engage demand must never reach the main view's state — before the
+  // view axis, its plan call hit the disengage branch and destroyed the main
+  // lens's entries on every selector pass.
+
+  it("a rail's never-engaging plan leaves the main view's tiles untouched", async () => {
+    const h = harness({ policy: { kind: 'continuous' } });
+    const main = h.manager.plan(1, DEEP, true, 'stage');
+    expect(main.engaged).toBe(true);
+    expect(h.pending).toHaveLength(4);
+    await h.resolveAll();
+    const painted = h.manager.plan(1, DEEP, true, 'stage');
+    expect(painted.paint.length).toBeGreaterThan(0);
+
+    // the sidebar opens: the thumbnail lens plans the SAME page, tiny demand
+    const rail = h.manager.plan(1, { desiredDeviceWidth: 200 }, true, 'stage-thumbs');
+    expect(rail.engaged).toBe(false);
+    expect(rail.paint).toHaveLength(0);
+
+    // …and the main view's plan is byte-identical — nothing dropped, nothing
+    // refetched, no thrash
+    const after = h.manager.plan(1, DEEP, true, 'stage');
+    expect(after.paint.length).toBe(painted.paint.length);
+    expect(h.manager.stats(1, 'stage').entries).toBeGreaterThan(0);
+    expect(h.manager.stats(1, 'stage-thumbs').entries).toBe(0);
+  });
+
+  it('releasing one view keeps the other view fetching and painting', async () => {
+    const h = harness({ policy: { kind: 'continuous' } });
+    h.manager.plan(1, DEEP, true, 'stage');
+    h.manager.plan(1, DEEP, true, 'stage-thumbs'); // a second full-size lens
+    const inFlight = h.pending.filter((p) => !p.aborted()).length;
+    expect(inFlight).toBeGreaterThan(0);
+
+    // the rail scrolls this page out and releases ITS plane…
+    h.manager.releasePage(1, 'stage-thumbs');
+    expect(h.manager.stats(1, 'stage-thumbs').entries).toBe(0);
+    // …while the main view's fetches stay alive and resolve to a paint list
+    await h.resolveAll();
+    const main = h.manager.plan(1, DEEP, true, 'stage');
+    expect(main.paint.length).toBeGreaterThan(0);
+  });
+
+  it('painted reports are view-scoped: one view painting never releases the other', async () => {
+    const h = harness({ policy: { kind: 'continuous' } });
+    h.manager.plan(1, DEEP, true, 'stage');
+    await h.resolveAll();
+    const plan = h.manager.plan(1, DEEP, true, 'stage');
+    const key = plan.paint[0]!.key;
+    // a report against the WRONG view is a no-op…
+    h.manager.sourcePainted(1, key, 'stage-thumbs');
+    expect(h.manager.plan(1, DEEP, true, 'stage')).toBe(plan); // memo intact
+    // …the right view's report advances its own plan
+    h.manager.sourcePainted(1, key, 'stage');
+    expect(h.manager.plan(1, DEEP, true, 'stage')).not.toBe(plan);
+  });
+
+  it('the view argument defaults — single-lens callers keep the implicit view', () => {
+    const h = harness({ policy: { kind: 'continuous' } });
+    h.manager.plan(1, DEEP, true); // no view: the shared implicit one
+    expect(h.manager.stats(1).entries).toBeGreaterThan(0);
+    expect(h.manager.stats(1, 'stage').entries).toBe(0);
   });
 });

--- a/packages/plugin/render/src/tile-manager.ts
+++ b/packages/plugin/render/src/tile-manager.ts
@@ -56,13 +56,25 @@ import {
  * is idempotent (the store singleflights); resolution handlers dispatch
  * the wake-up (`onAdvance`) that makes subscribed layers recompute.
  */
+/** One state entry per VIEW-of-page (see the class doc). */
+const stateKey = (view: string, pon: number): string => `${view}\u0000${pon}`;
+
 /** Backpressure: raw rasters in flight at once (render + encode transit). */
 const MAX_IN_FLIGHT = 8;
 /** Stage-less (no visibleRect) demand is capped to this many whole-page tiles. */
 const STAGELESS_TILE_CAP = 64;
 
 export class TileManager {
-  private readonly pages = new Map<number, PageTileState>();
+  /**
+   * Tile state is PER VIEW-OF-PAGE, never per page: a document may be shown
+   * through several lenses at once (the main view, a thumbnail rail), each
+   * calling `plan` with its own demand. One shared entry would let the
+   * rail's below-engage demand hit the disengage branch and destroy the
+   * main view's tiles on every selector pass (the "sidebar opens, main view
+   * goes blurry" bug). Keyed by `view\0pon`; the RasterStore underneath
+   * stays shared — bytes dedupe across views by conformed width.
+   */
+  private readonly pages = new Map<string, PageTileState>();
   private strategyMemo: { policy: EngineRenderPolicy; strategy: ResolvedStrategy } | null = null;
   /** Live fetches across all pages — the backpressure counter. */
   private inFlight = 0;
@@ -99,7 +111,7 @@ export class TileManager {
     return this.strategyMemo.strategy;
   }
 
-  plan(pon: number, demand: PageViewDemand, includeAnnotations: boolean): TilePaintPlan {
+  plan(view: string, pon: number, demand: PageViewDemand, includeAnnotations: boolean): TilePaintPlan {
     const { options } = this.deps;
     if (!options.tiles.enabled) return EMPTY_TILE_PLAN;
     const strategy = this.strategy();
@@ -107,7 +119,7 @@ export class TileManager {
     if (!page) return EMPTY_TILE_PLAN;
 
     const epoch = this.deps.getEpoch(pon, includeAnnotations);
-    const state = this.pageState(pon);
+    const state = this.pageState(pon, view);
 
     // Epoch exception: old-epoch pixels are WRONG, not blurry — drop all.
     if (state.epoch !== epoch) {
@@ -293,8 +305,8 @@ export class TileManager {
   }
 
   /** The layer's painted report: this key's pixels had a presentation opportunity. */
-  sourcePainted(pon: number, key: string): void {
-    const state = this.pages.get(pon);
+  sourcePainted(view: string, pon: number, key: string): void {
+    const state = this.pages.get(stateKey(view, pon));
     const entry = state?.entries.get(key);
     if (!state || !entry || entry.painted) return;
     entry.painted = true;
@@ -313,22 +325,22 @@ export class TileManager {
    * retained coarse coverage over a region that momentarily has no sharp
    * pixels. Painted is a statement about the SCREEN, so it follows the DOM.
    */
-  sourceUnpainted(pon: number, key: string): void {
-    const entry = this.pages.get(pon)?.entries.get(key);
+  sourceUnpainted(view: string, pon: number, key: string): void {
+    const entry = this.pages.get(stateKey(view, pon))?.entries.get(key);
     if (entry) entry.painted = false;
   }
 
   /** A lens unmounted its tile plane: stop fetching, drop bookkeeping.
    *  Resolved bytes stay in the RasterStore for a re-mount. */
-  releasePage(pon: number): void {
-    const state = this.pages.get(pon);
+  releasePage(view: string, pon: number): void {
+    const state = this.pages.get(stateKey(view, pon));
     if (!state) return;
     this.abortAll(state);
-    this.pages.delete(pon);
+    this.pages.delete(stateKey(view, pon));
   }
 
-  private pageState(pon: number): PageTileState {
-    let state = this.pages.get(pon);
+  private pageState(pon: number, view: string): PageTileState {
+    let state = this.pages.get(stateKey(view, pon));
     if (!state) {
       state = {
         epoch: -1,
@@ -342,7 +354,7 @@ export class TileManager {
         pendingLevel: null,
         lastVisible: null,
       };
-      this.pages.set(pon, state);
+      this.pages.set(stateKey(view, pon), state);
     }
     return state;
   }
@@ -590,8 +602,11 @@ export class TileManager {
   }
 
   /** Test/diagnostic introspection: bookkeeping size for one page. */
-  stats(pon: number): { entries: number; inFlight: number } {
-    return { entries: this.pages.get(pon)?.entries.size ?? 0, inFlight: this.inFlight };
+  stats(view: string, pon: number): { entries: number; inFlight: number } {
+    return {
+      entries: this.pages.get(stateKey(view, pon))?.entries.size ?? 0,
+      inFlight: this.inFlight,
+    };
   }
 
   /** Idempotent transit-slot release — the ONE place inFlight decrements. */

--- a/packages/plugin/render/src/tile-residency.test.ts
+++ b/packages/plugin/render/src/tile-residency.test.ts
@@ -31,7 +31,7 @@ function harness(opts?: {
   let liveFetches = 0;
   let maxLiveFetches = 0;
 
-  const manager = new TileManager({
+  const raw = new TileManager({
     store,
     options: resolveRenderOptions({ tiles: { settleMs: 0, bleed: 0, ...opts?.tiling } }),
     getPolicy: () => ({ kind: 'continuous' }) as never,
@@ -70,6 +70,18 @@ function harness(opts?: {
     onAdvance: () => {},
   });
 
+  // The tests predate the view axis and address one implicit view; this
+  // facade binds it (trailing `view` overrides for multi-view tests) so the
+  // suite exercises the REAL required-view API through one seam.
+  const manager = {
+    plan: (pon: number, demand: Parameters<TileManager['plan']>[2], ann: boolean, view = 'test') =>
+      raw.plan(view, pon, demand, ann),
+    sourcePainted: (pon: number, key: string, view = 'test') => raw.sourcePainted(view, pon, key),
+    sourceUnpainted: (pon: number, key: string, view = 'test') =>
+      raw.sourceUnpainted(view, pon, key),
+    releasePage: (pon: number, view = 'test') => raw.releasePage(view, pon),
+    stats: (pon: number, view = 'test') => raw.stats(view, pon),
+  };
   return {
     manager,
     store,

--- a/packages/plugin/render/src/types.ts
+++ b/packages/plugin/render/src/types.ts
@@ -102,6 +102,48 @@ export type RenderAction =
     }
   | { type: 'PAINT_ADVANCED'; pon: PageObjectNumber };
 
+/**
+ * One view's scoped tile surface (see {@link RenderCapability.tilesFor}).
+ * Identity (the view) is bound at creation; every call addresses that view's
+ * own state for the given page.
+ */
+export interface ViewTiles {
+  /**
+   * The tile paint plan for a page under this view's demand. Tiling is a
+   * STRATEGY inside this plugin, not a sibling.
+   * Memoized: the same object returns until the demand, an epoch, or a
+   * tile resolution actually changes it, so layers can subscribe with
+   * plain `Object.is`. Calling it schedules the want-set fetches (visible
+   * first, center-out, prefetch ring after) — idempotent, store-deduped.
+   * Engagement is pure arithmetic against what the base will ACTUALLY
+   * supply (the same `baseAsk` the base layer sizes with): tiles fire when
+   * demand exceeds the budget/ladder cap × engageAt — on every engine.
+   * A thumbnail-sized demand never engages.
+   */
+  plan(
+    pon: PageObjectNumber,
+    demand: PageViewDemand,
+    opts?: { includeAnnotations?: boolean },
+  ): TilePaintPlan;
+  /**
+   * The painter's report: the image for this plan key had a presentation
+   * opportunity. Retained coarser generations covered by painted want-set
+   * tiles release on this signal — never on fetch completion or image load,
+   * which could drop the backdrop before replacement pixels are presented.
+   */
+  painted(pon: PageObjectNumber, key: string): void;
+  /**
+   * The inverse report: this plan key's <img> left the DOM, so its pixels
+   * are no longer compositable. Painted is a statement about the SCREEN and
+   * must follow the DOM — a remounting tile re-decodes, and until it
+   * reports painted again, retention may not count it as coverage.
+   */
+  unpainted(pon: PageObjectNumber, key: string): void;
+  /** This view unmounted its tile plane for the page: abort in-flight tile
+   *  fetches, drop ITS bookkeeping (resolved bytes stay cached). */
+  release(pon: PageObjectNumber): void;
+}
+
 export interface RenderCapability {
   /**
    * Render a page (by its durable pon) to an ENCODED image. Abortable. Encoded
@@ -140,39 +182,16 @@ export interface RenderCapability {
   /** The document's advertised policy (sugar over `DocumentMeta.renderPolicy`). */
   renderPolicy(): EngineRenderPolicy;
   /**
-   * The tile paint plan for a page under a host-supplied demand. Tiling is a
-   * STRATEGY inside this plugin, not a sibling.
-   * Memoized: the same object returns until the demand, an epoch, or a
-   * tile resolution actually changes it, so layers can subscribe with
-   * plain `Object.is`. Calling it schedules the want-set fetches (visible
-   * first, center-out, prefetch ring after) — idempotent, store-deduped.
-   * Engagement is pure arithmetic against what the base will ACTUALLY
-   * supply (the same `baseAsk` the base layer sizes with): tiles fire when
-   * demand exceeds the budget/ladder cap × engageAt — on every engine.
-   * A thumbnail-sized demand never engages.
+   * This view's tile surface — the ONE tile entry point. `view` is the
+   * consuming view's identity (`PageContextValue.view`: a stage lens id, or
+   * a PageView instance id). Tile state is kept PER VIEW × PAGE, so two
+   * views showing the same page plan independently — a thumbnail rail's
+   * never-engaging demand cannot disturb the main view's tiles. Binding the
+   * identity ONCE makes it unforgettable and unmixable: the handle's four
+   * calls can never disagree about whose state they address. Stable per
+   * view — safe as a hook/effect dependency.
    */
-  tilePlan(
-    pon: PageObjectNumber,
-    demand: PageViewDemand,
-    opts?: { includeAnnotations?: boolean },
-  ): TilePaintPlan;
-  /**
-   * The painter's report: the image for this plan key had a presentation
-   * opportunity. Retained coarser generations covered by painted want-set
-   * tiles release on this signal — never on fetch completion or image load,
-   * which could drop the backdrop before replacement pixels are presented.
-   */
-  tilePainted(pon: PageObjectNumber, key: string): void;
-  /**
-   * The inverse report: this plan key's <img> left the DOM, so its pixels
-   * are no longer compositable. Painted is a statement about the SCREEN and
-   * must follow the DOM — a remounting tile re-decodes, and until it
-   * reports painted again, retention may not count it as coverage.
-   */
-  tileUnpainted(pon: PageObjectNumber, key: string): void;
-  /** A lens unmounted its tile plane: abort in-flight tile fetches and drop
-   *  the page's tile bookkeeping (resolved bytes stay cached). */
-  releaseTiles(pon: PageObjectNumber): void;
+  tilesFor(view: string): ViewTiles;
   /**
    * Version of the raster the given options would produce. Key a long-lived
    * render on it: when it bumps, refetch. Base renders version on content

--- a/packages/plugin/stage/src/capability.ts
+++ b/packages/plugin/stage/src/capability.ts
@@ -1312,18 +1312,24 @@ export function createStageCapability(
       const item = paged() ? sc0.items[0] : sc0.items[itemIndexOfPage(ctx.getState().cursor)];
       // The ladder (the platform convention): ascending READING POSTURES, each
       // derived from a zoom intent — see the page (automatic), read the text
-      // (fit-width), inspect (2.5× the automatic fit). A double-tap climbs to
-      // the next posture meaningfully above the current zoom; past the top it
-      // resets to the base fit. Stops within 10% of a neighbor collapse — on
-      // phones automatic IS fit-width, so the ladder degenerates to the
-      // familiar two-state toggle.
+      // (fit-width), inspect (2.5× the automatic fit). Stops within 10% of a
+      // neighbor collapse — on phones automatic IS fit-width, so the ladder
+      // degenerates to the familiar two-state toggle.
+      //
+      // The rule (iOS's): the ladder ascends only from ON a rung — a tap at a
+      // posture moves to the next, wrapping past the top. A pinch to any
+      // OTHER level is leaving the ladder, and double-tap there is a RESET to
+      // the base fit ("take me back to reading"), never a further zoom-in.
       const fit = fitBox(item);
       const auto = S.resolveZoom({ mode: S.ZoomMode.Automatic }, fit, vp(), pad());
       const fitW = S.resolveZoom({ mode: S.ZoomMode.FitWidth }, fit, vp(), pad());
       const stops = [auto, fitW, Math.min(auto * 2.5, S.ZOOM_MAX)]
         .sort((a, b) => a - b)
         .filter((z, i, all) => i === 0 || z > all[i - 1] * 1.1);
-      const target = stops.find((z) => z > cam().zoom * 1.1) ?? stops[0];
+      // the same ±10% band the dedupe uses: "at a posture" tolerates fit drift
+      const near = (z: number, stop: number) => z > stop / 1.1 && z < stop * 1.1;
+      const onRung = stops.findIndex((s) => near(cam().zoom, s));
+      const target = onRung >= 0 ? stops[(onRung + 1) % stops.length] : stops[0];
       // The INTENT commits UP FRONT (the `reveal` precedent): a caught tween
       // must never leave the camera on some intermediate zoom while the stored
       // intent still says "fit" — the next refit would snap somewhere the user

--- a/packages/plugin/stage/test/stage.capability.test.ts
+++ b/packages/plugin/stage/test/stage.capability.test.ts
@@ -1758,6 +1758,48 @@ describe('doubleTapZoom', () => {
     settle(sched, 0);
     expect(stage.zoomLevel()).toBeCloseTo((393 - 2 * 4) / 600, 3); // compact padding
   });
+
+  it('pinched IN between rungs: double-tap RESETS to the base fit, never climbs (iOS)', () => {
+    const sched = manualScheduler();
+    const { stage } = harness(PORTRAIT, { scheduler: sched.scheduler });
+    stage.setViewport({ width: 393, height: 700 });
+    const fitW = (393 - 2 * 4) / 600;
+    stage.zoomTo({ level: fitW * 1.5 }); // a pinch left the ladder
+    stage.doubleTapZoom({ x: 200, y: 350 });
+    settle(sched, 0);
+    expect(stage.zoomLevel()).toBeCloseTo(fitW, 3); // back to reading, NOT detail
+  });
+
+  it('pinched BEYOND the top rung: double-tap also resets to the base fit', () => {
+    const sched = manualScheduler();
+    const { stage } = harness(PORTRAIT, { scheduler: sched.scheduler });
+    stage.setViewport({ width: 393, height: 700 });
+    const fitW = (393 - 2 * 4) / 600;
+    stage.zoomTo({ level: fitW * 3.4 }); // past detail (2.5×)
+    stage.doubleTapZoom({ x: 200, y: 350 });
+    settle(sched, 0);
+    expect(stage.zoomLevel()).toBeCloseTo(fitW, 3);
+  });
+
+  it('"at a rung" tolerates ±10% fit drift — a near-fit zoom still climbs', () => {
+    const sched = manualScheduler();
+    const { stage } = harness(PORTRAIT, { scheduler: sched.scheduler });
+    stage.setViewport({ width: 393, height: 700 });
+    const fitW = (393 - 2 * 4) / 600;
+    stage.zoomTo({ level: fitW * 1.05 }); // within the rung's band
+    stage.doubleTapZoom({ x: 200, y: 350 });
+    settle(sched, 0);
+    expect(stage.zoomLevel()).toBeCloseTo(fitW * 2.5, 3); // treated as ON fit-width
+  });
+
+  it('desktop off-ladder reset lands on the base rung (automatic)', () => {
+    const sched = manualScheduler();
+    const { stage } = harness(PORTRAIT, { scheduler: sched.scheduler });
+    stage.zoomTo({ level: 2.0 }); // between fit-width (1.59) and detail (2.5)
+    stage.doubleTapZoom({ x: 500, y: 350 });
+    settle(sched, 0);
+    expect(stage.zoomLevel()).toBeCloseTo(1, 3);
+  });
 });
 
 describe('doubleTapZoom interruption (catch) consistency', () => {


### PR DESCRIPTION
Tile state is now scoped per view×page: TileManager keys entries by view+pon and RenderCapability exposes tilesFor(view) which returns a stable ViewTiles handle (plan/painted/unpainted/release). React PageView and Stage provide a view id via PageContext.view (useId or stage.lensId) so multiple views of the same page plan rasters independently. Double-tap ladder behavior adjusted: ladder ascends only when ON a rung (±10%); double-tap off-rung resets to the base fit. Tests and .changeset files updated to cover the new API and behavior.