### PR TITLE
Gate stage placement until initial view commits

### DIFF
--- a/.changeset/placement-commit-plugin-stage.md
+++ b/.changeset/placement-commit-plugin-stage.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/plugin-stage': patch
+---
+
+Keep page and scrollbar screen geometry hidden until initial viewport placement commits. Stage consumers no longer receive origin-based placeholder geometry while viewport, responsive settings, and camera state are being initialized, preventing pages from rendering at the top-left before their final placement.

--- a/.changeset/prepaint-placement-react.md
+++ b/.changeset/prepaint-placement-react.md
@@ -1,0 +1,5 @@
+---
+'@embedpdf/react': patch
+---
+
+Bind Stage surface measurement before browser paint so the initial viewport and camera placement settle before page surfaces become visible. React viewers no longer show a transient incorrectly positioned page while a document opens.

--- a/packages/framework/react/src/stage.tsx
+++ b/packages/framework/react/src/stage.tsx
@@ -9,7 +9,7 @@
 // One-line-per-feature: registration travels with the UI.
 export * from '@embedpdf/plugin-stage';
 import * as React from 'react';
-import { useEffect, useMemo, useRef } from 'react';
+import { useLayoutEffect, useMemo, useRef } from 'react';
 import { StageToken, createScrollHandler, settingsEqual } from '@embedpdf/plugin-stage';
 import type { StageCapability, VisiblePage } from '@embedpdf/plugin-stage';
 import type { CapabilityToken } from '@embedpdf/core';
@@ -252,7 +252,7 @@ export function Stage({
     [projector, pages],
   );
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const el = ref.current!;
     // The WHOLE browser binding — viewport/DPR reporting, sample normalization,
     // gesture controller — is the shared @embedpdf/web surface, so every

--- a/packages/plugin/stage/src/capability.ts
+++ b/packages/plugin/stage/src/capability.ts
@@ -380,9 +380,11 @@ export function createStageCapability(
     direction: ctx.getState().direction,
   });
 
-  // Initial-view placement flag — declared up here so the rest detector can
-  // read it; the placement logic further down owns it.
-  let hasPlaced = false;
+  // Behavioral latch: flips when initial placement STARTS, while state.placed
+  // is the render-commit latch that flips only after placement finishes. The
+  // distinction keeps placement-time camera behavior unchanged while making
+  // partial geometry unobservable to renderers.
+  let placementStarted = false;
 
   // ── gesture transaction (touch pan/pinch) ───────────────────────────────────
   // While open: zoomAround defers its intent PATCH, and the rest countdown is
