### PR TITLE
Buffer S3 request stream; improve error logging

### DIFF
--- a/.changeset/s3-stream-buffer-server.md
+++ b/.changeset/s3-stream-buffer-server.md
@@ -1,0 +1,5 @@
+---
+'@cloudpdf/server': patch
+---
+
+Fix AWS S3-backed streaming uploads by buffering small source chunks before the SDK applies checksum framing, preventing `InvalidChunkSizeError` during document imports and other streamed writes. Handled 5xx responses now also emit structured error logs with the request ID and HTTP status.

--- a/cloudpdf/server/src/app/buildApp.ts
+++ b/cloudpdf/server/src/app/buildApp.ts
@@ -5,7 +5,7 @@ import { EngineError, EngineErrorCode } from '@embedpdf/engine-core/runtime';
 import compress from '@fastify/compress';
 import cors from '@fastify/cors';
 import multipart from '@fastify/multipart';
-import Fastify, { type FastifyInstance } from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyReply, type FastifyRequest } from 'fastify';
 import { sql, type Kysely } from 'kysely';
 
 import type { AuthFailureLimiterOptions } from './auth-failure-limiter';
@@ -476,10 +476,21 @@ export async function buildAppForTesting(opts: BuildAppOptions): Promise<AppBund
     engineShards !== undefined && engineShards > 1 && opts.engineIsolation !== 'inline'
       ? Math.ceil((opts.poolSize ?? engineShards) / engineShards) * engineShards
       : opts.poolSize;
+  // Teardown must fit INSIDE the runner's hook budget, with margin. The
+  // production default (30s) exists so real in-flight traffic can finish
+  // before a supervisor's kill deadline — but it happens to equal
+  // vitest's `hookTimeout`, so a single stuck connection at teardown
+  // burns the whole budget and the hook fails with "Hook timed out in
+  // 30000ms" instead of costing a blink. Proven: one never-finishing
+  // request makes `shutdown()` take exactly 30.0s. Tests have no
+  // supervisor and no long-running traffic, so bound it hard here;
+  // a fixture that genuinely needs longer passes its own value.
+  const shutdownTimeoutMs = opts.shutdownTimeoutMs ?? 2_000;
   if (engineIsolation === 'host') {
     return buildAppUnchecked({
       ...opts,
       engineIsolation,
+      shutdownTimeoutMs,
       ...(engineShards !== undefined ? { engineShards } : {}),
       ...(poolSize !== undefined ? { poolSize } : {}),
       engineHostEntry:
@@ -487,7 +498,7 @@ export async function buildAppForTesting(opts: BuildAppOptions): Promise<AppBund
       engineHostExecArgv: opts.engineHostExecArgv ?? ['--import', 'tsx'],
     });
   }
-  return buildAppUnchecked({ ...opts, engineIsolation });
+  return buildAppUnchecked({ ...opts, engineIsolation, shutdownTimeoutMs });
 }
 
 async function buildAppUnchecked(opts: BuildAppOptions): Promise<AppBundle> {
@@ -1337,68 +1348,7 @@ async function buildAppUnchecked(opts: BuildAppOptions): Promise<AppBundle> {
     }
   }
 
-  app.setErrorHandler((err, req, reply) => {
-    if (err instanceof EngineBusyError) {
-      // Honest backpressure: retry cheaply instead of hanging. A shed
-      // interactive job is the overload signal (background sheds are
-      // swallowed by their callers by design).
-      reply.header('Retry-After', '2');
-      reply.code(503).send({ error: { code: err.code, message: err.message } });
-      return;
-    }
-    if (err instanceof DocumentQuarantinedError) {
-      reply.code(422).send({ error: { code: err.code, message: err.message } });
-      return;
-    }
-    if (EngineError.is(err) && (err as EngineError).code === EngineErrorCode.DocNotOpen) {
-      // Server-side override of the generic mapping: DocNotOpen reaching
-      // HTTP is always pool state (post-retry: the engine respawned more
-      // than once inside one request) — a transient 503, never a 404
-      // (real document-absence surfaces as NotFound from the DB layer).
-      reply.header('Retry-After', '2');
-      reply.code(503).send({ error: { code: 'EngineRestarting', message: err.message } });
-      return;
-    }
-    if (EngineError.is(err)) {
-      const engineErr = err as EngineError;
-      const code = mapToHttp(engineErr.code);
-      // The `name: 'EngineError'` discriminator is required by
-      // EngineErrorPayloadSchema on the client side; without it the
-      // typed code/message/details get dropped and clients see a
-      // status-only InvalidArg fallback.
-      reply.code(code).send({
-        error: {
-          name: 'EngineError',
-          code: engineErr.code,
-          message: engineErr.message,
-          details: engineErr.details,
-        },
-      });
-      return;
-    }
-    const e = err as Error & { code?: string; status?: number; statusCode?: number };
-    if (e.status && typeof e.status === 'number') {
-      reply.code(e.status).send({ error: { code: e.code ?? 'Unknown', message: e.message } });
-      return;
-    }
-    // Fastify's own errors (body parsing, payload limits, validation) carry
-    // `statusCode`, not `status`. Pass 4xx through as the client errors they
-    // are; 5xx still falls to the unhandled branch below so it gets logged.
-    if (typeof e.statusCode === 'number' && e.statusCode >= 400 && e.statusCode < 500) {
-      reply.code(e.statusCode).send({ error: { code: e.code ?? 'Unknown', message: e.message } });
-      return;
-    }
-    if (e.code === 'NotFound') {
-      reply.code(404).send({ error: { code: 'NotFound', message: e.message } });
-      return;
-    }
-    if (e.code === 'Forbidden') {
-      reply.code(403).send({ error: { code: 'Forbidden', message: e.message } });
-      return;
-    }
-    req.log.error({ err: e }, 'unhandled error');
-    reply.code(500).send({ error: { code: 'Unknown', message: e.message } });
-  });
+  app.setErrorHandler(handleAppError);
 
   const shutdownTimeoutMs = opts.shutdownTimeoutMs ?? 30_000;
   const shutdownDrainMs = opts.shutdownDrainMs ?? 0;
@@ -1471,6 +1421,86 @@ async function buildAppUnchecked(opts: BuildAppOptions): Promise<AppBundle> {
     beginDrain: () => drainCoordinator.begin(),
     shutdown,
   };