@@ -408,7 +410,7 @@ export function createStageCapability(
     // Initial placement snaps immediately (first paint is crisp), and an
     // environment without real frames keeps snapping always-on — rest-gating
     // is a live-gesture refinement, not a contract.
-    if (!canAnimate || !hasPlaced) return;
+    if (!canAnimate || !placementStarted) return;
     if (ctx.getState().cameraResting) ctx.dispatch({ type: 'CAMERA_REST', resting: false });
     if (restRaf) scheduler.caf(restRaf);
     let t0 = 0;
@@ -927,8 +929,19 @@ export function createStageCapability(
   // SAME bounds the pan clamp uses (stayBounds: the slice item in paged flow,
   // the scene in continuous). Memoized like visiblePages: a stable reference
   // until a field actually moves, so adapter selectors can use plain equality.
+  const EMPTY_SCROLL_METRICS: S.ScrollMetrics = {
+    scrollLeft: 0,
+    scrollTop: 0,
+    scrollWidth: 0,
+    scrollHeight: 0,
+    clientWidth: 0,
+    clientHeight: 0,
+    scrollableX: false,
+    scrollableY: false,
+  };
   let scrollMemo: S.ScrollMetrics | null = null;
   const scrollMetricsNow = (): S.ScrollMetrics => {
+    if (!ctx.getState().placed) return EMPTY_SCROLL_METRICS;
     const sc = buildScene();
     const m = S.scrollMetrics(
       cam(),
@@ -954,9 +967,11 @@ export function createStageCapability(
 
   // Memoized visiblePages -> stable reference (no useSyncExternalStore tearing loop).
   // Paged renders ONLY the slice's item; continuous renders the camera's query window.
+  const EMPTY_VISIBLE_PAGES: VisiblePage[] = [];
   let visSig = '';
   let vis: VisiblePage[] = [];
   const visiblePages = (): VisiblePage[] => {
+    if (!ctx.getState().placed) return EMPTY_VISIBLE_PAGES;
     const c = cam();
     const v = vp();
     const sc = buildScene();
@@ -1060,7 +1075,7 @@ export function createStageCapability(
 
   // Initial-view providers (storage restore, deep-link, an explicit prop…). One owner
   // (placeInitial) resolves them by priority — no effect-ordering races.
-  // (`hasPlaced` is declared above the camera-rest detector, which reads it.)
+  // (`placementStarted` is declared above the camera-rest detector, which reads it.)
   const initialViewProviders: Array<{ priority: number; fn: () => StageViewState | null }> = [];
 
   const api: StageCapability = {
@@ -1082,6 +1097,7 @@ export function createStageCapability(
         label: p.label ?? null,
       })),
     pageRect: (pon) => {
+      if (!ctx.getState().placed) return null;
       const meta = ctx.document();
       const index = meta ? meta.pages.findIndex((p) => p.pageObjectNumber === pon) : -1;
       if (index < 0) return null;
@@ -1177,7 +1193,7 @@ export function createStageCapability(
       // the initial view (storage/deep-link providers, else reset). Every report
       // re-checks the condition — no watch, no effect-registration race, no edge
       // to miss when the viewport was already sized before anyone listened.
-      if (!hasPlaced) {
+      if (!placementStarted) {
         ctx.dispatch({ type: 'VP', vp: v });
         syncResponsive(false); // rules see the box before placement resolves
         if (v.width > 0 && v.height > 0 && (ctx.document()?.pageCount ?? 0) > 0) {
@@ -1359,7 +1375,7 @@ export function createStageCapability(
       // re-place against the now-current scene, keeping the anchored page-point.
       // No-op until the first placement; the scene is re-keyed on the registry
       // revision, so `reapply` reads the rotated footprint.
-      if (!hasPlaced) return;
+      if (!placementStarted) return;
       cancelAnim();
       reapply(currentAnchor());
     },
@@ -1520,16 +1536,21 @@ export function createStageCapability(
       initialViewProviders.push({ priority, fn });
     },
     placeInitial: () => {
-      hasPlaced = true;
+      placementStarted = true;
       const sorted = [...initialViewProviders].sort((a, b) => b.priority - a.priority);
       for (const p of sorted) {
         const view = p.fn();
         if (view) {
           api.applyViewState(view);
+          ctx.dispatch({ type: 'PLACED' });
           return;
         }
       }
       api.resetView();
+      // Publish renderability LAST. The VP/responsive/camera writes above are
+      // still ordinary observable store updates, but page/scroll render-root
+      // selectors return stable empty values until this commit lands.
+      ctx.dispatch({ type: 'PLACED' });
     },
     // Home = page 0, a fresh arrival at arrivalAlign (the clamp collapses any
     // fitting axis to its fitAlign rest point).

--- a/packages/plugin/stage/src/reducer.ts
+++ b/packages/plugin/stage/src/reducer.ts
@@ -7,6 +7,7 @@ export const initialStageState = (config: StageConfig): StageState => {
   const { scheduler: _scheduler, responsive: _responsive, ...overrides } = config;
   return {
     camera: { x: 0, y: 0, zoom: 1 },
+    placed: false,
     cameraResting: true,
     vp: { width: 0, height: 0 },
     dpr: 1,
@@ -39,6 +40,8 @@ export const stageReducer = (state: StageState, a: StageAction): StageState => {
       return { ...state, camera: a.camera };
     case 'CAMERA_REST':
       return state.cameraResting === a.resting ? state : { ...state, cameraResting: a.resting };
+    case 'PLACED':
+      return state.placed ? state : { ...state, placed: true };
     case 'VP':
       return { ...state, vp: a.vp };
     case 'DPR':

--- a/packages/plugin/stage/src/types.ts
+++ b/packages/plugin/stage/src/types.ts
@@ -257,6 +257,13 @@ export interface VisiblePage extends PageBox {
 export interface StageState extends StageSettings {
   camera: Camera;
   /**
+   * One-way render-commit latch. False while the initial viewport-driven
+   * placement is unresolved; true only after its camera/settings writes have
+   * completed. Page/scroll screen-space selectors refuse to answer while
+   * false, so an adapter can never paint the placeholder camera at the origin.
+   */
+  placed: boolean;
+  /**
    * Names of the responsive rules currently matching the box, in source order.
    * State (not derived) so `matches()` is reactive through the ordinary
    * selector machinery in every framework.
@@ -291,6 +298,7 @@ export interface StageState extends StageSettings {
 export type StageAction =
   | { type: 'CAMERA'; camera: Camera }
   | { type: 'CAMERA_REST'; resting: boolean }
+  | { type: 'PLACED' }
   | { type: 'VP'; vp: Size }
   | { type: 'DPR'; dpr: number }
   | { type: 'CURSOR'; cursor: number }

--- a/packages/plugin/stage/test/stage.capability.test.ts
+++ b/packages/plugin/stage/test/stage.capability.test.ts
@@ -4,7 +4,7 @@ import { createStageCapability } from '../src/capability';
 import { initialStageState, stageReducer } from '../src/reducer';
 import { DEFAULT_SETTINGS, settingsEqual } from '../src/settings';
 import { stagePlugin } from '../src/stage.plugin';
-import type { StageAction, StageConfig, StageState } from '../src/types';
+import type { StageAction, StageCapability, StageConfig, StageState } from '../src/types';
 
 /**
  * Kernel-free harness: drive the real capability against the real reducer + real
@@ -29,6 +29,13 @@ function harness(
   // Test layout at 1:1 (world units = points) so absolute-size assertions read
   // cleanly; the 96/72 physical factor is exercised in the stage-core layout test.
   let state = initialStageState({ viewUnitsPerPoint: 1, ...config });
+  const transitions: Array<{
+    action: StageAction['type'];
+    pages: ReturnType<StageCapability['visiblePages']>;
+    pageScreenX: number | null;
+    metrics: ReturnType<StageCapability['scrollMetrics']>;
+  }> = [];
+  let stage!: StageCapability;
   const ctx = {
     id: 'stage',
     documentId: 'doc',
@@ -36,12 +43,20 @@ function harness(
     getState: () => state,
     dispatch: (a: StageAction) => {
       state = stageReducer(state, a);
+      if (stage) {
+        transitions.push({
+          action: a.type,
+          pages: stage.visiblePages(),
+          pageScreenX: stage.pageRect(1)?.screenX ?? null,
+          metrics: stage.scrollMetrics(),
+        });
+      }
     },
     subscribe: () => () => {},
     document: () => meta,
   } as unknown as PluginContext<StageState, StageAction>;
 
-  const stage = createStageCapability(ctx, config);
+  stage = createStageCapability(ctx, config);
   // Mirror the real lifecycle: the shell reports the viewport — initial placement
   // is level-triggered inside setViewport (no manual placeInitial; that's the fix
   // for the "page stuck at top-left until the first scroll" race).
@@ -50,13 +65,45 @@ function harness(
   // a page's rotation + bumping `revision` simulates a rotate/move/delete event,
   // exactly as the kernel's event→registry bridge would (which the stage effect
   // then turns into a `refit()`).
-  return { stage, meta };
+  return { stage, meta, transitions };
 }
 
 const PORTRAIT = Array.from({ length: 5 }, () => ({ width: 600, height: 800 }));
 const PAD = 24; // default StageSettings.padding — the fit inset + arrival gutter
 
 describe('initial placement is level-triggered (the new-pane / HMR race)', () => {
+  it('publishes screen geometry only on the final placement commit', () => {
+    const { stage, transitions } = harness(PORTRAIT, undefined, { skipViewport: true });
+    const pendingPages = stage.visiblePages();
+
+    expect(pendingPages).toEqual([]);
+    expect(stage.visiblePages()).toBe(pendingPages); // stable empty selector value
+    expect(stage.pageRect(1)).toBeNull();
+    expect(stage.scrollMetrics()).toEqual({
+      scrollLeft: 0,
+      scrollTop: 0,
+      scrollWidth: 0,
+      scrollHeight: 0,
+      clientWidth: 0,
+      clientHeight: 0,
+      scrollableX: false,
+      scrollableY: false,
+    });
+
+    stage.setViewport({ width: 1000, height: 700 });
+
+    const commit = transitions.findIndex((t) => t.action === 'PLACED');
+    expect(commit).toBeGreaterThan(0);
+    for (const transition of transitions.slice(0, commit)) {
+      expect(transition.pages).toBe(pendingPages);
+      expect(transition.pageScreenX).toBeNull();
+      expect(transition.metrics.scrollableX).toBe(false);
+      expect(transition.metrics.scrollableY).toBe(false);
+    }
+    expect(transitions[commit].pages.map((p) => p.pageIndex)).toContain(0);
+    expect(transitions[commit].pageScreenX).toBeCloseTo(200, 0);
+  });
+
   it('places the moment the viewport is reported — no effect/watch involved', () => {
     // The bug: placement hung off an edge-triggered width watch registered during
     // openDocument; if the viewport was already sized first, the edge never came and
@@ -72,11 +119,16 @@ describe('initial placement is level-triggered (the new-pane / HMR race)', () =>
   });
 
   it('a half-laid-out viewport (height 0) does not place; the real one does', () => {
-    const { stage } = harness(PORTRAIT, undefined, { skipViewport: true });
+    const { stage, transitions } = harness(PORTRAIT, undefined, { skipViewport: true });
+    const pendingPages = stage.visiblePages();
     stage.setViewport({ width: 1000, height: 0 }); // mid-layout flex collapse
     expect(stage.camera()).toEqual({ x: 0, y: 0, zoom: 1 }); // not placed yet
+    expect(stage.visiblePages()).toBe(pendingPages);
+    expect(stage.pageRect(1)).toBeNull();
+    expect(transitions.some((t) => t.action === 'PLACED')).toBe(false);
     stage.setViewport({ width: 1000, height: 700 }); // the real report
     expect(stage.camera()).not.toEqual({ x: 0, y: 0, zoom: 1 }); // placed now
+    expect(stage.visiblePages()).not.toBe(pendingPages);
     expect(stage.toScreen({ x: stage.pageRect(1)!.x, y: stage.pageRect(1)!.y }).y).toBeCloseTo(
       PAD,
       0,


### PR DESCRIPTION
The stage now waits for the initial viewport-driven placement to finish before exposing page and scroll geometry, preventing placeholder camera state from being painted during the initial layout race. This change switches the React binding to a layout effect, adds a one-way PLACED latch in the stage state, and ensures selectors like visiblePages, pageRect, and scrollMetrics return empty values until placement has fully committed. Tests cover the pending-vs-committed geometry transition and the viewport-report race.