+}
+
+/**
+ * Preserve the distinction between an expected client rejection and a server
+ * failure while ensuring that handled 5xx responses do not disappear from
+ * the structured logs. Fastify will still write its normal `request
+ * completed` record; the additional error record carries the error itself
+ * and inherits the request logger's reqId.
+ */
+export function handleAppError(err: unknown, req: FastifyRequest, reply: FastifyReply): void {
+  if (err instanceof EngineBusyError) {
+    // Honest backpressure: retry cheaply instead of hanging. A shed
+    // interactive job is the overload signal (background sheds are
+    // swallowed by their callers by design).
+    logHandledServerError(req, err, 503);
+    reply.header('Retry-After', '2');
+    reply.code(503).send({ error: { code: err.code, message: err.message } });
+    return;
+  }
+  if (err instanceof DocumentQuarantinedError) {
+    reply.code(422).send({ error: { code: err.code, message: err.message } });
+    return;
+  }
+  if (EngineError.is(err) && (err as EngineError).code === EngineErrorCode.DocNotOpen) {
+    // Server-side override of the generic mapping: DocNotOpen reaching
+    // HTTP is always pool state (post-retry: the engine respawned more
+    // than once inside one request) — a transient 503, never a 404
+    // (real document-absence surfaces as NotFound from the DB layer).
+    logHandledServerError(req, err, 503);
+    reply.header('Retry-After', '2');
+    reply.code(503).send({ error: { code: 'EngineRestarting', message: err.message } });
+    return;
+  }
+  if (EngineError.is(err)) {
+    const engineErr = err as EngineError;
+    const code = mapToHttp(engineErr.code);
+    logHandledServerError(req, engineErr, code);
+    // The `name: 'EngineError'` discriminator is required by
+    // EngineErrorPayloadSchema on the client side; without it the
+    // typed code/message/details get dropped and clients see a
+    // status-only InvalidArg fallback.
+    reply.code(code).send({
+      error: {
+        name: 'EngineError',
+        code: engineErr.code,
+        message: engineErr.message,
+        details: engineErr.details,
+      },
+    });
+    return;
+  }
+  const e = err as Error & { code?: string; status?: number; statusCode?: number };
+  if (e.status && typeof e.status === 'number') {
+    logHandledServerError(req, e, e.status);
+    reply.code(e.status).send({ error: { code: e.code ?? 'Unknown', message: e.message } });
+    return;
+  }
+  // Fastify's own errors (body parsing, payload limits, validation) carry
+  // `statusCode`, not `status`. Pass 4xx through as the client errors they
+  // are; 5xx still falls to the unhandled branch below so it gets logged.
+  if (typeof e.statusCode === 'number' && e.statusCode >= 400 && e.statusCode < 500) {
+    reply.code(e.statusCode).send({ error: { code: e.code ?? 'Unknown', message: e.message } });
+    return;
+  }
+  if (e.code === 'NotFound') {
+    reply.code(404).send({ error: { code: 'NotFound', message: e.message } });
+    return;
+  }
+  if (e.code === 'Forbidden') {
+    reply.code(403).send({ error: { code: 'Forbidden', message: e.message } });
+    return;
+  }
+  req.log.error({ err: e, statusCode: 500 }, 'unhandled error');
+  reply.code(500).send({ error: { code: 'Unknown', message: e.message } });
+}
+
+function logHandledServerError(req: FastifyRequest, err: unknown, statusCode: number): void {
+  if (statusCode >= 500) {
+    req.log.error({ err, statusCode }, 'request failed');
+  }
 }
 
 /**

--- a/cloudpdf/server/src/storage/adapters/S3ObjectStore.ts
+++ b/cloudpdf/server/src/storage/adapters/S3ObjectStore.ts
@@ -50,6 +50,15 @@ type S3Module = typeof import('@aws-sdk/client-s3');
 type PresignerModule = typeof import('@aws-sdk/s3-request-presigner');
 type S3Client = InstanceType<S3Module['S3Client']>;
 
+/**
+ * S3's aws-chunked checksum framing requires every non-final data chunk to
+ * contain at least 8 KiB. Import sources may emit arbitrarily small chunks,
+ * so let the SDK coalesce them before its checksum middleware sees them.
+ * 64 KiB is the SDK's documented example and remains bounded per in-flight
+ * streaming request.
+ */
+const REQUEST_STREAM_BUFFER_SIZE = 64 * 1024;
+
 interface S3Deps {
   client: S3Client;
   /** Command constructors, captured from the lazily-imported module. */
@@ -107,6 +116,7 @@ export class S3ObjectStore implements ObjectStore {
       opts.client ??
       new cmd.S3Client({
         region: opts.region,
+        requestStreamBufferSize: REQUEST_STREAM_BUFFER_SIZE,
         ...(opts.endpoint ? { endpoint: opts.endpoint, forcePathStyle: true } : {}),
       });
     return { client, cmd, getSignedUrl: presigner.getSignedUrl };

--- a/cloudpdf/server/test/error-logging.test.ts
+++ b/cloudpdf/server/test/error-logging.test.ts
@@ -1,0 +1,57 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { describe, expect, test, vi } from 'vitest';
+
+import { handleAppError } from '../src/app/buildApp';
+
+function requestDouble(error: ReturnType<typeof vi.fn>): FastifyRequest {
+  return { log: { error } } as unknown as FastifyRequest;
+}
+
+function replyDouble(): {
+  reply: FastifyReply;
+  code: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+} {
+  const code = vi.fn();
+  const send = vi.fn();
+  const header = vi.fn();
+  const value = { code, send, header };
+  code.mockReturnValue(value);
+  header.mockReturnValue(value);
+  send.mockReturnValue(value);
+  return { reply: value as unknown as FastifyReply, code, send };
+}
+
+describe('application error logging', () => {
+  test('logs a handled 502 with structured status and error context', () => {
+    const logError = vi.fn();
+    const { reply, code, send } = replyDouble();
+    const err = Object.assign(new Error('transfer failed: Access Denied'), {
+      code: 'UpstreamError',
+      status: 502,
+    });
+
+    handleAppError(err, requestDouble(logError), reply);
+
+    expect(logError).toHaveBeenCalledOnce();
+    expect(logError).toHaveBeenCalledWith({ err, statusCode: 502 }, 'request failed');
+    expect(code).toHaveBeenCalledWith(502);
+    expect(send).toHaveBeenCalledWith({
+      error: { code: 'UpstreamError', message: 'transfer failed: Access Denied' },
+    });
+  });
+
+  test('does not error-log an expected handled 4xx', () => {
+    const logError = vi.fn();
+    const { reply, code } = replyDouble();
+    const err = Object.assign(new Error('invalid import request'), {
+      code: 'InvalidArg',
+      status: 400,
+    });
+
+    handleAppError(err, requestDouble(logError), reply);
+
+    expect(logError).not.toHaveBeenCalled();
+    expect(code).toHaveBeenCalledWith(400);
+  });
+});

--- a/cloudpdf/server/test/events-sse.test.ts
+++ b/cloudpdf/server/test/events-sse.test.ts
@@ -1,3 +1,4 @@
+import { connect } from 'node:net';
 import { createHash, randomBytes } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -395,6 +396,33 @@ describe('drain + readiness — shutdown ends streams instead of hanging on them
     await fx.bundle.shutdown();
     expect(Date.now() - started).toBeLessThan(10_000);
     await sse.waitForEnd();
+  });
+
+  test('teardown stays far inside the runner hook budget when a request is stuck', async () => {
+    // The defect this locks: buildApp's production `shutdownTimeoutMs`
+    // (30s — the budget real in-flight traffic gets before a supervisor
+    // kill) is EXACTLY vitest's `hookTimeout`, so one stuck connection
+    // at teardown consumed the entire hook budget and surfaced as
+    // "Hook timed out in 30000ms" — a phantom flake that looked like
+    // load. `buildAppForTesting` bounds it to 2s; if anyone restores the
+    // production default for tests, this test times out first and says
+    // why.
+    const port = Number(new URL(fx.baseUrl).port);
+    const socket = connect(port, '127.0.0.1');
+    await new Promise((resolve) => socket.once('connect', resolve));
+    // Headers promise 500 bytes of body; we send 5 and stop, so the
+    // request never completes and app.close() cannot settle on its own.
+    socket.write(
+      'POST /v1/docs/x/access HTTP/1.1\r\nHost: localhost\r\n' +
+        'Content-Type: application/json\r\nContent-Length: 500\r\n\r\n{"a":',
+    );
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const started = Date.now();
+    await fx.bundle.shutdown();
+    const elapsed = Date.now() - started;
+    socket.destroy();
+    expect(elapsed).toBeLessThan(10_000);
   });
 
   test('a stream connecting mid-drain is ended immediately', async () => {

--- a/cloudpdf/server/test/storage-s3-wire.test.ts
+++ b/cloudpdf/server/test/storage-s3-wire.test.ts
@@ -1,0 +1,233 @@
+import { once } from 'node:events';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { Readable } from 'node:stream';
+import { setImmediate as yieldToEventLoop } from 'node:timers/promises';
+
+import { S3Client } from '@aws-sdk/client-s3';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { S3ObjectStore } from '../src/storage/adapters/S3ObjectStore';
+
+const MIN_AWS_DATA_CHUNK_SIZE = 8 * 1024;
+const clients: S3Client[] = [];
+
+afterEach(() => {
+  for (const client of clients.splice(0)) client.destroy();
+});
+
+describe('S3ObjectStore AWS wire compatibility', () => {
+  test('reproduces the real S3 rejection when an unbuffered stream emits small chunks', async () => {
+    await withStrictS3Endpoint(async ({ endpoint, uploadedChunkSizes }) => {
+      const store = new S3ObjectStore({
+        bucket: 'strict-wire-test',
+        region: 'us-east-1',
+        client: newClient(endpoint, false),
+      });
+      const body = oneKibChunks(24 * 1024);
+      const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+      try {
+        await expect(
+          store.put('tenant/docs/strict/base.pdf', body, { contentLength: 24 * 1024 }),
+        ).rejects.toThrow(
+          'Only the last chunk is allowed to have a size less than 8192 bytes. ' +
+            'Set [requestStreamBufferSize=number e.g. 65_536] in client constructor',
+        );
+        expect(warning).toHaveBeenCalledWith(
+          'An error was encountered in a non-retryable streaming request.',
+        );
+      } finally {
+        warning.mockRestore();
+      }
+
+      expect(uploadedChunkSizes).toHaveLength(24);
+      expect(uploadedChunkSizes.slice(0, -1).every((size) => size < 8 * 1024)).toBe(true);
+    });
+  });
+
+  test('64 KiB request buffering produces an S3-valid wire stream', async () => {
+    await withStrictS3Endpoint(async ({ endpoint, uploadedChunkSizes }) => {
+      await withFakeAwsCredentials(async () => {
+        // No injected client: exercise the exact construction path used by
+        // production deployments, including its stream-buffer configuration.
+        const store = new S3ObjectStore({
+          bucket: 'strict-wire-test',
+          region: 'us-east-1',
+          endpoint,
+        });
+        const contentLength = 160 * 1024;
+
+        await expect(
+          store.put('tenant/docs/strict/base.pdf', oneKibChunks(contentLength), { contentLength }),
+        ).resolves.toMatchObject({ sha256: expect.stringMatching(/^[0-9a-f]{64}$/) });
+      });
+
+      expect(uploadedChunkSizes.length).toBeGreaterThan(1);
+      expect(uploadedChunkSizes.slice(0, -1).every((size) => size >= MIN_AWS_DATA_CHUNK_SIZE)).toBe(
+        true,
+      );
+    });
+  });
+});
+
+function newClient(endpoint: string, requestStreamBufferSize: number | false): S3Client {
+  const client = new S3Client({
+    region: 'us-east-1',
+    endpoint,
+    forcePathStyle: true,
+    credentials: {
+      accessKeyId: 'strict-wire-test-access-key',
+      secretAccessKey: 'strict-wire-test-secret-key',
+    },
+    requestChecksumCalculation: 'WHEN_SUPPORTED',
+    requestStreamBufferSize,
+  });
+  clients.push(client);
+  return client;
+}
+
+async function withFakeAwsCredentials(run: () => Promise<void>): Promise<void> {
+  const previousAccessKey = process.env['AWS_ACCESS_KEY_ID'];
+  const previousSecretKey = process.env['AWS_SECRET_ACCESS_KEY'];
+  const previousSessionToken = process.env['AWS_SESSION_TOKEN'];
+  process.env['AWS_ACCESS_KEY_ID'] = 'strict-wire-test-access-key';
+  process.env['AWS_SECRET_ACCESS_KEY'] = 'strict-wire-test-secret-key';
+  delete process.env['AWS_SESSION_TOKEN'];
+  try {
+    await run();
+  } finally {
+    restoreEnv('AWS_ACCESS_KEY_ID', previousAccessKey);
+    restoreEnv('AWS_SECRET_ACCESS_KEY', previousSecretKey);
+    restoreEnv('AWS_SESSION_TOKEN', previousSessionToken);
+  }
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function oneKibChunks(contentLength: number): Readable {
+  return Readable.from(
+    (async function* () {
+      let remaining = contentLength;
+      while (remaining > 0) {
+        const size = Math.min(1024, remaining);
+        yield Buffer.alloc(size, remaining % 251);
+        remaining -= size;
+        // Preserve the deliberately hostile source boundaries instead of
+        // letting a synchronous producer get coalesced before the SDK sees it.
+        await yieldToEventLoop();
+      }
+    })(),
+  );
+}
+
+interface StrictS3Endpoint {
+  endpoint: string;
+  uploadedChunkSizes: number[];
+}
+
+async function withStrictS3Endpoint(
+  run: (fixture: StrictS3Endpoint) => Promise<void>,
+): Promise<void> {
+  const uploadedChunkSizes: number[] = [];
+  const server = createServer((req, res) => {
+    handleStrictS3Request(req, res, uploadedChunkSizes).catch((err: unknown) => {
+      res.statusCode = 500;
+      res.end(err instanceof Error ? err.message : String(err));
+    });
+  });
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('strict S3 endpoint has no port');
+
+  try {
+    await run({ endpoint: `http://127.0.0.1:${address.port}`, uploadedChunkSizes });
+  } finally {
+    server.close();
+    await once(server, 'close');
+  }
+}
+
+async function handleStrictS3Request(
+  req: IncomingMessage,
+  res: ServerResponse,
+  uploadedChunkSizes: number[],
+): Promise<void> {
+  if (req.method !== 'PUT') {
+    res.statusCode = 405;
+    res.end();
+    return;
+  }
+
+  const body = await readRequest(req);
+  if (req.headers['content-encoding']?.includes('aws-chunked')) {
+    uploadedChunkSizes.push(...parseAwsDataChunkSizes(body));
+    const nonFinal = uploadedChunkSizes.slice(0, -1);
+    const badChunkSize = nonFinal.find((size) => size < MIN_AWS_DATA_CHUNK_SIZE);
+    if (badChunkSize !== undefined) {
+      res.statusCode = 400;
+      res.setHeader('content-type', 'application/xml');
+      res.setHeader('x-amz-request-id', 'strict-wire-request');
+      res.end(
+        '<?xml version="1.0" encoding="UTF-8"?>' +
+          '<Error>' +
+          '<Code>InvalidChunkSizeError</Code>' +
+          '<Message>Only the last chunk is allowed to have a size less than 8192 bytes</Message>' +
+          `<BadChunkSize>${badChunkSize}</BadChunkSize>` +
+          '<RequestId>strict-wire-request</RequestId>' +
+          '</Error>',
+      );
+      return;
+    }
+  }
+
+  if (req.headers['x-amz-copy-source']) {
+    res.statusCode = 200;
+    res.setHeader('content-type', 'application/xml');
+    res.end(
+      '<?xml version="1.0" encoding="UTF-8"?>' +
+        '<CopyObjectResult>' +
+        '<ETag>"strict-wire-etag"</ETag>' +
+        '<LastModified>2026-08-27T00:00:00.000Z</LastModified>' +
+        '</CopyObjectResult>',
+    );
+    return;
+  }
+
+  res.statusCode = 200;
+  res.setHeader('etag', '"strict-wire-etag"');
+  res.end();
+}
+
+async function readRequest(req: IncomingMessage): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(Buffer.from(chunk as Uint8Array));
+  return Buffer.concat(chunks);
+}
+
+function parseAwsDataChunkSizes(body: Buffer): number[] {
+  const sizes: number[] = [];
+  let offset = 0;
+  while (offset < body.length) {
+    const lineEnd = body.indexOf('\r\n', offset);
+    if (lineEnd < 0) throw new Error('malformed aws-chunked body: missing size terminator');
+    const sizeToken = body.subarray(offset, lineEnd).toString('ascii').split(';', 1)[0];
+    const size = Number.parseInt(sizeToken ?? '', 16);
+    if (!Number.isFinite(size)) throw new Error('malformed aws-chunked body: invalid size');
+    offset = lineEnd + 2;
+    if (size === 0) return sizes;
+    if (offset + size + 2 > body.length) {
+      throw new Error('malformed aws-chunked body: truncated data chunk');
+    }
+    sizes.push(size);
+    offset += size;
+    if (body.subarray(offset, offset + 2).toString('ascii') !== '\r\n') {
+      throw new Error('malformed aws-chunked body: missing data terminator');
+    }
+    offset += 2;
+  }
+  throw new Error('malformed aws-chunked body: missing final chunk');
+}


### PR DESCRIPTION
Buffer AWS S3 request streams (64 KiB) to avoid aws-chunked checksum framing errors (InvalidChunkSizeError) and set requestStreamBufferSize in S3 client construction. Refactor app error handling into handleAppError and log handled 5xx responses with structured context. Limit test teardown timeout by passing shutdownTimeoutMs for buildAppForTesting. Add tests reproducing S3 wire errors and validating buffering (storage-s3-wire.test.ts), error logging behavior (error-logging.test.ts), and a teardown timeout guard (events-sse.test.ts). Also include a changeset note documenting the patch.